### PR TITLE
fix(vite-plugin-angular): always strip license comments from builds

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -222,7 +222,7 @@ export function angular(
       config() {
         return {
           esbuild: {
-            legalComments: isProd ? 'none' : 'external',
+            legalComments: 'none',
             keepNames: false,
             define: isProd
               ? {


### PR DESCRIPTION
This prevents errors when using the plugin with Astro/Playwright/etc because
the license comments trigger a build error