### PR TITLE
feat: add default pretender route

### DIFF
--- a/apps/docs-app/docs/features/server/server-side-rendering.md
+++ b/apps/docs-app/docs/features/server/server-side-rendering.md
@@ -42,9 +42,11 @@ export default defineConfig(({ mode }) => ({
 }));
 ```
 
-With SSR, the  `"/"` route is pre-rendered by default.
+## Prerendering routes
 
-It is a necessary step to return a rendered HTML when the user visits the root of the application. The prerendered routes can be customized, but keep in mind to include the `"/"` value too. You can opt out of it by passing an empty array of routes.
+With SSR, the  `"/"` route is prerendered by default.
+
+It is a necessary step to return a rendered HTML when the user visits the root of the application. The prerendered routes can be customized, but keep in mind to include the `"/"` route also. 
 
 ```js
 import { defineConfig } from 'vite';
@@ -60,3 +62,5 @@ export default defineConfig(({ mode }) => ({
     })
   ],
 }));
+
+You can opt out of prerendering by passing an empty array of routes.

--- a/apps/docs-app/docs/features/server/server-side-rendering.md
+++ b/apps/docs-app/docs/features/server/server-side-rendering.md
@@ -42,4 +42,21 @@ export default defineConfig(({ mode }) => ({
 }));
 ```
 
-Next to the default SSR the `prerender.routes` has a default value. This is the `"/"` route. It is a necessary step to return a rendered HTML when the user visits the root of our app. If you set routes in the plugin config, keep in mind to include the `"/"` value too. You can opt out of it by passing a
+With SSR, the  `"/"` route is pre-rendered by default.
+
+It is a necessary step to return a rendered HTML when the user visits the root of the application. The prerendered routes can be customized, but keep in mind to include the `"/"` value too. You can opt out of it by passing an empty array of routes.
+
+```js
+import { defineConfig } from 'vite';
+import analog from '@analogjs/platform';
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => ({
+  // ...other config
+  plugins: [
+    analog({ 
+      prerender: {
+        routes: ['/', '/about']
+      }
+    })
+  ],
+}));

