### PR TITLE
fix(platform): absolute paths must be valid file URLs on windows #270

### DIFF
--- a/packages/platform/src/lib/vite-nitro-plugin.ts
+++ b/packages/platform/src/lib/vite-nitro-plugin.ts
@@ -16,8 +16,8 @@ export function viteNitroPlugin(
   let nitroConfig: NitroConfig = {
     rootDir,
     logLevel: nitroOptions?.logLevel || 0,
-    srcDir: `${rootDir}/src`,
-    scanDirs: [`${rootDir}/src/server`],
+    srcDir: `${rootDir}/src`.replace(/\\/g, '/'),
+    scanDirs: [`${rootDir}/src/server`.replace(/\\/g, '/')],
     output: {
       dir: '../dist/server',
       publicDir: '../dist/server/public',
@@ -64,10 +64,13 @@ export function viteNitroPlugin(
             external: ['rxjs', 'node-fetch-native/dist/polyfill', 'destr'],
           },
           moduleSideEffects: ['zone.js/bundles/zone-node.umd.js'],
-          renderer: `${__dirname}/runtime/renderer`,
+          renderer: `${__dirname}/runtime/renderer`.replace(/\\/g, '/'),
           handlers: [
             {
-              handler: `${__dirname}/runtime/api-middleware`,
+              handler: `${__dirname}/runtime/api-middleware`.replace(
+                /\\/g,
+                '/'
+              ),
               middleware: true,
             },
           ],

--- a/packages/platform/src/lib/vite-nitro-plugin.ts
+++ b/packages/platform/src/lib/vite-nitro-plugin.ts
@@ -5,6 +5,7 @@ import { Plugin, UserConfig, ViteDevServer } from 'vite';
 import { Options } from './options';
 import { buildServer } from './build-server';
 import { buildSSRApp } from './ssr/build';
+import { normalizePath } from 'vite';
 
 export function viteNitroPlugin(
   options?: Options,
@@ -16,8 +17,8 @@ export function viteNitroPlugin(
   let nitroConfig: NitroConfig = {
     rootDir,
     logLevel: nitroOptions?.logLevel || 0,
-    srcDir: `${rootDir}/src`.replace(/\\/g, '/'),
-    scanDirs: [`${rootDir}/src/server`.replace(/\\/g, '/')],
+    srcDir: normalizePath(`${rootDir}/src`),
+    scanDirs: [normalizePath(`${rootDir}/src/server`)],
     output: {
       dir: '../dist/server',
       publicDir: '../dist/server/public',
@@ -64,13 +65,10 @@ export function viteNitroPlugin(
             external: ['rxjs', 'node-fetch-native/dist/polyfill', 'destr'],
           },
           moduleSideEffects: ['zone.js/bundles/zone-node.umd.js'],
-          renderer: `${__dirname}/runtime/renderer`.replace(/\\/g, '/'),
+          renderer: normalizePath(`${__dirname}/runtime/renderer`),
           handlers: [
             {
-              handler: `${__dirname}/runtime/api-middleware`.replace(
-                /\\/g,
-                '/'
-              ),
+              handler: normalizePath(`${__dirname}/runtime/api-middleware`),
               middleware: true,
             },
           ],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [x] platform
- [ ] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #270

Current implementation causes paths like the following to be passed to nitro causing unhandled error:
```
"C:\\analog-personal-copy\\node_modules\\@analogjs\\platform\\src\\lib/runtime/api-middleware"
```

## What is the new behavior?

In windows `rootDir` and `__dirname` are paths with double backslashes `\\`. 

These are replaced with forward slash `/`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

closes #270 
