### PR TITLE
docs: use component in mdx pages, closes #90

### DIFF
--- a/packages/astro-angular/README.md
+++ b/packages/astro-angular/README.md
@@ -153,7 +153,7 @@ Find more information about [Client Directives](https://docs.astro.build/en/refe
 
 ## Using Components in MDX pages
 
-Install and configure MDX support by following the Astro integration of [@astrojs/mdx](https://docs.astro.build/en/guides/integrations-guide/mdx/). Your `astro.config.mjs` should now include the `@astrojs/mdx` integration.
+To use components with MDX pages, you must install and configure MDX support by following the Astro integration of [@astrojs/mdx](https://docs.astro.build/en/guides/integrations-guide/mdx/). Your `astro.config.mjs` should now include the `@astrojs/mdx` integration.
 
 ```js
 import { defineConfig } from 'astro/config';

--- a/packages/astro-angular/README.md
+++ b/packages/astro-angular/README.md
@@ -151,7 +151,7 @@ import { HelloComponent } from '../components/hello.component';
 
 Find more information about [Client Directives](https://docs.astro.build/en/reference/directives-reference/#client-directives) in the Astro documentation.
 
-## Use Component in MDX pages
+## Using Components in MDX pages
 
 Install and configure MDX support by following the Astro integration of [@astrojs/mdx](https://docs.astro.build/en/guides/integrations-guide/mdx/). Your `astro.config.mjs` should now include the `@astrojs/mdx` integration.
 

--- a/packages/astro-angular/README.md
+++ b/packages/astro-angular/README.md
@@ -165,7 +165,7 @@ export default defineConfig({
 });
 ```
 
-Create a `.mdx` file inside the `src/pages` directory and add the Angular component import below the frontmatter.
+Create an `.mdx` file inside the `src/pages` directory and add the Angular component import below the frontmatter.
 
 ```md
 ---

--- a/packages/astro-angular/README.md
+++ b/packages/astro-angular/README.md
@@ -139,7 +139,7 @@ const helpText = "Helping binding";
 <HelloComponent helpText={helpText} />
 ```
 
-To hydrate the component on the client, use one of the Astro directives:
+To hydrate the component on the client, use one of the Astro [client directives](https://docs.astro.build/en/reference/directives-reference/#client-directives):
 
 ```ts
 ---
@@ -150,6 +150,54 @@ import { HelloComponent } from '../components/hello.component';
 ```
 
 Find more information about [Client Directives](https://docs.astro.build/en/reference/directives-reference/#client-directives) in the Astro documentation.
+
+## Use Component in MDX pages
+
+Install and configure MDX support by following the Astro integration of [@astrojs/mdx](https://docs.astro.build/en/guides/integrations-guide/mdx/). Your `astro.config.mjs` should now include the `@astrojs/mdx` integration.
+
+```js
+import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
+import angular from '@analogjs/astro-angular';
+
+export default defineConfig({
+  integrations: [mdx(), angular()],
+});
+```
+
+Create a `.mdx` file inside the `src/pages` directory and add the Angular component import below the frontmatter.
+
+```md
+---
+layout: "../../layouts/BlogPost.astro"
+title: "Using Angular in MDX"
+description: "Lorem ipsum dolor sit amet"
+pubDate: "Sep 22 2022"
+---
+
+import { HelloComponent } from "../../components/hello.component.ts";
+
+<HelloComponent />
+<HelloComponent helpText="Helping" />
+```
+
+To hydrate the component on the client, use one of the Astro [client directives](https://docs.astro.build/en/reference/directives-reference/#client-directives):
+
+```md
+---
+layout: "../../layouts/BlogPost.astro"
+title: "Using Angular in MDX"
+description: "Lorem ipsum dolor sit amet"
+pubDate: "Sep 22 2022"
+---
+
+import { HelloComponent } from "../../components/hello.component.ts";
+
+<HelloComponent client:load />
+<HelloComponent client:visible helpText="Helping" />
+```
+
+> Important: In `.mdx` files the component import must end with the `.ts` suffix. Otherwise the dynamic import of the component will fail and the component won't be hydrated.
 
 ## Current Limitations
 


### PR DESCRIPTION
* add link to client directives

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [x] astro-angular
- [ ] create-analog

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #90 


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
