### PR TITLE
fix(astro-angular): check ComponentMirror before setting input 

### DIFF
--- a/packages/astro-angular/src/client.ts
+++ b/packages/astro-angular/src/client.ts
@@ -1,5 +1,8 @@
 import 'zone.js/dist/zone.js';
-import type { ɵComponentType as ComponentType } from '@angular/core';
+import {
+  reflectComponentType,
+  ɵComponentType as ComponentType,
+} from '@angular/core';
 import { ApplicationRef, NgZone, createComponent } from '@angular/core';
 import { createApplication } from '@angular/platform-browser';
 
@@ -17,9 +20,17 @@ export default (element: HTMLElement) => {
           hostElement: element,
         });
 
-        if (props) {
+        const mirror = reflectComponentType(Component);
+        if (props && mirror) {
           for (const [key, value] of Object.entries(props)) {
-            componentRef.setInput(key, value);
+            if (
+              mirror.inputs.some(
+                ({ templateName, propName }) =>
+                  templateName === key || propName === key
+              )
+            ) {
+              componentRef.setInput(key, value);
+            }
           }
         }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [x] astro-angular
- [ ] create-analog

## What is the current behavior?
Right now the client side of the rendering doesn't check the ComponentMirror before setting the inputs of the angular component. Astro might add additional props that cause ng0303 error

Issue Number: #79 


## What is the new behavior?
Client rendering checks the ComponentMirror and sets the inputs only if they are defined on the component.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
