### PR TITLE
feat(platform): allow nx-plugin to be packaged with @analogjs/platform

### DIFF
--- a/apps/nx-plugin-e2e/project.json
+++ b/apps/nx-plugin-e2e/project.json
@@ -7,12 +7,12 @@
     "e2e": {
       "executor": "@nrwl/nx-plugin:e2e",
       "options": {
-        "target": "nx-plugin:build",
+        "target": "platform:package",
         "jestConfig": "apps/nx-plugin-e2e/jest.config.ts",
         "coverageDirectory": "../../coverage/apps/nx-plugin-e2e"
       }
     }
   },
   "tags": [],
-  "implicitDependencies": ["nx-plugin"]
+  "implicitDependencies": ["platform"]
 }

--- a/apps/nx-plugin-e2e/tests/nx-plugin.spec.ts
+++ b/apps/nx-plugin-e2e/tests/nx-plugin.spec.ts
@@ -13,8 +13,12 @@ describe('nx-plugin e2e', () => {
   // consumes 1 workspace. The tests should each operate
   // on a unique project in the workspace, such that they
   // are not dependent on one another.
-  beforeAll(() => {
-    ensureNxProject('@analogjs/nx', 'dist/packages/nx-plugin');
+  beforeAll(async () => {
+    ensureNxProject(
+      '@analogjs/vite-plugin-angular',
+      'node_modules/@analogjs/vite-plugin-angular'
+    );
+    ensureNxProject('@analogjs/platform', 'node_modules/@analogjs/platform');
   });
 
   afterAll(() => {
@@ -25,18 +29,15 @@ describe('nx-plugin e2e', () => {
 
   it('should create hello-world', async () => {
     const project = uniq('hello-world');
-    await runNxCommandAsync(`generate @analogjs/nx:app ${project}`);
-    const result = await runNxCommandAsync(`build ${project}`);
-    expect(result.stdout).toContain(
-      'Successfully ran target build for project'
-    );
+    await runNxCommandAsync(`generate @analogjs/platform:app ${project}`);
+    expect(() => checkFilesExist(`apps/${project}/index.html`)).not.toThrow();
   }, 120000);
 
   describe('--directory', () => {
     it('should create src in the specified directory', async () => {
       const project = uniq('hello-world');
       await runNxCommandAsync(
-        `generate @analogjs/nx:app ${project} --directory subdir`
+        `generate @analogjs/platform:app ${project} --directory subdir`
       );
       expect(() =>
         checkFilesExist(`apps/subdir/${project}/index.html`)
@@ -48,10 +49,10 @@ describe('nx-plugin e2e', () => {
     it('should add tags to the project', async () => {
       const projectName = uniq('hello-world');
       await runNxCommandAsync(
-        `generate @analogjs/nx:app ${projectName} --tags e2etag,e2ePackage`
+        `generate @analogjs/platform:app ${projectName} --tags analog,analogApplication`
       );
       const project = readJson(`apps/${projectName}/project.json`);
-      expect(project.tags).toEqual(['e2etag', 'e2ePackage']);
+      expect(project.tags).toEqual(['analog', 'analogApplication']);
     }, 120000);
   });
 });

--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -11,7 +11,7 @@
   },
   "schematics": {
     "app": {
-      "factory": "./src/generators/app/generator",
+      "factory": "./src/generators/app/compat",
       "schema": "./src/generators/app/schema.json",
       "description": "Add Angular Three with proper packages and config"
     }

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -1,7 +1,5 @@
 {
   "name": "@analogjs/nx",
-  "version": "0.0.1-alpha.0",
-  "main": "src/index.js",
-  "generators": "./generators.json",
-  "schematics": "./generators.json"
+  "version": "0.0.1",
+  "main": "src/index.js"
 }

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -8,7 +8,7 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "dist/packages/nx-plugin",
+        "outputPath": "node_modules/@analogjs/platform/src/lib/nx-plugin",
         "main": "packages/nx-plugin/src/index.ts",
         "tsConfig": "packages/nx-plugin/tsconfig.lib.json",
         "assets": [

--- a/packages/nx-plugin/src/generators/app/compat.ts
+++ b/packages/nx-plugin/src/generators/app/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxGenerator } from '@nrwl/devkit';
+import generator from './generator';
+
+export default convertNxGenerator(generator);

--- a/packages/nx-plugin/src/generators/app/generator.ts
+++ b/packages/nx-plugin/src/generators/app/generator.ts
@@ -3,6 +3,7 @@ import {
   formatFiles,
   generateFiles,
   getWorkspaceLayout,
+  installPackagesTask,
   names,
   offsetFromRoot as determineOffsetFromRoot,
   stripIndents,
@@ -12,7 +13,6 @@ import * as path from 'path';
 import { AnalogNxApplicationGeneratorOptions } from './schema';
 import { lt, major } from 'semver';
 import { getInstalledAngularVersion } from '../../utils/version-utils';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { addAnalogProjectConfig } from './lib/add-analog-project-config';
 import {
   V15_ANALOG_JS_CONTENT,
@@ -113,12 +113,7 @@ async function addDependencies(tree: Tree, majorAngularVersion: number) {
     vitest: majorAngularVersion === 15 ? V15_VITEST : V16_VITEST,
   };
 
-  const installDependencies = addDependenciesToPackageJson(
-    tree,
-    dependencies,
-    devDependencies
-  );
-  await runTasksInSerial(installDependencies);
+  addDependenciesToPackageJson(tree, dependencies, devDependencies);
 }
 
 function addFiles(
@@ -128,7 +123,6 @@ function addFiles(
 ) {
   const templateOptions = {
     ...options,
-    offsetFromRoot: options.offsetFromRoot,
     template: '',
   };
   generateFiles(
@@ -169,4 +163,8 @@ export default async function (
   if (!normalizedOptions.skipFormat) {
     await formatFiles(tree);
   }
+
+  return () => {
+    installPackagesTask(tree);
+  };
 }

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -26,5 +26,7 @@
   "dependencies": {
     "nitropack": "^1.0.0",
     "@analogjs/vite-plugin-angular": "latest"
-  }
+  },
+  "generators": "./src/lib/nx-plugin/generators.json",
+  "schematics": "./src/lib/nx-plugin/generators.json"
 }

--- a/packages/platform/project.json
+++ b/packages/platform/project.json
@@ -27,6 +27,13 @@
       },
       "defaultConfiguration": "production"
     },
+    "package": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["yarn nx build platform", "yarn nx build nx-plugin"],
+        "parallel": false
+      }
+    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],


### PR DESCRIPTION
the nx plugin can now be packaged as part of @analogjs/platform to package the two run: nx run platform:package. also addressed the suggested changes in the previous PR. e2e tests were also adjusted because they stopped passing. there should be a follow-up PR that improves those tests and makes sure we can build those applications. (need to investigate e2e testing for nx projects, specifically when it comes to sharing node_module imports)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [x] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the nx plugin cannot be packaged with @analogjs/platform. 
This PR allows for exactly that.

Issue Number: N/A

## What is the new behavior?

You can now package the nx-plugin with plaform using `nx run platform:package` before you publish a new version of platform.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
