### PR TITLE
chore(create-analog): update template application to latest dependencies

### DIFF
--- a/packages/create-analog/template-angular-v14/README.md
+++ b/packages/create-analog/template-angular-v14/README.md
@@ -8,7 +8,7 @@ Run `yarn` to install the application dependencies.
 
 ## Development
 
-Run `yarn dev` for a dev server. Navigate to `http://localhost:3000/`. The application will automatically reload if you change any of the source files.
+Run `yarn dev` for a dev server. Navigate to `http://localhost:5173/`. The application will automatically reload if you change any of the source files.
 
 ## Build
 

--- a/packages/create-analog/template-angular-v14/README.md
+++ b/packages/create-analog/template-angular-v14/README.md
@@ -22,3 +22,5 @@ Run `yarn test` to run unit tests with [Vitest](https://vitest.dev).
 
 - Join the [Discord](https://discord.gg/mKC2Ec48U5)
 - Visit and Star the [GitHub Repo](https://github.com/analogjs/analog)
+- Visit the [Website](https://analogjs.org/)
+- Follow us on [Twitter](https://twitter.com/analogjs)

--- a/packages/create-analog/template-angular-v14/package.json
+++ b/packages/create-analog/template-angular-v14/package.json
@@ -1,6 +1,10 @@
 {
   "name": "my-app",
   "version": "0.0.0",
+  "private": true,
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "ng": "ng",
@@ -10,7 +14,6 @@
     "test": "vitest",
     "postinstall": "vite optimize"
   },
-  "private": true,
   "dependencies": {
     "@angular/animations": "^14.0.0",
     "@angular/common": "^14.0.0",

--- a/packages/create-analog/template-angular-v14/package.json
+++ b/packages/create-analog/template-angular-v14/package.json
@@ -20,9 +20,9 @@
     "@angular/platform-browser": "^14.0.0",
     "@angular/platform-browser-dynamic": "^14.0.0",
     "@angular/router": "^14.0.0",
-    "rxjs": "~7.5.0",
-    "tslib": "^2.3.0",
-    "zone.js": "~0.11.4"
+    "rxjs": "~7.5.6",
+    "tslib": "^2.4.0",
+    "zone.js": "~0.11.8"
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "latest",
@@ -30,8 +30,8 @@
     "@angular/cli": "~14.0.3",
     "@angular/compiler-cli": "^14.0.0",
     "jsdom": "^20.0.0",
-    "typescript": "~4.7.2",
-    "vite": "^2.9.13",
-    "vitest": "^0.17.0"
+    "typescript": "~4.7.4",
+    "vite": "^3.0.9",
+    "vitest": "^0.22.1"
   }
 }


### PR DESCRIPTION
Hello,

### This PR does

- Closes #44 

### Remarks/Questions

- The default port is now `5173`
- The default host should be `localhost` but on Node.js under v17 it's displayed as `http://127.0.0.1:5173/`, what do you want to do ?
    - Keep it like this
    - Apply the workaround from the doc https://vitejs.dev/config/server-options.html#server-host
    - Set minimum Node.js version to `17+`
- Vite no longer supports `Node.js 12 / 13 / 15`
    - Should we set minimum Node.js version to `14.18+` / `16+` ?