### PR TITLE
feat(content): add support for lazy loading content files

### DIFF
--- a/apps/blog-app/vite.config.ts
+++ b/apps/blog-app/vite.config.ts
@@ -18,7 +18,12 @@ export default defineConfig(() => {
         static: true,
         prerender: {
           routes: async () => {
-            return ['/', '/about', '/blog/2022-12-27-my-first-post'];
+            return [
+              '/',
+              '/about',
+              '/blog/2022-12-27-my-first-post',
+              '/blog/2022-12-31-my-second-post',
+            ];
           },
         },
         vite: {

--- a/packages/content/src/lib/content-file.ts
+++ b/packages/content/src/lib/content-file.ts
@@ -2,6 +2,6 @@ export interface ContentFile<
   Attributes extends Record<string, any> = Record<string, any>
 > {
   filename: string;
-  content: string;
+  content?: string;
   attributes: Attributes;
 }

--- a/packages/content/src/lib/content-files-list-token.spec.ts
+++ b/packages/content/src/lib/content-files-list-token.spec.ts
@@ -1,18 +1,18 @@
 import { TestBed } from '@angular/core/testing';
-import { CONTENT_FILES_TOKEN } from './content-files-token';
+import { CONTENT_FILES_LIST_TOKEN } from './content-files-list-token';
 
 vi.mock('./get-content-files', () => {
   return {
     getContentFilesList: () => ({
-      '/test.md': '---\ntitle: Test\n---\n# Hello World',
+      '/test.md': { title: 'Test' },
     }),
   };
 });
-describe('CONTENT_FILES_TOKEN', () => {
+describe('CONTENT_FILES_LIST_TOKEN', () => {
   it('should be the token', () => {
-    const { CONTENT_FILES_TOKEN } = setup();
-    const firstParsedFile = CONTENT_FILES_TOKEN[0];
-    expect(CONTENT_FILES_TOKEN).toBeTruthy();
+    const { CONTENT_FILES_LIST_TOKEN } = setup();
+    const firstParsedFile = CONTENT_FILES_LIST_TOKEN[0];
+    expect(CONTENT_FILES_LIST_TOKEN).toBeTruthy();
     expect(firstParsedFile.filename).toEqual('/test.md');
     expect(firstParsedFile.attributes['title']).toEqual('Test');
   });
@@ -20,7 +20,7 @@ describe('CONTENT_FILES_TOKEN', () => {
   function setup() {
     TestBed.configureTestingModule({});
     return {
-      CONTENT_FILES_TOKEN: TestBed.inject(CONTENT_FILES_TOKEN),
+      CONTENT_FILES_LIST_TOKEN: TestBed.inject(CONTENT_FILES_LIST_TOKEN),
     };
   }
 });

--- a/packages/content/src/lib/content-files-list-token.ts
+++ b/packages/content/src/lib/content-files-list-token.ts
@@ -1,0 +1,23 @@
+import { InjectionToken } from '@angular/core';
+
+import { ContentFile } from './content-file';
+import { getContentFilesList } from './get-content-files';
+
+export const CONTENT_FILES_LIST_TOKEN = new InjectionToken<ContentFile[]>(
+  '@analogjs/content Content Files List',
+  {
+    providedIn: 'root',
+    factory() {
+      const contentFiles = getContentFilesList();
+
+      return Object.keys(contentFiles).map((filename) => {
+        const attributes = contentFiles[filename];
+
+        return {
+          filename,
+          attributes,
+        };
+      });
+    },
+  }
+);

--- a/packages/content/src/lib/content-files-token.spec.ts
+++ b/packages/content/src/lib/content-files-token.spec.ts
@@ -1,9 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { CONTENT_FILES_TOKEN } from './content-files-token';
 
-vi.mock('./get-raw-files', () => {
+vi.mock('./get-content-files', () => {
   return {
-    getRawFiles: () => ({
+    getContentFilesList: () => ({
       '/test.md': '---\ntitle: Test\n---\n# Hello World',
     }),
   };
@@ -15,7 +15,6 @@ describe('CONTENT_FILES_TOKEN', () => {
     expect(CONTENT_FILES_TOKEN).toBeTruthy();
     expect(firstParsedFile.filename).toEqual('/test.md');
     expect(firstParsedFile.attributes['title']).toEqual('Test');
-    expect(firstParsedFile.content).toEqual('# Hello World');
   });
 
   function setup() {

--- a/packages/content/src/lib/content-files-token.ts
+++ b/packages/content/src/lib/content-files-token.ts
@@ -1,23 +1,14 @@
 import { InjectionToken } from '@angular/core';
 
-import { ContentFile } from './content-file';
-import { getContentFilesList } from './get-content-files';
+import { getContentFiles } from './get-content-files';
 
-export const CONTENT_FILES_TOKEN = new InjectionToken<ContentFile[]>(
-  '@analogjs/content Content Files',
-  {
-    providedIn: 'root',
-    factory() {
-      const contentFiles = getContentFilesList();
+export const CONTENT_FILES_TOKEN = new InjectionToken<
+  Record<string, () => Promise<string>>
+>('@analogjs/content Content Files', {
+  providedIn: 'root',
+  factory() {
+    const contentFiles = getContentFiles();
 
-      return Object.keys(contentFiles).map((filename) => {
-        const attributes = contentFiles[filename];
-
-        return {
-          filename,
-          attributes,
-        };
-      });
-    },
-  }
-);
+    return contentFiles;
+  },
+});

--- a/packages/content/src/lib/content-files-token.ts
+++ b/packages/content/src/lib/content-files-token.ts
@@ -1,23 +1,20 @@
 import { InjectionToken } from '@angular/core';
-import fm from 'front-matter';
+
 import { ContentFile } from './content-file';
-import { getRawFiles } from './get-raw-files';
+import { getContentFilesList } from './get-content-files';
 
 export const CONTENT_FILES_TOKEN = new InjectionToken<ContentFile[]>(
   '@analogjs/content Content Files',
   {
     providedIn: 'root',
     factory() {
-      const rawContentFiles = getRawFiles();
+      const contentFiles = getContentFilesList();
 
-      return Object.keys(rawContentFiles).map((filename) => {
-        const { body, attributes } = fm<Record<string, any>>(
-          rawContentFiles[filename]
-        );
+      return Object.keys(contentFiles).map((filename) => {
+        const attributes = contentFiles[filename];
 
         return {
           filename,
-          content: body,
           attributes,
         };
       });

--- a/packages/content/src/lib/content.ts
+++ b/packages/content/src/lib/content.ts
@@ -8,6 +8,7 @@ import { Observable, of } from 'rxjs';
 
 import { ContentFile } from './content-file';
 import { CONTENT_FILES_TOKEN } from './content-files-token';
+import { waitFor } from './utils/zone-wait-for';
 
 /**
  * Retrieves the static content using the provided param
@@ -38,21 +39,14 @@ export function injectContent<
       }
 
       return new Promise<string>((resolve) => {
+        const contentResolver = contentFile();
+
         if (import.meta.env.SSR === true) {
-          const macroTask = (globalThis as any)[
-            'Zone'
-          ].current.scheduleMacroTask(
-            `AnalogResolveContent-${Math.random()}`,
-            () => {},
-            {},
-            () => {}
-          );
-          contentFile().then((content) => {
-            macroTask.invoke();
+          waitFor(contentResolver).then((content) => {
             resolve(content);
           });
         } else {
-          contentFile().then((content) => {
+          contentResolver.then((content) => {
             resolve(content);
           });
         }

--- a/packages/content/src/lib/content.ts
+++ b/packages/content/src/lib/content.ts
@@ -7,7 +7,7 @@ import fm from 'front-matter';
 import { Observable, of } from 'rxjs';
 
 import { ContentFile } from './content-file';
-import { getContentFiles } from './get-content-files';
+import { CONTENT_FILES_TOKEN } from './content-files-token';
 
 /**
  * Retrieves the static content using the provided param
@@ -22,7 +22,7 @@ export function injectContent<
   fallback = 'No Content Found'
 ): Observable<ContentFile<Attributes | Record<string, never>>> {
   const route = inject(ActivatedRoute);
-  const contentFiles = getContentFiles();
+  const contentFiles = inject(CONTENT_FILES_TOKEN);
   return route.paramMap.pipe(
     map((params) => params.get(param)),
     switchMap((slug) => {

--- a/packages/content/src/lib/get-content-files.ts
+++ b/packages/content/src/lib/get-content-files.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns the list of content files by filename with ?analog-content-list=true.
+ * We use the query param to transform the return into an array of
+ * just front matter attributes.
+ *
+ * @returns
+ */
+export const getContentFilesList = () =>
+  import.meta.glob<Record<string, any>>('/src/content/**/*.md', {
+    eager: true,
+    import: 'default',
+    query: { 'analog-content-list': true },
+  });
+
+/**
+ * Returns the lazy loaded content files for lookups.
+ *
+ * @returns
+ */
+export const getContentFiles = () =>
+  import.meta.glob(['/src/content/**/*.md'], {
+    as: 'raw',
+  });

--- a/packages/content/src/lib/get-raw-files.ts
+++ b/packages/content/src/lib/get-raw-files.ts
@@ -1,5 +1,0 @@
-export const getRawFiles = () =>
-  import.meta.glob('/src/content/**/*.md', {
-    eager: true,
-    as: 'raw',
-  });

--- a/packages/content/src/lib/inject-content-files.spec.ts
+++ b/packages/content/src/lib/inject-content-files.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { expect } from 'vitest';
-import { CONTENT_FILES_TOKEN } from './content-files-token';
+import { CONTENT_FILES_LIST_TOKEN } from './content-files-list-token';
 import { ContentFile } from './content-file';
 import { injectContentFiles } from './inject-content-files';
 
@@ -30,7 +30,7 @@ describe('injectContentFiles', () => {
   function setup<Attributes extends Record<string, any>>(
     contentFiles: ContentFile[] = []
   ) {
-    TestBed.overrideProvider(CONTENT_FILES_TOKEN, {
+    TestBed.overrideProvider(CONTENT_FILES_LIST_TOKEN, {
       useValue: contentFiles,
     });
     return {

--- a/packages/content/src/lib/inject-content-files.ts
+++ b/packages/content/src/lib/inject-content-files.ts
@@ -1,9 +1,9 @@
 import { ContentFile } from './content-file';
 import { inject } from '@angular/core';
-import { CONTENT_FILES_TOKEN } from './content-files-token';
+import { CONTENT_FILES_LIST_TOKEN } from './content-files-list-token';
 
 export function injectContentFiles<
   Attributes extends Record<string, any>
 >(): ContentFile<Attributes>[] {
-  return inject(CONTENT_FILES_TOKEN) as ContentFile<Attributes>[];
+  return inject(CONTENT_FILES_LIST_TOKEN) as ContentFile<Attributes>[];
 }

--- a/packages/content/src/lib/markdown.component.ts
+++ b/packages/content/src/lib/markdown.component.ts
@@ -32,7 +32,7 @@ export default class AnalogMarkdownComponent
   private route = inject(ActivatedRoute);
   public content$: Observable<SafeHtml> = of('');
 
-  @Input() content!: string | null;
+  @Input() content!: string | undefined | null;
   @Input() classes = 'analog-markdown';
 
   contentRenderer = inject(ContentRenderer);

--- a/packages/content/src/lib/markdown.component.ts
+++ b/packages/content/src/lib/markdown.component.ts
@@ -15,6 +15,7 @@ import { catchError, map, mergeMap, switchMap } from 'rxjs/operators';
 
 import { ContentRenderer } from './content-renderer';
 import { AnchorNavigationDirective } from './anchor-navigation.directive';
+import { waitFor } from './utils/zone-wait-for';
 
 @Component({
   selector: 'analog-markdown',
@@ -53,18 +54,7 @@ export default class AnalogMarkdownComponent
           return of(this.content);
         } else {
           if (import.meta.env.SSR === true) {
-            const macroTask = (globalThis as any)[
-              'Zone'
-            ].current.scheduleMacroTask(
-              `AnalogResolveMarkdown-${Math.random()}`,
-              () => {},
-              {},
-              () => {}
-            );
-            return contentResolver().then((content) => {
-              macroTask.invoke();
-              return content;
-            });
+            return waitFor(contentResolver());
           } else {
             return contentResolver();
           }

--- a/packages/content/src/lib/utils/zone-wait-for.ts
+++ b/packages/content/src/lib/utils/zone-wait-for.ts
@@ -1,0 +1,19 @@
+import { firstValueFrom, isObservable, Observable } from 'rxjs';
+
+declare const Zone: any;
+
+export async function waitFor<T>(prom: Promise<T> | Observable<T>): Promise<T> {
+  if (isObservable(prom)) {
+    prom = firstValueFrom(prom);
+  }
+  const macroTask = Zone.current.scheduleMacroTask(
+    `AnalogContentResolve-${Math.random()}`,
+    () => {},
+    {},
+    () => {}
+  );
+  return prom.then((p: T) => {
+    macroTask.invoke();
+    return p;
+  });
+}

--- a/packages/platform/src/lib/content-plugin.ts
+++ b/packages/platform/src/lib/content-plugin.ts
@@ -42,5 +42,20 @@ export function contentPlugin(): Plugin[] {
         };
       },
     },
+    {
+      name: 'analogjs-content-frontmatter',
+      async transform(_code, id) {
+        // Transform only the frontmatter into a JSON object for lists
+        if (id.includes('.md?analog-content-list')) {
+          const fm: any = await import('front-matter');
+          const fileContents = fs.readFileSync(id.split('?')[0], 'utf8');
+          const frontmatter = fm(fileContents).attributes;
+
+          return `export default ${JSON.stringify(frontmatter)}`;
+        }
+
+        return;
+      },
+    },
   ];
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [x] platform
- [x] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #234 

## What is the new behavior?

Content files are lazy-loaded and not included in the main bundle. The content files list includes the filename and frontmatter attributes for lists.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
