### PR TITLE
fix(vite-plugin-angular): skip transforming inline scripts

### DIFF
--- a/apps/astro-app/src/pages/index.astro
+++ b/apps/astro-app/src/pages/index.astro
@@ -108,3 +108,7 @@ const serverSideTitle = 'Angular (server side binding)';
 		padding: 0;
 	}
 </style>
+
+<script>
+	console.log('Hello Astro');
+</script>

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -161,6 +161,18 @@ export function angular(options?: PluginOptions): Plugin[] {
           return;
         }
 
+        /**
+         * Check for .ts extenstions for inline script files being
+         * transformed (Astro).
+         *
+         * Example ID:
+         *
+         * /src/pages/index.astro?astro&type=script&index=0&lang.ts
+         */
+        if (id.includes('type=script')) {
+          return;
+        }
+
         if (/\.[cm]?tsx?$/.test(id)) {
           /**
            * Re-analyze on each transform


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #95


## What is the new behavior?

Inline scripts `type=script` passed through the transform are ignored. When using inline scripts with Astro, the script gets inline so it can pass through Vite's transform pipeline. This file isn't part of the Angular TypeScript compilation, but because it ends with a `.ts` extension, the transform tries to handle it.

This change ignores files like this that are provided the `type=script` as part of the query string on the filename.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
