### PR TITLE
fix(routes): fix nested dynamic routes path

### DIFF
--- a/packages/router/src/lib/routes.spec.ts
+++ b/packages/router/src/lib/routes.spec.ts
@@ -118,6 +118,49 @@ describe('routes', () => {
     });
   });
 
+  describe('a nested dynamic route', () => {
+    const files: Files = {
+      '/app/routes/categories.[categoryId].products.[productId].ts': () =>
+        Promise.resolve({ default: RouteComponent }),
+    };
+
+    const routes = getRoutes(files);
+    const route: ModuleRoute = routes[0];
+
+    it('should have a path', () => {
+      expect(route.path).toBe('categories/:categoryId/products/:productId');
+    });
+
+    it('should have a pathMatch set to prefix', () => {
+      expect(route.pathMatch).toBe('prefix');
+    });
+
+    it('should have a _module property', () => {
+      expect(route._module).toBeDefined();
+
+      expect(typeof route._module).toBe('function');
+    });
+
+    it('should have a loadChildren property', () => {
+      expect(route.loadChildren).toBeDefined();
+
+      expect(typeof route.loadChildren).toBe('function');
+    });
+
+    it('should return an array of one route config from the loadChildren property', async () => {
+      expect(route.loadChildren).toBeDefined();
+
+      const routes = (await route.loadChildren()) as Route[];
+
+      expect(routes.length).toBe(1);
+
+      const innerRoute = routes.shift();
+
+      expect(innerRoute.path).toBe('');
+      expect(innerRoute.component).toBe(RouteComponent);
+    });
+  });
+
   describe('an index route', () => {
     const files: Files = {
       '/app/routes/index.ts': () =>

--- a/packages/router/src/lib/routes.ts
+++ b/packages/router/src/lib/routes.ts
@@ -48,7 +48,9 @@ export function getRoutes(
         .filter(Boolean);
 
       segments.reduce((parent, segment, index) => {
-        const path = segment.replace(/index|^\(.*?\)$/g, '').replace('.', '/');
+        const path = segment
+          .replace(/index|^\(.*?\)$/g, '')
+          .replace(/\./g, '/');
         const isIndex = !path;
         const isCatchall = path === '**';
         const pathMatch = isIndex ? 'full' : 'prefix';


### PR DESCRIPTION
As commented at https://github.com/analogjs/analog/issues/273#issuecomment-1477800171, we need an adjust on the `replace` function to switch all `.` to `/` since by default only the first occurrence is replaced.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [x] router
- [ ] platform
- [ ] content

## What is the current behavior?

With a route file with name `route.[route-id].subroute.[subroute-id].ts`, Analog produces the route `route/:route-id].subroute.[subroute-id]`.

Issue Number: N/A

## What is the new behavior?

Now Analog produces the route `route/:route-id/subroute/:subroute-id` correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
