### PR TITLE
feat(vite-plugin-angular): change tsTransformers parameter type

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -20,13 +20,10 @@ export interface PluginOptions {
   workspaceRoot?: string;
   inlineStylesExtension?: string;
   advanced?: {
-   /**
-    * Custom TypeScript transformers that are run before Angular compilation
-    */
-    tsTransformers?: (
-      | ts.TransformerFactory<ts.SourceFile>
-      | ts.CustomTransformerFactory
-    )[];
+    /**
+     * Custom TypeScript transformers that are run before Angular compilation
+     */
+    tsTransformers?: ts.CustomTransformers;
   };
 }
 
@@ -59,7 +56,12 @@ export function angular(options?: PluginOptions): Plugin[] {
     workspaceRoot: options?.workspaceRoot ?? process.cwd(),
     inlineStylesExtension: options?.inlineStylesExtension ?? 'css',
     advanced: {
-      tsTransformers: options?.advanced?.tsTransformers ?? [],
+      tsTransformers: {
+        before: options?.advanced?.tsTransformers?.before ?? [],
+        after: options?.advanced?.tsTransformers?.after ?? [],
+        afterDeclarations:
+          options?.advanced?.tsTransformers?.afterDeclarations ?? [],
+      },
     },
   };
 
@@ -457,8 +459,11 @@ export function angular(options?: PluginOptions): Plugin[] {
         {
           before: [
             replaceBootstrap(getTypeChecker),
-            ...pluginOptions.advanced.tsTransformers,
+            ...pluginOptions.advanced.tsTransformers.before,
           ],
+          after: pluginOptions.advanced.tsTransformers.after,
+          afterDeclarations:
+            pluginOptions.advanced.tsTransformers.afterDeclarations,
         },
         angularCompiler.prepareEmit().transformers
       ),


### PR DESCRIPTION
To cover all possible use cases it's better to pass a whole `ts.CustomTransformers` object rather than just `before` tranformers

Closes #220

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content

## What is the current behavior?

We pass only `before` object to custom transformers

Issue Number: #220 

## What is the new behavior?

Pass a whole `ts.CustomTransformers` object. An example from the original issue now should look like:

```ts
import { defineConfig } from 'vite';
import analog from '@analogjs/platform';

// https://vitejs.dev/config/
export default defineConfig(() => {
  return {
    plugins: [
      analog({
        advanced: {
          tsTransformers: {
            before: [customTransformer]
          }
        }
      })
    ]
  };
});
```

Additionally `after` and `afterDeclarations` could be passed as well.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
