### PR TITLE
fix(vite-plugin-angular): allow build-angular v15

### DIFF
--- a/packages/vite-plugin-angular/package.json
+++ b/packages/vite-plugin-angular/package.json
@@ -19,6 +19,6 @@
     "url": "https://github.com/analogjs/analog.git"
   },
   "peerDependencies": {
-    "@angular-devkit/build-angular": "^14.0.0"
+    "@angular-devkit/build-angular": "^14.0.0 || ^15.0.0"
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [X] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router

## What is the current behavior?

The peer dependency `@angular-devkit/build-angular` supports only major version 14.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The peer dependency `@angular-devkit/build-angular` should also support major version 15.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
