### PR TITLE
fix: undefined viteServer

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -210,7 +210,7 @@ export function angular(options?: PluginOptions): Plugin[] {
            * for test(Vitest)
            */
           if (isTest) {
-            const tsMod = viteServer!.moduleGraph.getModuleById(id);
+            const tsMod = viteServer?.moduleGraph.getModuleById(id);
             if (tsMod) {
               sourceFileCache.invalidate(id);
               await buildAndAnalyze();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content

## What is the current behavior?

Build crashes when `process.env['NODE_ENV'] === 'test' || !!process.env['VITEST']` is `true` and `viteServer` is `undefined`.

## What is the new behavior?

The build won't crash when `viteServer` is `undefined`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Exploring your repo about Playwright component testing and trying to avoid requiring users to install the [Vite plugin](https://github.com/brandonroberts/analog-playwright-component-tests/blob/main/playwright-ct.config.ts#L3) and specify [the tsconfig](https://github.com/brandonroberts/analog-playwright-component-tests/blob/main/playwright-ct.config.ts#L34).

Hence i'm setting `process.env['NODE_ENV']` environment variable to `'test'` so that the Vite plugin can resolve this by it self: https://github.com/analogjs/analog/blob/main/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts#L53

The build will fail when i do this because `viteServer` will be `undefined` in this scenario.

Related to: https://github.com/microsoft/playwright/issues/14153#issuecomment-1363385493