### PR TITLE
feat(vite-plugin-angular): add tsTransformers config

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -19,6 +19,12 @@ export interface PluginOptions {
   tsconfig?: string;
   workspaceRoot?: string;
   inlineStylesExtension?: string;
+  advanced?: {
+    tsTransformers?: (
+      | ts.TransformerFactory<ts.SourceFile>
+      | ts.CustomTransformerFactory
+    )[];
+  };
 }
 
 interface EmitFileResult {
@@ -49,6 +55,9 @@ export function angular(options?: PluginOptions): Plugin[] {
         : './tsconfig.app.json'),
     workspaceRoot: options?.workspaceRoot ?? process.cwd(),
     inlineStylesExtension: options?.inlineStylesExtension ?? 'css',
+    advanced: {
+      tsTransformers: options?.advanced?.tsTransformers ?? [],
+    },
   };
 
   // The file emitter created during `onStart` that will be used during the build in `onLoad` callbacks for TS files
@@ -69,10 +78,10 @@ export function angular(options?: PluginOptions): Plugin[] {
   let host: ts.CompilerHost;
   let nextProgram: NgtscProgram;
   let builderProgram: ts.EmitAndSemanticDiagnosticsBuilderProgram;
-  let watchMode: boolean = false;
-  let sourceFileCache = new SourceFileCache();
-  let isProd = process.env['NODE_ENV'] === 'production';
-  let isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
+  let watchMode = false;
+  const sourceFileCache = new SourceFileCache();
+  const isProd = process.env['NODE_ENV'] === 'production';
+  const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
   let viteServer: ViteDevServer | undefined;
   let cssPlugin: Plugin | undefined;
 
@@ -158,7 +167,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             return ctx.modules;
           }
 
-          let mods: ModuleNode[] = [];
+          const mods: ModuleNode[] = [];
           ctx.modules.forEach((mod) => {
             mod.importers.forEach((imp) => {
               sourceFileCache.invalidate(imp.id);
@@ -443,7 +452,10 @@ export function angular(options?: PluginOptions): Plugin[] {
       builder,
       mergeTransformers(
         {
-          before: [replaceBootstrap(getTypeChecker)],
+          before: [
+            replaceBootstrap(getTypeChecker),
+            ...pluginOptions.advanced.tsTransformers,
+          ],
         },
         angularCompiler.prepareEmit().transformers
       ),


### PR DESCRIPTION
Add configuration to allow custom TypeScript transformers to be added

Closes #210

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content

## What is the current behavior?

There is no way to add a custom TypeScript transformer

Issue Number: #210 

## What is the new behavior?

Added config parameter which allows to add a custom transformer to before array

```ts
import { defineConfig } from 'vite';
import analog from '@analogjs/platform';

// https://vitejs.dev/config/
export default defineConfig(() => {
  return {
    plugins: [
      analog({
        advanced: {
          tsTransformers: [customTransformer]
        }
      })
    ]
  };
});
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I tested changes on a small application that uses a transformer from https://github.com/morrys/ts-relay-plugin

Everything works as expected but I'm not sure should we add a test or an example app here.