### PR TITLE
docs(content): correct import of ActivatedRoute

### DIFF
--- a/apps/docs-app/docs/features/routing/overview.md
+++ b/apps/docs-app/docs/features/routing/overview.md
@@ -67,7 +67,7 @@ The example route below in `src/app/pages/products.[productId].page.ts` defines 
 ```ts
 import { Component, inject } from '@angular/core';
 import { AsyncPipe, JsonPipe } from '@angular/common';
-import { ActivatedRoute } from '@analogjs/router';
+import { ActivatedRoute } from '@angular/router';
 import { map } from 'rxjs';
 
 @Component({
@@ -149,7 +149,7 @@ The nested `src/app/pages/products/[productId].page.ts` file contains the `/prod
 ```ts
 import { Component, inject } from '@angular/core';
 import { AsyncPipe, JsonPipe } from '@angular/common';
-import { ActivatedRoute } from '@analogjs/router';
+import { ActivatedRoute } from '@angular/router';
 import { map } from 'rxjs';
 
 @Component({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [x] content

## What is the current behavior?

Issue Number: N/A

## What is the new behavior?

`ActivatedRoute` is being imported from `@analogjs/router` in the examples. This throws an error like:

```[ERROR] TS2305: Module "@analogjs/router" has no exported member 'ActivatedRoute'```

Correct import is from `@angular/router`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
