### PR TITLE
docs(content): correct injecting ActivatedRoute

### DIFF
--- a/apps/docs-app/docs/features/routing/overview.md
+++ b/apps/docs-app/docs/features/routing/overview.md
@@ -65,9 +65,9 @@ The parameter for the route is extracted from the route path.
 The example route below in `src/app/pages/products.[productId].page.ts` defines a `/products/:productId` route.
 
 ```ts
-import { Component, inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { AsyncPipe, JsonPipe } from '@angular/common';
-import { ActivatedRoute } from '@analogjs/router';
+import { injectActivatedRoute } from '@analogjs/router';
 import { map } from 'rxjs';
 
 @Component({
@@ -81,7 +81,7 @@ import { map } from 'rxjs';
   `,
 })
 export default class ProductDetailsPageComponent {
-  private readonly route = inject(ActivatedRoute);
+  private readonly route = injectActivatedRoute();
 
   readonly productId$ = this.route.paramMap.pipe(
     map((params) => params.get('productId'))
@@ -147,9 +147,9 @@ export default class ProductsListComponent {}
 The nested `src/app/pages/products/[productId].page.ts` file contains the `/products/:productId` details page.
 
 ```ts
-import { Component, inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { AsyncPipe, JsonPipe } from '@angular/common';
-import { ActivatedRoute } from '@analogjs/router';
+import { injectActivatedRoute } from '@analogjs/router';
 import { map } from 'rxjs';
 
 @Component({
@@ -163,7 +163,7 @@ import { map } from 'rxjs';
   `,
 })
 export default class ProductDetailsPageComponent {
-  private readonly route = inject(ActivatedRoute);
+  private readonly route = injectActivatedRoute();
 
   readonly productId$ = this.route.paramMap.pipe(
     map((params) => params.get('productId'))


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-angular-plugin
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [x] content

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

`ActivatedRoute` is injected via `injectActivatedRoute` instead of `inject(ActivatedRoute)`. Corrected the examples in the documentation

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
