### PR TITLE
docs(astro-angular): add tsx glob to example astro tsconfig.app.json

### DIFF
--- a/packages/astro-angular/README.md
+++ b/packages/astro-angular/README.md
@@ -56,7 +56,7 @@ Create a `tsconfig.app.json` in the root of the project.
     "strictTemplates": true
   },
   "files": [],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }
 ```
 


### PR DESCRIPTION
Adds `"src/**/*.tsx"` to the example `tsconfig.app.json` config in the `astro-angular` README.md.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [x] astro-angular
- [ ] create-analog
- [ ] router

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [128](https://github.com/analogjs/analog/issues/128)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No