### PR TITLE
feat(content): add support for front-matter in routes using markdown …

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,6 +12,7 @@ module.exports = {
         'astro-angular',
         'router',
         'platform',
+        'content',
       ],
     ],
   },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@angular/router": "15.0.0",
     "@nrwl/angular": "15.4.1",
     "marked": "^4.2.4",
+    "front-matter": "^4.0.2",
     "rxjs": "7.5.7",
     "tslib": "^2.4.0",
     "zone.js": "~0.11.8"

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -24,7 +24,8 @@
     "@angular/router": "^15.0.0",
     "rxjs": "^6.5.0 || ^7.5.0",
     "marked": "^4.2.4",
-    "prismjs": "^1.29.0"
+    "prismjs": "^1.29.0",
+    "front-matter": "^4.0.2"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/content/project.json
+++ b/packages/content/project.json
@@ -30,6 +30,9 @@
           "packages/content/**/*.html"
         ]
       }
+    },
+    "test": {
+      "executor": "@nrwl/vite:test"
     }
   },
   "tags": []

--- a/packages/content/src/lib/markdown-content-renderer.service.spec.ts
+++ b/packages/content/src/lib/markdown-content-renderer.service.spec.ts
@@ -1,0 +1,25 @@
+import { MarkdownContentRendererService } from './markdown-content-renderer.service';
+import { TestBed } from '@angular/core/testing';
+
+describe('MarkdownContentRendererService', () => {
+  function setup() {
+    TestBed.configureTestingModule({
+      providers: [MarkdownContentRendererService],
+    });
+    return { service: TestBed.inject(MarkdownContentRendererService) };
+  }
+
+  it('render should transform raw markdown input into the appropriate html', async () => {
+    const { service } = setup();
+    const result = await service.render('# Hello World');
+    expect(result).toMatch('<h1 id="hello-world">Hello World</h1>\n');
+  });
+
+  it('render should strip the attributes from a front-matter markdown input and only return the content transformed into the appropriate html', async () => {
+    const { service } = setup();
+    const result = await service.render(
+      '----\ntitle: Test Title\ndescription: Test Description\npublishedDate: 2023-01-01\nslug: test-slug\npublished: true----\n# Hello World'
+    );
+    expect(result).toMatch('<h1 id="hello-world">Hello World</h1>\n');
+  });
+});

--- a/packages/content/src/lib/markdown-content-renderer.service.ts
+++ b/packages/content/src/lib/markdown-content-renderer.service.ts
@@ -4,6 +4,7 @@
  */
 import { inject, Injectable, PLATFORM_ID, Provider } from '@angular/core';
 import { marked } from 'marked';
+import fm from 'front-matter';
 
 import 'prismjs';
 import 'prismjs/plugins/toolbar/prism-toolbar';
@@ -71,7 +72,9 @@ export class MarkdownContentRendererService implements ContentRenderer {
       xhtml: false,
     });
 
-    return marked(content);
+    const { body } = fm(content);
+
+    return marked(body);
   }
 
   // eslint-disable-next-line

--- a/packages/content/src/test-setup.ts
+++ b/packages/content/src/test-setup.ts
@@ -1,0 +1,16 @@
+import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@angular/compiler';
+
+/**
+ * Initialize TestBed for all tests inside of content
+ */
+import { TestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+TestBed.initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/packages/content/tsconfig.spec.json
+++ b/packages/content/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["node", "vitest/globals"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/packages/content/vite.config.ts
+++ b/packages/content/vite.config.ts
@@ -1,0 +1,23 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite';
+import { offsetFromRoot } from '@nrwl/devkit';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => {
+  return {
+    root: 'src',
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['src/test-setup.ts'],
+      include: ['**/*.spec.ts'],
+      cache: {
+        dir: `${offsetFromRoot('packages/content/src')}/node_modules/.vitest`,
+      },
+    },
+    define: {
+      'import.meta.vitest': mode !== 'production',
+    },
+  };
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9348,6 +9348,13 @@ from@~0:
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==
 
+front-matter@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-4.0.2.tgz#b14e54dc745cfd7293484f3210d15ea4edd7f4d5"
+  integrity sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==
+  dependencies:
+    js-yaml "^3.13.1"
+
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"


### PR DESCRIPTION
Add support for front-matter in routes that
use markdown files by first passing the content
passed to the MarkdownContentRenderer through
front-matter to extract any possible attributes.

Closes #198

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Added test config for content package

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [x] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #198 

## What is the new behavior?

Frontmatter content is not displayed in markdown routes anymore.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
