### PR TITLE
feat: enable ssr by default for analog platform plugin

### DIFF
--- a/apps/analog-app/vite.config.ts
+++ b/apps/analog-app/vite.config.ts
@@ -17,7 +17,6 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       analog({
-        ssr: true,
         ssrBuildDir: '../../dist/apps/analog-app/ssr',
         entryServer: 'apps/analog-app/src/main.server.ts',
         vite: {

--- a/apps/blog-app/vite.config.ts
+++ b/apps/blog-app/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig(() => {
     },
     plugins: [
       analog({
-        ssr: true,
         ssrBuildDir: '../../dist/apps/blog-app/ssr',
         entryServer: 'apps/blog-app/src/main.server.ts',
         static: true,

--- a/apps/docs-app/docs/features/server/server-side-rendering.md
+++ b/apps/docs-app/docs/features/server/server-side-rendering.md
@@ -2,7 +2,8 @@
 
 Analog supports server-side rendering during development and building for production.
 
-Enable SSR in the `vite.config.ts` using the `analog()` plugin:
+SSR is enabled by default. You can opt out of it and generate a client-only build by
+adding the following option to the `analog()` plugin in your `vite.config.ts`:
 
 ```ts
 import { defineConfig } from 'vite';
@@ -10,6 +11,6 @@ import analog from '@analogjs/platform';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  plugins: [analog({ ssr: true })],
+  plugins: [analog({ ssr: false })],
 }));
 ```

--- a/packages/platform/project.json
+++ b/packages/platform/project.json
@@ -35,6 +35,7 @@
       }
     },
     "test": {
+      "dependsOn": ["^build"],
       "executor": "@nrwl/vite:test"
     }
   },

--- a/packages/platform/src/lib/platform-plugin.spec.ts
+++ b/packages/platform/src/lib/platform-plugin.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect } from 'vitest';
+import { platformPlugin } from './platform-plugin';
+
+vi.mock('./vite-nitro-plugin');
+vi.mock('./ssr/ssr-build-plugin');
+vi.mock('./ssr/dev-server-plugin');
+
+describe('platformPlugin', () => {
+  const setup = async () => {
+    const viteNitroPluginImport = await import('./vite-nitro-plugin');
+    const viteNitroPluginSpy = vi.fn();
+    viteNitroPluginImport.viteNitroPlugin = viteNitroPluginSpy;
+
+    const ssrBuildPluginImport = await import('./ssr/ssr-build-plugin');
+    const ssrBuildPluginSpy = vi.fn();
+    ssrBuildPluginImport.ssrBuildPlugin = ssrBuildPluginSpy;
+
+    const devServerPluginImport = await import('./ssr/dev-server-plugin');
+    const devServerPluginSpy = vi.fn();
+    devServerPluginImport.devServerPlugin = devServerPluginSpy;
+
+    return {
+      viteNitroPluginSpy,
+      ssrBuildPluginSpy,
+      devServerPluginSpy,
+      platformPlugin,
+    };
+  };
+
+  it('should default ssr to true and pass that value to other plugins if no ssr value provided in options', async () => {
+    const {
+      viteNitroPluginSpy,
+      ssrBuildPluginSpy,
+      devServerPluginSpy,
+      platformPlugin,
+    } = await setup();
+    platformPlugin();
+
+    expect(viteNitroPluginSpy).toHaveBeenCalledWith({ ssr: true }, undefined);
+    expect(ssrBuildPluginSpy).toHaveBeenCalled();
+    expect(devServerPluginSpy).toHaveBeenCalled();
+  });
+
+  it('should pass ssr value as true if options.ssr is set to true', async () => {
+    const {
+      viteNitroPluginSpy,
+      ssrBuildPluginSpy,
+      devServerPluginSpy,
+      platformPlugin,
+    } = await setup();
+    platformPlugin({ ssr: true });
+
+    expect(viteNitroPluginSpy).toHaveBeenCalledWith({ ssr: true }, undefined);
+    expect(ssrBuildPluginSpy).toHaveBeenCalled();
+    expect(devServerPluginSpy).toHaveBeenCalled();
+  });
+
+  it('should pass ssr value as false if options.ssr is set to false', async () => {
+    const {
+      viteNitroPluginSpy,
+      ssrBuildPluginSpy,
+      devServerPluginSpy,
+      platformPlugin,
+    } = await setup();
+    platformPlugin({ ssr: false });
+
+    expect(viteNitroPluginSpy).toHaveBeenCalledWith({ ssr: false }, undefined);
+    expect(ssrBuildPluginSpy).not.toHaveBeenCalled();
+    expect(devServerPluginSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -8,12 +8,20 @@ import { ssrBuildPlugin } from './ssr/ssr-build-plugin';
 import { contentPlugin } from './content-plugin';
 
 export function platformPlugin(opts: Options = {}): Plugin[] {
+  const defaultOptions: Options = {
+    ssr: true,
+  };
+  const mergedOptions = {
+    ...defaultOptions,
+    ...opts,
+  };
+
   return [
-    viteNitroPlugin(opts, opts?.nitro),
-    (opts.ssr ? ssrBuildPlugin() : false) as Plugin,
+    viteNitroPlugin(mergedOptions, mergedOptions?.nitro),
+    (mergedOptions.ssr ? ssrBuildPlugin() : false) as Plugin,
     ...routerPlugin(),
     ...contentPlugin(),
-    (opts.ssr
+    (mergedOptions.ssr
       ? devServerPlugin({ entryServer: opts.entryServer })
       : false) as Plugin,
     ...angular(opts?.vite),


### PR DESCRIPTION
Instead of enabling SSR/SSG in the Analog config,
SSR/SSG would are now enabled by default for server-side support out of the box. SSR can still be disabled for client-only builds setting the ssr option to false.

Closes #294

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [x] platform
- [ ] content

## What is the current behavior?

Currently you need to enable SSR by setting the ssr option to true.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #294 

## What is the new behavior?

This change enables SSR by default and let's you opt out of it by setting the ssr option to false.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
