### PR TITLE
fix(create-analog): pin @nrwl/vite package to 15.3.x

### DIFF
--- a/packages/create-analog/template-angular-v15/package.json
+++ b/packages/create-analog/template-angular-v15/package.json
@@ -32,7 +32,7 @@
     "@angular-devkit/build-angular": "^15.0.0",
     "@angular/cli": "~15.0.0",
     "@angular/compiler-cli": "^15.0.0",
-    "@nrwl/vite": "^15.4.0",
+    "@nrwl/vite": "~15.3.0",
     "jsdom": "^20.0.0",
     "typescript": "~4.8.4",
     "vite": "^4.0.3",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [x] create-analog
- [ ] router

## What is the current behavior?

Nx 15.4.x introduced a change that requires a project.json. This pins the Vite plugin to Nx 15.3.x to get the template app working again

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
