### PR TITLE
fix(platform): only transform xhr2 to default import one time

### DIFF
--- a/packages/platform/src/lib/ssr/ssr-build-plugin.ts
+++ b/packages/platform/src/lib/ssr/ssr-build-plugin.ts
@@ -23,7 +23,10 @@ export function ssrBuildPlugin(): Plugin {
       // Convert usage of xhr2 default import
       if (code.includes('new xhr2.')) {
         return {
-          code: code.replace('new xhr2.', 'new xhr2.default.'),
+          code: code.replace(
+            'new xhr2.XMLHttpRequest',
+            'new xhr2.default.XMLHttpRequest'
+          ),
         };
       }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Doing the replacement of `xhr2.XMLHttpRequest` to `xhr2.default.XMLHttpRequest` for esm support only happens once.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
