### PR TITLE
docs: correct edit URL

### DIFF
--- a/apps/docs-app/docusaurus.config.js
+++ b/apps/docs-app/docusaurus.config.js
@@ -30,7 +30,7 @@ const config = {
       ({
         blog: false,
         docs: {
-          editUrl: `https://github.com/${organizationName}/${projectName}/edit/main`,
+          editUrl: `https://github.com/${organizationName}/${projectName}/edit/main/apps/docs-app/docs`,
           sidebarPath: require.resolve('./sidebars.js'),
         },
         theme: {


### PR DESCRIPTION
# References
- Fixes #45 

# Documentation
Correct the edit URL path so that *Edit this page* links on the documentation website aren't broken.