--- a/apps/docs-app/docs/features/server/server-side-rendering.md
+++ b/apps/docs-app/docs/features/server/server-side-rendering.md
@@ -41,3 +41,5 @@ export default defineConfig(({ mode }) => ({
   plugins: [analog({ ssr: false })],
 }));
 ```
+
+Next to the default SSR the `prerender.routes` has a default value. This is the `"/"` route. It is a necessary step to return a rendered HTML when the user visits the root of our app. If you set routes in the plugin config, keep in mind to include the `"/"` value too. You can opt out of it by passing a

--- a/packages/vite-plugin-nitro/src/lib/vite-nitro-plugin.spec.data.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-nitro-plugin.spec.data.ts
@@ -1,0 +1,51 @@
+import { NitroConfig } from 'nitropack';
+import { ConfigEnv, UserConfig, Plugin } from 'vite';
+import { Mock, vi } from 'vitest';
+
+export const mockViteDevServer = {
+  middlewares: {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    use: () => {},
+  },
+};
+
+export const mockNitroConfig: NitroConfig = {
+  buildDir: './dist/.nitro',
+  logLevel: 0,
+  output: {
+    dir: '../dist/analog',
+    publicDir: '../dist/analog/public',
+  },
+  rootDir: '.',
+  runtimeConfig: {},
+  scanDirs: ['src/server'],
+  srcDir: 'src',
+  prerender: {
+    crawlLinks: undefined,
+  },
+  typescript: {
+    generateTsConfig: false,
+  },
+};
+
+export async function mockBuildFunctions(): Promise<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [Mock<any, any>, Mock<any, any>]
+> {
+  const buildServerImport = await import('./build-server');
+  const buildServerImportSpy = vi.fn();
+  buildServerImport.buildServer = buildServerImportSpy;
+
+  const buildSSRAppImport = await import('./build-ssr');
+  const buildSSRAppImportSpy = vi.fn();
+  buildSSRAppImport.buildSSRApp = buildSSRAppImportSpy;
+
+  return [buildSSRAppImportSpy, buildServerImportSpy];
+}
+
+export async function runConfigAndCloseBundle(plugin: Plugin): Promise<void> {
+  await (
+    plugin.config as (config: UserConfig, env: ConfigEnv) => Promise<UserConfig>
+  )({}, { command: 'build' } as ConfigEnv);
+  await (plugin.closeBundle as () => Promise<void>)();
+}

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
 import { nitro } from './vite-plugin-nitro';
+import {
+  mockBuildFunctions,
+  mockNitroConfig,
+  mockViteDevServer,
+  runConfigAndCloseBundle,
+} from './vite-nitro-plugin.spec.data';
 
-const mockViteDevServer = {
-  middlewares: {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    use: () => {},
-  },
-};
-
-describe('viteNitroPlugin', () => {
+describe('nitro', () => {
+  vi.mock('./build-ssr');
+  vi.mock('./build-server');
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -27,5 +28,91 @@ describe('viteNitroPlugin', () => {
     // Assert
     expect(spy).toHaveBeenCalledTimes(0);
     expect(spy).not.toHaveBeenCalledWith('/api', expect.anything());
+  });
+
+  it('should build the server with prerender route "/" if nothing was provided', async () => {
+    // Arrange
+    const [buildSSRAppImportSpy, buildServerImportSpy] =
+      await mockBuildFunctions();
+    const plugin = nitro({
+      ssr: true,
+    });
+
+    // Act
+    await runConfigAndCloseBundle(plugin);
+
+    // Assert
+    expect(buildSSRAppImportSpy).toHaveBeenCalledWith({}, { ssr: true });
+    expect(buildServerImportSpy).toHaveBeenCalledWith(
+      { ssr: true },
+      { ...mockNitroConfig, prerender: { routes: ['/'] } }
+    );
+  });
+
+  it('should build the server with prerender route "/" even if ssr is false', async () => {
+    // Arrange
+    const [buildSSRAppImportSpy, buildServerImportSpy] =
+      await mockBuildFunctions();
+    const plugin = nitro({
+      ssr: false,
+    });
+
+    // Act
+    await runConfigAndCloseBundle(plugin);
+
+    // Assert
+    expect(buildSSRAppImportSpy).not.toHaveBeenCalled();
+    expect(buildServerImportSpy).toHaveBeenCalledWith(
+      { ssr: false },
+      { ...mockNitroConfig, prerender: { routes: ['/'] } }
+    );
+  });
+
+  it('should build the server without prerender route when an empty array was passed', async () => {
+    // Arrange
+    const [buildSSRAppImportSpy, buildServerImportSpy] =
+      await mockBuildFunctions();
+    const prerenderRoutes = { prerender: { routes: [] } };
+    const plugin = nitro({
+      ssr: true,
+      ...prerenderRoutes,
+    });
+
+    // Act
+    await runConfigAndCloseBundle(plugin);
+
+    // Assert
+    expect(buildSSRAppImportSpy).toHaveBeenCalledWith(
+      {},
+      { ssr: true, ...prerenderRoutes }
+    );
+    expect(buildServerImportSpy).toHaveBeenCalledWith(
+      { ssr: true, ...prerenderRoutes },
+      { ...mockNitroConfig }
+    );
+  });
+
+  it('should build the server with provided routes', async () => {
+    // Arrange
+    const [buildSSRAppImportSpy, buildServerImportSpy] =
+      await mockBuildFunctions();
+    const prerenderRoutes = { prerender: { routes: ['/blog', '/about'] } };
+    const plugin = nitro({
+      ssr: true,
+      ...prerenderRoutes,
+    });
+
+    // Act
+    await runConfigAndCloseBundle(plugin);
+
+    // Assert
+    expect(buildSSRAppImportSpy).toHaveBeenCalledWith(
+      {},
+      { ssr: true, ...prerenderRoutes }
+    );
+    expect(buildServerImportSpy).toHaveBeenCalledWith(
+      { ssr: true, ...prerenderRoutes },
+      { ...mockNitroConfig, ...prerenderRoutes }
+    );
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content

## What is the current behavior?

Currently in the site plugin, if we just set the `ssr: true` (default behavior), the root route won't be served to the client. This can be achieved by setting the `{ pretender: {routes: ["/"] } }` array. The problem with this, that this is not covered in the documentation, and require some extra setup.

Issue Number: N/A

## What is the new behavior?

The point of the PR to add the `"/"` route to the routes array as default.

Also if the developer pass an empty array as argument, it won't be applied.

If they pass an array with values, this route won't be added to the array. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
