### PR TITLE
feat(router): set title and meta tags for markdown pages

### DIFF
--- a/apps/blog-app/src/app/routes/about.md
+++ b/apps/blog-app/src/app/routes/about.md
@@ -1,3 +1,12 @@
+---
+title: About
+meta:
+  - name: description
+    content: About Page Description
+  - property: og:title
+    content: About
+---
+
 ## About Analog
 
 Analog is a meta-framework for Angular.

--- a/apps/blog-app/src/app/routes/blog.ts
+++ b/apps/blog-app/src/app/routes/blog.ts
@@ -17,7 +17,8 @@ export const routeMeta: RouteMeta = {
     <ng-container *ngFor="let post of posts">
       <a [routerLink]="post.attributes.slug"> {{ post.attributes.title }}</a> |
     </ng-container>
-    <a routerLink="/about">About</a>
+    <a routerLink="/about">About</a> |
+    <a routerLink="/contact">Contact</a>
 
     <router-outlet></router-outlet>
   `,

--- a/apps/blog-app/src/app/routes/contact.md
+++ b/apps/blog-app/src/app/routes/contact.md
@@ -1,0 +1,3 @@
+# Contact Us
+
+Take me [home](./).

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -8,3 +8,4 @@ export {
   provideContent,
   withMarkdownRenderer,
 } from './lib/markdown-content-renderer.service';
+export { parseRawContentFile } from './lib/parse-raw-content-file';

--- a/packages/content/src/lib/content.ts
+++ b/packages/content/src/lib/content.ts
@@ -2,13 +2,13 @@
 
 import { inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { map, switchMap } from 'rxjs/operators';
-import fm from 'front-matter';
 import { Observable, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 
 import { ContentFile } from './content-file';
 import { CONTENT_FILES_TOKEN } from './content-files-token';
 import { waitFor } from './utils/zone-wait-for';
+import { parseRawContentFile } from './parse-raw-content-file';
 
 /**
  * Retrieves the static content using the provided param
@@ -50,15 +50,14 @@ export function injectContent<
             resolve(content);
           });
         }
-      }).then((content) => {
-        const { body, attributes } = fm<Attributes | Record<string, never>>(
-          content
-        );
+      }).then((rawContentFile) => {
+        const { content, attributes } =
+          parseRawContentFile<Attributes>(rawContentFile);
 
         return {
           filename,
           attributes,
-          content: body,
+          content,
         };
       });
     })

--- a/packages/content/src/lib/markdown-content-renderer.service.spec.ts
+++ b/packages/content/src/lib/markdown-content-renderer.service.spec.ts
@@ -14,12 +14,4 @@ describe('MarkdownContentRendererService', () => {
     const result = await service.render('# Hello World');
     expect(result).toMatch('<h1 id="hello-world">Hello World</h1>\n');
   });
-
-  it('render should strip the attributes from a front-matter markdown input and only return the content transformed into the appropriate html', async () => {
-    const { service } = setup();
-    const result = await service.render(
-      '----\ntitle: Test Title\ndescription: Test Description\npublishedDate: 2023-01-01\nslug: test-slug\npublished: true----\n# Hello World'
-    );
-    expect(result).toMatch('<h1 id="hello-world">Hello World</h1>\n');
-  });
 });

--- a/packages/content/src/lib/markdown-content-renderer.service.ts
+++ b/packages/content/src/lib/markdown-content-renderer.service.ts
@@ -4,7 +4,6 @@
  */
 import { inject, Injectable, PLATFORM_ID, Provider } from '@angular/core';
 import { marked } from 'marked';
-import fm from 'front-matter';
 
 import 'prismjs';
 import 'prismjs/plugins/toolbar/prism-toolbar';
@@ -72,9 +71,7 @@ export class MarkdownContentRendererService implements ContentRenderer {
       xhtml: false,
     });
 
-    const { body } = fm(content);
-
-    return marked(body);
+    return marked(content);
   }
 
   // eslint-disable-next-line

--- a/packages/content/src/lib/markdown.component.ts
+++ b/packages/content/src/lib/markdown.component.ts
@@ -11,11 +11,10 @@ import {
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ActivatedRoute, Data } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import { catchError, map, mergeMap, switchMap } from 'rxjs/operators';
+import { catchError, map, mergeMap } from 'rxjs/operators';
 
 import { ContentRenderer } from './content-renderer';
 import { AnchorNavigationDirective } from './anchor-navigation.directive';
-import { waitFor } from './utils/zone-wait-for';
 
 @Component({
   selector: 'analog-markdown',
@@ -48,18 +47,7 @@ export default class AnalogMarkdownComponent
 
   updateContent() {
     this.content$ = this.route.data.pipe(
-      map<Data, () => Promise<string>>((data) => data['_analogContent']),
-      switchMap((contentResolver) => {
-        if (this.content) {
-          return of(this.content);
-        } else {
-          if (import.meta.env.SSR === true) {
-            return waitFor(contentResolver());
-          } else {
-            return contentResolver();
-          }
-        }
-      }),
+      map<Data, string>((data) => this.content ?? data['_analogContent']),
       mergeMap((contentString) => this.renderContent(contentString)),
       map((content) => this.sanitizer.bypassSecurityTrustHtml(content)),
       catchError((e) => of(`There was an error ${e}`))

--- a/packages/content/src/lib/parse-raw-content-file.ts
+++ b/packages/content/src/lib/parse-raw-content-file.ts
@@ -1,0 +1,8 @@
+import fm from 'front-matter';
+
+export function parseRawContentFile<Attributes extends Record<string, any>>(
+  rawContentFile: string
+): { content: string; attributes: Attributes } {
+  const { body, attributes } = fm<Attributes>(rawContentFile);
+  return { content: body, attributes };
+}

--- a/packages/router/src/lib/markdown-helpers.ts
+++ b/packages/router/src/lib/markdown-helpers.ts
@@ -1,0 +1,18 @@
+import { RouteExport } from './models';
+
+export function toMarkdownModule(
+  markdownFileFactory: () => Promise<string>
+): () => Promise<RouteExport> {
+  return () =>
+    Promise.all([import('@analogjs/content'), markdownFileFactory()]).then(
+      ([{ parseRawContentFile, MarkdownComponent }, markdownFile]) => {
+        const { content, attributes } = parseRawContentFile(markdownFile);
+        const { title, meta } = attributes;
+
+        return {
+          default: MarkdownComponent,
+          routeMeta: { data: { _analogContent: content }, title, meta },
+        };
+      }
+    );
+}

--- a/packages/router/src/lib/routes.ts
+++ b/packages/router/src/lib/routes.ts
@@ -4,6 +4,7 @@ import type { Route } from '@angular/router';
 
 import { RouteExport, RouteMeta } from './models';
 import { toRouteConfig } from './route-config';
+import { toMarkdownModule } from './markdown-helpers';
 
 const FILES = import.meta.glob<RouteExport>([
   '/app/routes/**/*.ts',
@@ -29,13 +30,7 @@ export function getRoutes(
   const routeConfigs = ROUTES.reduce<Route[]>(
     (routes: Route[], key: string) => {
       const module: () => Promise<RouteExport> = key.endsWith('.md')
-        ? () =>
-            import('@analogjs/content').then((m) => ({
-              default: m.MarkdownComponent,
-              routeMeta: {
-                data: { _analogContent: files[key] },
-              },
-            }))
+        ? toMarkdownModule(files[key] as () => Promise<string>)
         : (files[key] as () => Promise<RouteExport>);
 
       const segments = key


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [x] router
- [ ] platform
- [x] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #215

## What is the new behavior?

We can set `title` and `meta` tags for markdown routes:

```md
---
title: About
meta:
  - name: description
    content: About Page Description
---

# About

Welcome!
```

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

```
BREAKING CHANGES:

`MarkdownComponent` no longer parses provided content using `front-matter`.
Instead, it expects the content body to be provided directly.

This breaking change will not affect cases where the `injectContent` result is passed
to `MarkdownComponent` because the `injectContent` function already parses
a raw content file and returns the content body.
```
