### PR TITLE
fix: add plugin to remove inline resource imports

### DIFF
--- a/apps/analog-app/vite.config.ts
+++ b/apps/analog-app/vite.config.ts
@@ -16,15 +16,6 @@ export default defineConfig(({ mode }) => {
       outDir: `${offsetFromRoot('apps/analog-app/src')}/dist/apps/analog-app`,
       emptyOutDir: true,
       target: 'es2020',
-      rollupOptions: {
-        external: [/ngResource/],
-        onwarn: (warning, warn) => {
-          if (warning.message.includes('ngResource')) {
-            return;
-          }
-          warn(warning);
-        },
-      },
     },
     resolve: {
       mainFields: ['module'],

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -342,7 +342,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         return;
       },
     },
-    componentAssetsPlugin(pluginOptions.inlineStylesExtension),
+    ...componentAssetsPlugin(pluginOptions.inlineStylesExtension),
   ];
 
   function setupCompilation() {

--- a/packages/vite-plugin-angular/src/lib/component-assets-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/component-assets-plugin.ts
@@ -10,51 +10,69 @@ const virtualModuleId = 'virtual:analog-components-assets-module';
  * return them as imported assets to pass through the appropriate
  * transform pipeline.
  */
-export function componentAssetsPlugin(inlineStylesExtension = ''): Plugin {
-  return {
-    name: '@analogjs/vite-plugin-angular-component-assets',
-    enforce: 'pre',
-    resolveId(id) {
-      if (id.includes('html?ngResource') && !id.includes(virtualModuleId)) {
-        return '\0' + virtualModuleId + id;
-      }
+export function componentAssetsPlugin(inlineStylesExtension = ''): Plugin[] {
+  return [
+    {
+      name: '@analogjs/vite-plugin-angular-component-assets',
+      enforce: 'pre',
+      resolveId(id) {
+        if (id.includes('html?ngResource') && !id.includes(virtualModuleId)) {
+          return '\0' + virtualModuleId + id;
+        }
 
-      if (
-        id.includes(`.${inlineStylesExtension}?ngResource`) &&
-        /data=(.*)\!/.test(id)
-      ) {
-        return '\0' + virtualModuleId + id;
-      }
+        if (
+          id.includes(`.${inlineStylesExtension}?ngResource`) &&
+          /data=(.*)\!/.test(id)
+        ) {
+          return '\0' + virtualModuleId + id;
+        }
 
-      return undefined;
-    },
-    async load(id) {
-      if (!id.startsWith(`\0${virtualModuleId}`)) {
         return undefined;
-      }
+      },
+      async load(id) {
+        if (!id.startsWith(`\0${virtualModuleId}`)) {
+          return undefined;
+        }
 
-      if (id.includes(`.html`)) {
-        return `export default "${id
-          .replace('\x00', '')
-          .replace(virtualModuleId, '')}"`;
-      }
+        if (id.includes(`.html`)) {
+          return `export default "${id
+            .replace('\x00', '')
+            .replace(virtualModuleId, '')}"`;
+        }
 
-      if (
-        id.includes(`.${inlineStylesExtension}?ngResource`) &&
-        /data=(.*)\!/.test(id)
-      ) {
-        const encodedStyles = id.match(/data=(.*)\!/)![1];
-        const styles = Buffer.from(
-          decodeURIComponent(encodedStyles),
-          'base64'
-        ).toString();
+        if (
+          id.includes(`.${inlineStylesExtension}?ngResource`) &&
+          /data=(.*)\!/.test(id)
+        ) {
+          const encodedStyles = id.match(/data=(.*)\!/)![1];
+          const styles = Buffer.from(
+            decodeURIComponent(encodedStyles),
+            'base64'
+          ).toString();
+
+          return {
+            code: styles,
+          };
+        }
+
+        return;
+      },
+    },
+    {
+      name: '@analogjs/vite-plugin-angular-remove-inline-resource',
+      enforce: 'post',
+      transform(_code) {
+        /**
+         * Remove the resources replaced with import
+         * statements from the Angular Compiler
+         * that are no longer being used.
+         */
+        const code = _code.replace(/import.*inline-resource.*\n/g, '');
 
         return {
-          code: styles,
+          code,
         };
-      }
-
-      return;
+      },
     },
-  };
+  ];
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

This removes the workaround for Rollup warnings by removing the inline resource imports from the Angular Compilation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
