### PR TITLE
test: add config to be able to use component from libs and use it in …

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -14,6 +14,7 @@
     "docs-app": "apps/docs-app",
     "platform": "packages/platform",
     "router": "packages/router",
+    "top-bar": "libs/top-bar",
     "vite-plugin-angular": "packages/vite-plugin-angular"
   },
   "defaultProject": "analog-app"

--- a/apps/analog-app/src/app/app.component.spec.ts
+++ b/apps/analog-app/src/app/app.component.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
-import { TopBarComponent } from './top-bar/top-bar.component';
+import { TopBarComponent } from '@analogjs/top-bar';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -10,13 +10,12 @@ describe('AppComponent', () => {
         RouterTestingModule,
         AppComponent,
         TopBarComponent,
-        RouterTestingModule.withRoutes([])
+        RouterTestingModule.withRoutes([]),
       ],
-      declarations: [
-      ]
+      declarations: [],
     }).compileComponents();
   });
-  
+
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;

--- a/apps/analog-app/src/app/app.component.ts
+++ b/apps/analog-app/src/app/app.component.ts
@@ -1,14 +1,13 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-
-import { TopBarComponent } from './top-bar/top-bar.component';
+import { TopBarComponent } from '@analogjs/top-bar';
 
 @Component({
   selector: 'analogjs-root',
   standalone: true,
   imports: [TopBarComponent, RouterOutlet],
   template: `
-    <app-top-bar></app-top-bar>
+    <analogjs-top-bar />
 
     <div class="container">
       <router-outlet></router-outlet>

--- a/apps/analog-app/src/styles.css
+++ b/apps/analog-app/src/styles.css
@@ -18,7 +18,7 @@ body {
   flex-direction: row;
 }
 
-router-outlet + *  {
+router-outlet + * {
   padding: 0 16px;
 }
 
@@ -32,7 +32,8 @@ h2 {
   font-size: 20px;
 }
 
-h1, h2 {
+h1,
+h2 {
   font-weight: lighter;
 }
 
@@ -59,7 +60,7 @@ input {
   border-radius: 2px;
   padding: 8px;
   margin-bottom: 16px;
-  border: 1px solid #BDBDBD;
+  border: 1px solid #bdbdbd;
 }
 
 label {
@@ -71,7 +72,8 @@ label {
 }
 
 /* Button */
-.button, button {
+.button,
+button {
   display: inline-flex;
   align-items: center;
   padding: 8px 16px;
@@ -83,12 +85,14 @@ label {
   border: none;
 }
 
-.button:hover, button:hover {
+.button:hover,
+button:hover {
   opacity: 0.8;
   font-weight: normal;
 }
 
-.button:disabled, button:disabled {
+.button:disabled,
+button:disabled {
   opacity: 0.5;
   cursor: auto;
 }
@@ -107,7 +111,7 @@ label {
 
 /* Top Bar */
 
-app-top-bar {
+analogjs-top-bar {
   width: 100%;
   height: 68px;
   background-color: #1976d2;
@@ -118,14 +122,16 @@ app-top-bar {
   align-items: center;
 }
 
-app-top-bar h1 {
+analogjs-top-bar h1 {
   color: white;
   margin: 0;
+  font-size: 1.5rem;
 }
 
 /* Checkout Cart, Shipping Prices */
 
-.cart-item, .shipping-item {
+.cart-item,
+.shipping-item {
   width: 100%;
   min-width: 400px;
   max-width: 450px;
@@ -135,5 +141,5 @@ app-top-bar h1 {
   padding: 16px 32px;
   margin-bottom: 8px;
   border-radius: 2px;
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
 }

--- a/apps/analog-app/vite.config.ts
+++ b/apps/analog-app/vite.config.ts
@@ -3,6 +3,7 @@
 import analog from '@analogjs/platform';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, Plugin, splitVendorChunkPlugin } from 'vite';
+import tsConfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -41,6 +42,9 @@ export default defineConfig(({ mode }) => {
             routes: ['/'],
           },
         },
+      }),
+      tsConfigPaths({
+        root: '../../',
       }),
       visualizer() as Plugin,
       splitVendorChunkPlugin(),

--- a/libs/top-bar/.eslintrc.json
+++ b/libs/top-bar/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "analogjs",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "analogjs",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/top-bar/README.md
+++ b/libs/top-bar/README.md
@@ -1,0 +1,7 @@
+# top-bar
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test top-bar` to execute the unit tests.

--- a/libs/top-bar/project.json
+++ b/libs/top-bar/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "top-bar",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/top-bar/src",
+  "prefix": "analogjs",
+  "targets": {
+    "test": {
+      "executor": "@nrwl/vite:test"
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/top-bar/**/*.ts", "libs/top-bar/**/*.html"]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/top-bar/src/index.ts
+++ b/libs/top-bar/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/top-bar/top-bar.component';

--- a/libs/top-bar/src/lib/top-bar/top-bar.component.spec.ts
+++ b/libs/top-bar/src/lib/top-bar/top-bar.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { TopBarComponent } from './top-bar.component';
+
+describe('TopBarComponent', () => {
+  let component: TopBarComponent;
+  let fixture: ComponentFixture<TopBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TopBarComponent, RouterTestingModule.withRoutes([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TopBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/top-bar/src/lib/top-bar/top-bar.component.ts
+++ b/libs/top-bar/src/lib/top-bar/top-bar.component.ts
@@ -1,18 +1,22 @@
-import { Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewEncapsulation,
+} from '@angular/core';
 import { RouterLinkWithHref } from '@angular/router';
 
 @Component({
-  selector: 'app-top-bar',
+  selector: 'analogjs-top-bar',
   standalone: true,
   imports: [RouterLinkWithHref],
-  template: `
-    <a routerLink="/">
+  template: ` <a routerLink="/">
       <h1>My Store</h1>
     </a>
 
     <a routerLink="/cart" class="button fancy-button">
       <i class="material-icons">shopping_cart</i>Checkout
-    </a>
-  `,
+    </a>`,
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TopBarComponent {}

--- a/libs/top-bar/src/test-setup.ts
+++ b/libs/top-bar/src/test-setup.ts
@@ -1,0 +1,16 @@
+import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@angular/compiler';
+
+/**
+ * Initialize TestBed for all tests inside of content
+ */
+import { TestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+TestBed.initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/libs/top-bar/tsconfig.json
+++ b/libs/top-bar/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/top-bar/tsconfig.lib.json
+++ b/libs/top-bar/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/top-bar/tsconfig.spec.json
+++ b/libs/top-bar/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["node", "vitest/globals"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/libs/top-bar/vite.config.ts
+++ b/libs/top-bar/vite.config.ts
@@ -1,0 +1,23 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite';
+import { offsetFromRoot } from '@nrwl/devkit';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => {
+  return {
+    root: 'src',
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['src/test-setup.ts'],
+      include: ['**/*.spec.ts'],
+      cache: {
+        dir: `${offsetFromRoot('libs/top-bar/src')}/node_modules/.vitest`,
+      },
+    },
+    define: {
+      'import.meta.vitest': mode !== 'production',
+    },
+  };
+});

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "ts-node": "10.9.1",
     "typescript": "4.9.4",
     "vite": "4.0.4",
+    "vite-tsconfig-paths": "4.0.5",
     "vitest": "0.25.8",
     "webpack-bundle-analyzer": "^4.7.0"
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,6 +19,7 @@
       "@analogjs/content": ["packages/content/src/index.ts"],
       "@analogjs/platform": ["packages/platform/src/index.ts"],
       "@analogjs/router": ["packages/router/src/index.ts"],
+      "@analogjs/top-bar": ["libs/top-bar/src/index.ts"],
       "@analogjs/vite-plugin-angular": [
         "packages/vite-plugin-angular/src/index.ts"
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -17552,6 +17552,11 @@ ts-node@10.9.1, ts-node@^10.8.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
+tsconfck@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-2.0.2.tgz#860a488f9acd024a85b2db458888410009b5383d"
+  integrity sha512-H3DWlwKpow+GpVLm/2cpmok72pwRr1YFROV3YzAmvzfGFiC1zEM/mc9b7+1XnrxuXtEbhJ7xUSIqjPFbedp7aQ==
+
 tsconfig-paths-webpack-plugin@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.0.0.tgz#84008fc3e3e0658fdb0262758b07b4da6265ff1a"
@@ -18256,6 +18261,15 @@ vfile@^5.0.0, vfile@^5.3.2:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^3.0.0"
     vfile-message "^3.0.0"
+
+vite-tsconfig-paths@4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-4.0.5.tgz#c7c54e2cf7ccc5e600db565cecd7b368a1fa8889"
+  integrity sha512-/L/eHwySFYjwxoYt1WRJniuK/jPv+WGwgRGBYx3leciR5wBeqntQpUE6Js6+TJemChc+ter7fDBKieyEWDx4yQ==
+  dependencies:
+    debug "^4.1.1"
+    globrex "^0.1.2"
+    tsconfck "^2.0.1"
 
 vite@4.0.4, vite@^4.0.3:
   version "4.0.4"


### PR DESCRIPTION
…analog-app

To ensure there is compatibility of Analog being used within an Nx workspace, the analog-app project in this repository is updated to use a library.
This includes installing vite-tsconfig-paths and updating the analog-apps vite.config.ts with the plugin and setting the root to the workspace root. This allows vite to pick up the workspace tsconfig.base.json, which includes the necessary mapping of the import url to the lib.

Closes #259

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Adds a lib-component and makes sure it is correctly picked up by analog-app

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 259

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
