### PR TITLE
refactor: remove unnecessary peer dep

### DIFF
--- a/packages/astro-angular/package.json
+++ b/packages/astro-angular/package.json
@@ -37,7 +37,6 @@
     "@angular/compiler": "^14.0.0",
     "@angular/core": "^14.0.0",
     "@angular/language-service": "^14.0.0",
-    "@angular/forms": "^14.0.0",
     "@angular/platform-browser": "^14.0.0",
     "@angular/platform-browser-dynamic": "^14.0.0",
     "@angular/platform-server": "^14.0.0",


### PR DESCRIPTION
refactor: remove unnecessary peer dep

Removed @angular/forms from the peer deps array for the astro-angular package

Resolves #61