### PR TITLE
fix(vite-plugin-angular): use babel to make transform results compati…

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -25,6 +25,7 @@ export interface PluginOptions {
      */
     tsTransformers?: ts.CustomTransformers;
   };
+  supportedBrowsers?: string[];
 }
 
 interface EmitFileResult {
@@ -63,6 +64,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           options?.advanced?.tsTransformers?.afterDeclarations ?? [],
       },
     },
+    supportedBrowsers: options?.supportedBrowsers ?? ['iOS <=15'],
   };
 
   // The file emitter created during `onStart` that will be used during the build in `onLoad` callbacks for TS files
@@ -273,6 +275,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               [
                 angularApplicationPreset,
                 {
+                  supportedBrowsers: pluginOptions.supportedBrowsers,
                   forceAsyncTransformation,
                   optimize: isProd && {},
                 },


### PR DESCRIPTION
…ble with Webkit

Angular's compilation results use static blocks by default. These static blocks are not supported by Safari or other webkit based browsers. https://caniuse.com/mdn-javascript_classes_static_initialization_blocks We need to use babel transformations to make the output compatible with iOS. This is for serving content in development as well as building for production.

Closes #202

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Analog output is broken in Webkit based (Safari & all iOS) browsers.

Issue Number: #202

## What is the new behavior?

Analog works as expected in Webkit based browsers
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is just a PR to share my findings and the patch that got it to work.
I hope someone with more insight can explain why it works and if there is a better way to achieve the same results.