### PR TITLE
docs: remove stylus pre-processor

### DIFF
--- a/apps/docs-app/docs/packages/vite-plugin-angular/css-preprocessors.md
+++ b/apps/docs-app/docs/packages/vite-plugin-angular/css-preprocessors.md
@@ -65,4 +65,4 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-Support CSS pre-processor extensions include `scss`, `sass`, `less`, `styl`, and `stylus`. More information about CSS pre-processing can be found in the [Vite Docs](https://vitejs.dev/guide/features.html#css-pre-processors).
+Support CSS pre-processor extensions include `scss`, `sass` and `less`. More information about CSS pre-processing can be found in the [Vite Docs](https://vitejs.dev/guide/features.html#css-pre-processors).

--- a/packages/astro-angular/README.md
+++ b/packages/astro-angular/README.md
@@ -110,7 +110,7 @@ export default defineConfig({
       vite: {
         tsconfig: 'path/to/tsconfig.app.json',
         workspaceRoot: 'rootDir',
-        inlineStylesExtension: 'scss|sass|less|styl|stylus'
+        inlineStylesExtension: 'scss|sass|less'
       },
     }),
   ],


### PR DESCRIPTION
stylus support for Angular has been deprecated since the release of [Angular 15.0.0](https://github.com/angular/angular-cli/releases/tag/15.0.0) and should not be listed anymore.

closes #243

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-angular-plugin
- [x] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #243

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
