### PR TITLE
fix(vite-plugin-angular): add rxjs and rxjs/operators to dep optimizations

### DIFF
--- a/packages/platform/src/lib/router-plugin.ts
+++ b/packages/platform/src/lib/router-plugin.ts
@@ -18,7 +18,6 @@ export function routerPlugin(): Plugin[] {
             noExternal: ['@analogjs/**', '@angular/**'],
           },
           optimizeDeps: {
-            include: ['rxjs'],
             exclude: ['@angular/platform-server', '@analogjs/router'],
           },
         };

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -106,6 +106,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
         return {
           optimizeDeps: {
+            include: ['rxjs/operators', 'rxjs'],
             esbuildOptions: {
               plugins: [
                 createCompilerPlugin({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

rxjs/operators are not optimized and loaded with individual requests

Issue Number: N/A

## What is the new behavior?

rxjs/operators are eagerly optimized and loaded as a single request, speeding up the initial load and refresh cycle

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
