### PR TITLE
feat: make nx plugin work without angular preset and add tailwind option

### DIFF
--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -7,6 +7,12 @@
       "factory": "./src/generators/app/generator",
       "schema": "./src/generators/app/schema.json",
       "description": "Generates an AnalogJs application"
+    },
+    "preset": {
+      "factory": "./src/generators/preset/generator",
+      "schema": "./src/generators/preset/schema.json",
+      "description": "Analog preset for create-nx-workspace",
+      "x-use-standalone-layout": true
     }
   },
   "schematics": {

--- a/packages/nx-plugin/src/generators/app/files/tailwind/postcss.config.js__template__
+++ b/packages/nx-plugin/src/generators/app/files/tailwind/postcss.config.js__template__
@@ -1,0 +1,10 @@
+const { join } = require('path');
+
+module.exports = {
+  plugins: {
+    tailwindcss: {
+      config: join(__dirname, 'tailwind.config.js')
+    },
+    autoprefixer: {}
+  }
+};

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/.eslintrc.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/.eslintrc.json__template__
@@ -1,11 +1,11 @@
 {
-  "extends": ["../../.eslintrc.json"],
+  "extends": ["<%= offsetFromRoot %>.eslintrc.json"],
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {
       "files": ["*.ts"],
       "extends": [
-        "plugin:@nrwl/nx/angular",
+        "plugin:<%= nxPackageNamespace %>/nx/angular",
         "plugin:@angular-eslint/template/process-inline-templates"
       ],
       "rules": {
@@ -29,7 +29,7 @@
     },
     {
       "files": ["*.html"],
-      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "extends": ["plugin:<%= nxPackageNamespace %>/nx/angular-template"],
       "rules": {}
     }
   ]

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/tsconfig.app.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/tsconfig.app.json__template__
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": [],
     "target": "ES2022",
     "useDefineForClassFields": false

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/tsconfig.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/tsconfig.json__template__
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "files": [],
   "include": [],
   "exclude": ["./src/server/**/*"],

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/tsconfig.spec.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/tsconfig.spec.json__template__
@@ -1,12 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": ["node", "vitest/globals"]
   },
   "files": [
     "src/test-setup.ts",
-    "src/polyfills.ts"
   ],
   "include": [
     "src/**/*.spec.ts",

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/vite.config.ts__template__
@@ -17,33 +17,33 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       analog({
-        ssrBuildDir: '../../dist/apps/<%= projectName %>/ssr',
-        entryServer: 'apps/<%= projectName %>/src/main.server.ts',
+        ssrBuildDir: '<%= offsetFromRoot %>dist/<%= appsDir %>/<%= projectName %>/ssr',
+        entryServer: '<%= appsDir %>/<%= projectName %>/src/main.server.ts',
         vite: {
           inlineStylesExtension: 'css',
           tsconfig:
             mode === 'test'
-              ? 'apps/<%= projectName %>/tsconfig.spec.json'
-              : 'apps/<%= projectName %>/tsconfig.app.json',
+              ? '<%= appsDir %>/<%= projectName %>/tsconfig.spec.json'
+              : '<%= appsDir %>/<%= projectName %>/tsconfig.app.json',
         },
         nitro: {
-          rootDir: 'apps/<%= projectName %>',
+          rootDir: '<%= appsDir %>/<%= projectName %>',
           output: {
-            dir: '../../../dist/apps/<%= projectName %>/analog',
-            publicDir: '../../../dist/apps/<%= projectName %>/analog/public',
+            dir: '<%= offsetFromRoot %>../dist/<%= appsDir %>/<%= projectName %>/analog',
+            publicDir: '<%= offsetFromRoot %>../dist/<%= appsDir %>/<%= projectName %>/analog/public',
           },
-          publicAssets: [{ dir: `../../../dist/apps/<%= projectName %>/client` }],
+          publicAssets: [{ dir: `<%= offsetFromRoot %>../dist/<%= appsDir %>/<%= projectName %>/client` }],
           serverAssets: [
-            { baseName: 'public', dir: `./dist/apps/<%= projectName %>/client` },
+            { baseName: 'public', dir: `./dist/<%= appsDir %>/<%= projectName %>/client` },
           ],
-          buildDir: '../../dist/apps/<%= projectName %>/.nitro',
+          buildDir: '<%= offsetFromRoot %>dist/<%= appsDir %>/<%= projectName %>/.nitro',
         },
         prerender: {
           routes: ['/'],
         },
       }),
       tsConfigPaths({
-        root: '../../',
+        root: '<%= offsetFromRoot %>',
       }),
       visualizer() as Plugin,
       splitVendorChunkPlugin(),
@@ -54,7 +54,7 @@ export default defineConfig(({ mode }) => {
       setupFiles: ['src/test-setup.ts'],
       include: ['**/*.spec.ts'],
       cache: {
-        dir: `../../node_modules/.vitest`,
+        dir: `<%= offsetFromRoot %>node_modules/.vitest`,
       },
     },
     define: {

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/.eslintrc.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/.eslintrc.json__template__
@@ -1,11 +1,11 @@
 {
-  "extends": ["../../.eslintrc.json"],
+  "extends": ["<%= offsetFromRoot %>.eslintrc.json"],
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {
       "files": ["*.ts"],
       "extends": [
-        "plugin:@nrwl/nx/angular",
+        "plugin:<%= nxPackageNamespace %>/nx/angular",
         "plugin:@angular-eslint/template/process-inline-templates"
       ],
       "rules": {
@@ -29,7 +29,7 @@
     },
     {
       "files": ["*.html"],
-      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "extends": ["plugin:<%= nxPackageNamespace %>/nx/angular-template"],
       "rules": {}
     }
   ]

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/tsconfig.app.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/tsconfig.app.json__template__
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": [],
     "target": "ES2022",
     "useDefineForClassFields": false

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/tsconfig.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/tsconfig.json__template__
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "files": [],
   "include": [],
   "exclude": ["./src/server/**/*"],

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/tsconfig.spec.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/tsconfig.spec.json__template__
@@ -1,12 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": ["node", "vitest/globals"]
   },
   "files": [
     "src/test-setup.ts",
-    "src/polyfills.ts"
   ],
   "include": [
     "src/**/*.spec.ts",

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/vite.config.ts__template__
@@ -17,33 +17,33 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       analog({
-        ssrBuildDir: '../../dist/apps/<%= projectName %>/ssr',
-        entryServer: 'apps/<%= projectName %>/src/main.server.ts',
+        ssrBuildDir: '<%= offsetFromRoot %>dist/<%= appsDir %>/<%= projectName %>/ssr',
+        entryServer: '<%= appsDir %>/<%= projectName %>/src/main.server.ts',
         vite: {
           inlineStylesExtension: 'css',
           tsconfig:
             mode === 'test'
-              ? 'apps/<%= projectName %>/tsconfig.spec.json'
-              : 'apps/<%= projectName %>/tsconfig.app.json',
+              ? '<%= appsDir %>/<%= projectName %>/tsconfig.spec.json'
+              : '<%= appsDir %>/<%= projectName %>/tsconfig.app.json',
         },
         nitro: {
-          rootDir: 'apps/<%= projectName %>',
+          rootDir: '<%= appsDir %>/<%= projectName %>',
           output: {
-            dir: '../../../dist/apps/<%= projectName %>/analog',
-            publicDir: '../../../dist/apps/<%= projectName %>/analog/public',
+            dir: '<%= offsetFromRoot %>../dist/<%= appsDir %>/<%= projectName %>/analog',
+            publicDir: '<%= offsetFromRoot %>../dist/<%= appsDir %>/<%= projectName %>/analog/public',
           },
-          publicAssets: [{ dir: `../../../dist/apps/<%= projectName %>/client` }],
+          publicAssets: [{ dir: `<%= offsetFromRoot %>../dist/<%= appsDir %>/<%= projectName %>/client` }],
           serverAssets: [
-            { baseName: 'public', dir: `./dist/apps/<%= projectName %>/client` },
+            { baseName: 'public', dir: `./dist/<%= appsDir %>/<%= projectName %>/client` },
           ],
-          buildDir: '../../dist/apps/<%= projectName %>/.nitro',
+          buildDir: '<%= offsetFromRoot %>dist/<%= appsDir %>/<%= projectName %>/.nitro',
         },
         prerender: {
           routes: ['/'],
         },
       }),
       tsConfigPaths({
-        root: '../../',
+        root: '<%= offsetFromRoot %>',
       }),
       visualizer() as Plugin,
       splitVendorChunkPlugin(),
@@ -51,10 +51,10 @@ export default defineConfig(({ mode }) => {
     test: {
       globals: true,
       environment: 'jsdom',
-      setupFiles: ['src/test.ts'],
+      setupFiles: ['src/test-setup.ts'],
       include: ['**/*.spec.ts'],
       cache: {
-        dir: `../../node_modules/.vitest`,
+        dir: `<%= offsetFromRoot %>node_modules/.vitest`,
       },
     },
     define: {

--- a/packages/nx-plugin/src/generators/app/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/app/generator.spec.ts
@@ -3,10 +3,12 @@ import { readJson, readProjectConfiguration } from '@nx/devkit';
 
 import generator from './generator';
 import { AnalogNxApplicationGeneratorOptions } from './schema';
+import { addDependenciesToPackageJson } from '@nrwl/devkit';
 
 describe('nx-plugin generator', () => {
   const setup = async (options: AnalogNxApplicationGeneratorOptions) => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    addDependenciesToPackageJson(tree, { nx: '16.0.0' }, {});
     await generator(tree, options);
     const config = readProjectConfiguration(tree, options.name);
     return {

--- a/packages/nx-plugin/src/generators/app/generator.ts
+++ b/packages/nx-plugin/src/generators/app/generator.ts
@@ -7,7 +7,6 @@ import {
   stripIndents,
   Tree,
 } from '@nx/devkit';
-import * as path from 'path';
 import { AnalogNxApplicationGeneratorOptions } from './schema';
 import { major } from 'semver';
 import { getInstalledPackageVersion } from '../../utils/version-utils';

--- a/packages/nx-plugin/src/generators/app/lib/add-analog-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-analog-dependencies.ts
@@ -1,0 +1,79 @@
+import { addDependenciesToPackageJson, Tree } from '@nrwl/devkit';
+import {
+  V15_ANALOG_JS_CONTENT,
+  V15_ANALOG_JS_PLATFORM,
+  V15_ANALOG_JS_ROUTER,
+  V15_ANGULAR_PLATFORM_SERVER,
+  V15_FRONT_MATTER,
+  V15_JSDOM,
+  V15_MARKED,
+  V15_NRWL_VITE,
+  V15_PRISMJS,
+  V15_TYPESCRIPT,
+  V15_VITE,
+  V15_VITE_TSCONFIG_PATHS,
+  V15_VITEST,
+  V16_ANALOG_JS_CONTENT,
+  V16_ANALOG_JS_PLATFORM,
+  V16_ANALOG_JS_ROUTER,
+  V16_ANGULAR_PLATFORM_SERVER,
+  V16_FRONT_MATTER,
+  V16_JSDOM,
+  V16_MARKED,
+  V16_NX_VITE,
+  V16_PRISMJS,
+  V16_TYPESCRIPT,
+  V16_VITE,
+  V16_VITE_TSCONFIG_PATHS,
+  V16_VITEST,
+} from '../versions';
+
+export async function addAnalogDependencies(
+  tree: Tree,
+  majorAngularVersion: number,
+  majorNxVersion: number
+) {
+  const dependencies = {
+    '@analogjs/content':
+      majorAngularVersion === 15
+        ? V15_ANALOG_JS_CONTENT
+        : V16_ANALOG_JS_CONTENT,
+    '@analogjs/router':
+      majorAngularVersion === 15 ? V15_ANALOG_JS_ROUTER : V16_ANALOG_JS_ROUTER,
+    '@angular/platform-server':
+      majorAngularVersion === 15
+        ? V15_ANGULAR_PLATFORM_SERVER
+        : V16_ANGULAR_PLATFORM_SERVER,
+    'front-matter':
+      majorAngularVersion === 15 ? V15_FRONT_MATTER : V16_FRONT_MATTER,
+    marked: majorAngularVersion === 15 ? V15_MARKED : V16_MARKED,
+    prismjs: majorAngularVersion === 15 ? V15_PRISMJS : V16_PRISMJS,
+  };
+
+  const nxViteDependency =
+    majorNxVersion === 15
+      ? {
+          '@nrwl/vite':
+            majorAngularVersion === 15 ? V15_NRWL_VITE : V16_NX_VITE,
+        }
+      : {
+          '@nx/vite': majorAngularVersion === 15 ? V15_NRWL_VITE : V16_NX_VITE,
+        };
+  const devDependencies = {
+    '@analogjs/platform':
+      majorAngularVersion === 15
+        ? V15_ANALOG_JS_PLATFORM
+        : V16_ANALOG_JS_PLATFORM,
+    ...nxViteDependency,
+    jsdom: majorAngularVersion === 15 ? V15_JSDOM : V16_JSDOM,
+    typescript: majorAngularVersion === 15 ? V15_TYPESCRIPT : V16_TYPESCRIPT,
+    vite: majorAngularVersion === 15 ? V15_VITE : V16_VITE,
+    'vite-tsconfig-paths':
+      majorAngularVersion === 15
+        ? V15_VITE_TSCONFIG_PATHS
+        : V16_VITE_TSCONFIG_PATHS,
+    vitest: majorAngularVersion === 15 ? V15_VITEST : V16_VITEST,
+  };
+
+  addDependenciesToPackageJson(tree, dependencies, devDependencies);
+}

--- a/packages/nx-plugin/src/generators/app/lib/add-analog-project-config.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-analog-project-config.ts
@@ -6,7 +6,9 @@ export function addAnalogProjectConfig(
   projectRoot: string,
   projectName: string,
   parsedTags: string[],
-  name: string
+  name: string,
+  appsDir: string,
+  nxPackageNamespace: string
 ) {
   const projectConfiguration: ProjectConfiguration = {
     root: projectRoot,
@@ -14,16 +16,16 @@ export function addAnalogProjectConfig(
     sourceRoot: `${projectRoot}/src`,
     targets: {
       build: {
-        executor: '@nx/vite:build',
+        executor: `${nxPackageNamespace}/vite:build`,
         outputs: [
           '{options.outputPath}',
-          `dist/apps/${projectName}/.nitro`,
-          `dist/apps/${projectName}/ssr`,
-          `dist/apps/${projectName}/analog`,
+          `dist/${appsDir}/${projectName}/.nitro`,
+          `dist/${appsDir}/${projectName}/ssr`,
+          `dist/${appsDir}/${projectName}/analog`,
         ],
         options: {
-          configFile: 'vite.config.ts',
-          outputPath: `dist/apps/${projectName}/client`,
+          configFile: `${appsDir}/${projectName}/vite.config.ts`,
+          outputPath: `dist/${appsDir}/${projectName}/client`,
         },
         defaultConfiguration: 'production',
         configurations: {
@@ -37,7 +39,7 @@ export function addAnalogProjectConfig(
         },
       },
       serve: {
-        executor: '@nx/vite:dev-server',
+        executor: `${nxPackageNamespace}/vite:dev-server`,
         defaultConfiguration: 'development',
         options: {
           buildTarget: `${projectName}:build`,
@@ -54,24 +56,24 @@ export function addAnalogProjectConfig(
         },
       },
       'extract-i18n': {
-        executor: '@angular-devkit/build-angular:extract-i18n',
+        executor: `@angular-devkit/build-angular:extract-i18n`,
         options: {
           browserTarget: `${projectName}:build`,
         },
       },
       lint: {
-        executor: '@nx/linter:eslint',
+        executor: `${nxPackageNamespace}/linter:eslint`,
         outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: [
-            `apps/${projectName}/**/*.ts`,
-            `apps/${projectName}/**/*.html`,
+            `${appsDir}/${projectName}/**/*.ts`,
+            `${appsDir}/${projectName}/**/*.html`,
           ],
         },
       },
       test: {
-        executor: '@nx/vite:test',
-        outputs: [`apps/${projectName}/coverage`],
+        executor: `${nxPackageNamespace}/vite:test`,
+        outputs: [`${appsDir}/${projectName}/coverage`],
       },
     },
     tags: parsedTags,

--- a/packages/nx-plugin/src/generators/app/lib/add-files.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-files.ts
@@ -1,0 +1,25 @@
+import { generateFiles, Tree } from '@nrwl/devkit';
+import * as path from 'path';
+import { NormalizedOptions } from '../generator';
+
+export function addFiles(
+  tree: Tree,
+  options: NormalizedOptions,
+  majorAngularVersion: number
+) {
+  const templateOptions = {
+    ...options,
+    template: '',
+  };
+  generateFiles(
+    tree,
+    path.join(
+      __dirname,
+      '..',
+      'files',
+      'template-angular-v' + majorAngularVersion
+    ),
+    options.projectRoot,
+    templateOptions
+  );
+}

--- a/packages/nx-plugin/src/generators/app/lib/add-tailwind-config.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-tailwind-config.ts
@@ -1,0 +1,32 @@
+import { generateFiles, Tree } from '@nrwl/devkit';
+import * as path from 'path';
+
+export async function addTailwindConfig(
+  tree: Tree,
+  projectRoot: string,
+  projectName: string,
+  majorNxVersion: number
+) {
+  if (majorNxVersion === 16) {
+    await (
+      await import(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        '@nx/angular/generators'
+      )
+    ).setupTailwindGenerator(tree, {
+      project: projectName,
+    });
+  } else {
+    await (
+      await import('@nrwl/angular/generators')
+    ).setupTailwindGenerator(tree, { project: projectName });
+  }
+
+  generateFiles(
+    tree,
+    path.join(__dirname, '..', 'files', 'tailwind'),
+    projectRoot,
+    { template: '' }
+  );
+}

--- a/packages/nx-plugin/src/generators/app/lib/initialize-analog-workspace.ts
+++ b/packages/nx-plugin/src/generators/app/lib/initialize-analog-workspace.ts
@@ -4,7 +4,7 @@ import {
   ensurePackage,
   stripIndents,
   Tree,
-} from '@nrwl/devkit';
+} from '@nx/devkit';
 import {
   MINIMUM_SUPPORTED_ANGULAR_VERSION,
   V15_ANGULAR,

--- a/packages/nx-plugin/src/generators/app/lib/initialize-analog-workspace.ts
+++ b/packages/nx-plugin/src/generators/app/lib/initialize-analog-workspace.ts
@@ -1,0 +1,95 @@
+import { lt, major } from 'semver';
+import {
+  addDependenciesToPackageJson,
+  ensurePackage,
+  stripIndents,
+  Tree,
+} from '@nrwl/devkit';
+import {
+  MINIMUM_SUPPORTED_ANGULAR_VERSION,
+  V15_ANGULAR,
+  V15_NRWL_ANGULAR,
+  V15_NRWL_DEVKIT,
+  V16_ANGULAR,
+  V16_NX_ANGULAR,
+  V16_NX_DEVKIT,
+} from '../versions';
+import { getInstalledPackageVersion } from '../../../utils/version-utils';
+import { NormalizedOptions } from '../generator';
+
+export async function initializeAngularWorkspace(
+  tree: Tree,
+  installedNxVersion: string,
+  normalizedOptions: NormalizedOptions
+) {
+  let angularVersion = getInstalledPackageVersion(tree, '@angular/core');
+
+  if (!angularVersion) {
+    console.log(
+      'Angular has not been installed yet. Creating an Angular application'
+    );
+
+    if (major(installedNxVersion) === 16) {
+      try {
+        ensurePackage('@nx/devkit', V16_NX_DEVKIT);
+        ensurePackage('@nx/angular', V16_NX_ANGULAR);
+      } catch {
+        // @nx/angular cannot be required so this fails but this will still allow executing the nx angular init later on
+      }
+      addDependenciesToPackageJson(
+        tree,
+        {},
+        {
+          '@nx/devkit': V16_NX_DEVKIT,
+          '@nx/angular': V16_NX_ANGULAR,
+        }
+      );
+    } else {
+      try {
+        ensurePackage('@nrwl/devkit', V15_NRWL_DEVKIT);
+        ensurePackage('@nrwl/angular', V15_NRWL_ANGULAR);
+      } catch {
+        // @nx/angular cannot be required so this fails but this will still allow executing the nx angular init later on
+      }
+      addDependenciesToPackageJson(
+        tree,
+        {},
+        {
+          '@nrwl/devkit': V15_NRWL_DEVKIT,
+          '@nrwl/angular': V15_NRWL_ANGULAR,
+        }
+      );
+    }
+
+    if (major(installedNxVersion) === 16) {
+      await (
+        await import(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          '@nx/angular/generators'
+        )
+      ).angularInitGenerator(tree, {
+        skipInstall: true,
+        skipFormat: normalizedOptions.skipFormat,
+      });
+      angularVersion = V16_ANGULAR;
+    } else {
+      await (
+        await import('@nrwl/angular/generators')
+      ).angularInitGenerator(tree, {
+        unitTestRunner: 'none' as any,
+        skipInstall: true,
+        skipFormat: normalizedOptions.skipFormat,
+      });
+      angularVersion = V15_ANGULAR;
+    }
+  }
+
+  if (lt(angularVersion, MINIMUM_SUPPORTED_ANGULAR_VERSION)) {
+    throw new Error(
+      stripIndents`AnalogJs only supports an Angular version of 15 and higher`
+    );
+  }
+
+  return angularVersion;
+}

--- a/packages/nx-plugin/src/generators/app/schema.d.ts
+++ b/packages/nx-plugin/src/generators/app/schema.d.ts
@@ -1,6 +1,6 @@
 export interface AnalogNxApplicationGeneratorOptions {
   name: string;
   tags?: string;
-  directory?: string;
+  skipTailwind?: boolean;
   skipFormat?: boolean;
 }

--- a/packages/nx-plugin/src/generators/app/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions.ts
@@ -2,7 +2,7 @@ export const MINIMUM_SUPPORTED_ANGULAR_VERSION = '15.0.0';
 // V16
 // dependencies
 export const V16_ANGULAR = '16.0.0';
-export const V16_NX_DEVKIT = '16.0.3';
+export const V16_NX_DEVKIT = '^16.0.0';
 export const V16_NX_ANGULAR = '16.1.0-rc.0';
 export const V16_ANALOG_JS_CONTENT = '^0.2.0-beta.3';
 export const V16_ANALOG_JS_ROUTER = '^0.2.0-beta.3';
@@ -13,7 +13,7 @@ export const V16_PRISMJS = '^1.29.0';
 
 // devDependencies
 export const V16_ANALOG_JS_PLATFORM = '^0.2.0-beta.3';
-export const V16_NX_VITE = '16.0.3';
+export const V16_NX_VITE = '^16.0.0';
 export const V16_JSDOM = '^20.0.0';
 export const V16_TYPESCRIPT = '~5.0.2';
 export const V16_VITE = '^4.0.3';

--- a/packages/nx-plugin/src/generators/app/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions.ts
@@ -1,5 +1,9 @@
+export const MINIMUM_SUPPORTED_ANGULAR_VERSION = '15.0.0';
 // V16
 // dependencies
+export const V16_ANGULAR = '16.0.0';
+export const V16_NX_DEVKIT = '16.0.3';
+export const V16_NX_ANGULAR = '16.1.0-rc.0';
 export const V16_ANALOG_JS_CONTENT = '^0.2.0-beta.3';
 export const V16_ANALOG_JS_ROUTER = '^0.2.0-beta.3';
 export const V16_ANGULAR_PLATFORM_SERVER = '^16.0.0';
@@ -9,7 +13,7 @@ export const V16_PRISMJS = '^1.29.0';
 
 // devDependencies
 export const V16_ANALOG_JS_PLATFORM = '^0.2.0-beta.3';
-export const V16_NRWL_VITE = '^15.7.0';
+export const V16_NX_VITE = '16.0.3';
 export const V16_JSDOM = '^20.0.0';
 export const V16_TYPESCRIPT = '~5.0.2';
 export const V16_VITE = '^4.0.3';
@@ -18,6 +22,9 @@ export const V16_VITEST = '^0.25.8';
 
 // V15
 // dependencies
+export const V15_ANGULAR = '15.2.7';
+export const V15_NRWL_DEVKIT = '15.9.2';
+export const V15_NRWL_ANGULAR = '15.9.2';
 export const V15_ANALOG_JS_CONTENT = '0.1.9';
 export const V15_ANALOG_JS_ROUTER = '0.1.0-alpha.10';
 export const V15_ANGULAR_PLATFORM_SERVER = '^15.0.0';

--- a/packages/nx-plugin/src/generators/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   Tree,
   readProjectConfiguration,

--- a/packages/nx-plugin/src/generators/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.spec.ts
@@ -1,0 +1,28 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  Tree,
+  readProjectConfiguration,
+  addDependenciesToPackageJson,
+} from '@nrwl/devkit';
+
+import generator from './generator';
+import { PresetGeneratorSchema } from './schema';
+import { AnalogNxApplicationGeneratorOptions } from '../app/schema';
+
+describe('preset generator', () => {
+  const setup = async (options: AnalogNxApplicationGeneratorOptions) => {
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    addDependenciesToPackageJson(tree, { nx: '16.0.0' }, {});
+    await generator(tree, options);
+    const config = readProjectConfiguration(tree, options.name);
+    return {
+      tree,
+      config,
+    };
+  };
+
+  it('should run successfully', async () => {
+    const { config, tree } = await setup({ name: 'analog' });
+    expect(config).toBeDefined();
+  });
+});

--- a/packages/nx-plugin/src/generators/preset/generator.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.ts
@@ -1,0 +1,8 @@
+import { Tree } from '@nrwl/devkit';
+import { PresetGeneratorSchema } from './schema';
+
+export default async function (tree: Tree, options: PresetGeneratorSchema) {
+  return await import('../app/generator').then(({ appGenerator }) =>
+    appGenerator(tree, options)
+  );
+}

--- a/packages/nx-plugin/src/generators/preset/schema.d.ts
+++ b/packages/nx-plugin/src/generators/preset/schema.d.ts
@@ -1,0 +1,5 @@
+export interface PresetGeneratorSchema {
+  name: string;
+  tags?: string;
+  skipTailwind?: boolean;
+}

--- a/packages/nx-plugin/src/generators/preset/schema.json
+++ b/packages/nx-plugin/src/generators/preset/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
-  "$id": "app",
+  "$id": "Preset",
   "title": "",
   "type": "object",
   "properties": {
@@ -24,12 +24,6 @@
       "type": "string",
       "description": "Add tags to the project (used for linting)",
       "alias": "t"
-    },
-    "skipFormat": {
-      "description": "Skip formatting files.",
-      "type": "boolean",
-      "default": false,
-      "x-priority": "internal"
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/utils/version-utils.ts
+++ b/packages/nx-plugin/src/utils/version-utils.ts
@@ -1,22 +1,28 @@
 import { readJson, Tree } from '@nx/devkit';
 import { clean, coerce } from 'semver';
 
-export function getInstalledAngularVersion(
+export function getInstalledPackageVersion(
   tree: Tree,
-  defaultVersion: string
-): string {
+  packageName: string,
+  defaultVersion?: string
+): string | null {
   const pkgJson = readJson(tree, 'package.json');
-  const installedAngularVersion =
-    pkgJson.dependencies && pkgJson.dependencies['@angular/core'];
+  const installedPackageVersion =
+    (pkgJson.dependencies && pkgJson.dependencies[packageName]) ||
+    (pkgJson.devDependencies && pkgJson.devDependencies[packageName]);
+  if (!installedPackageVersion && !defaultVersion) {
+    return null;
+  }
+
   if (
-    !installedAngularVersion ||
-    installedAngularVersion === 'latest' ||
-    installedAngularVersion === 'next'
+    !installedPackageVersion ||
+    installedPackageVersion === 'latest' ||
+    installedPackageVersion === 'next'
   ) {
     return clean(defaultVersion) ?? coerce(defaultVersion).version;
   }
 
   return (
-    clean(installedAngularVersion) ?? coerce(installedAngularVersion).version
+    clean(installedPackageVersion) ?? coerce(installedPackageVersion).version
   );
 }

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -27,7 +27,7 @@
     "nitropack": "^1.0.0",
     "@analogjs/vite-plugin-angular": "^0.2.0-beta.3",
     "@analogjs/vite-plugin-nitro": "^0.2.0-beta.3",
-    "@nx/devkit": "16.0.1"
+    "@nx/devkit": "^16.0.0"
   },
   "generators": "./src/lib/nx-plugin/generators.json",
   "schematics": "./src/lib/nx-plugin/generators.json"

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "nitropack": "^1.0.0",
     "@analogjs/vite-plugin-angular": "^0.2.0-beta.3",
-    "@analogjs/vite-plugin-nitro": "^0.2.0-beta.3"
+    "@analogjs/vite-plugin-nitro": "^0.2.0-beta.3",
+    "@nx/devkit": "16.0.1"
   },
   "generators": "./src/lib/nx-plugin/generators.json",
   "schematics": "./src/lib/nx-plugin/generators.json"


### PR DESCRIPTION
The nx plugin now works without any manual addition of @nx/angular. You can create an empty workspace and simply add the @analogjs/platform dependency. After installing it you can run one command: nx g @analogjs/platform:app. This will automatically install all angular and analog dependencies. This plugin should also work as a preset for npx create-workspace. Since e2e testing for nx plugins is still a bit messy I tested this manually for now. It worked as expected for an empty package based and an empty integrated workspace as well as for an already preconfigured angular workspace.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [x] platform
- [ ] content

## What is the current behavior?

Nx plugin required you to have your workspace already configured with angular.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #320

## What is the new behavior?

This PR makes the analog plugin take care of all the config. It also makes the Nx plugin
compatible with npx create-nx-workspace presets. (need to verify this after publishing to npm)
It also adds support for setting up tailwind

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I wouldn't consider this completing #320 because we still need to update the Docs and integrate a SPARTAN setup.
I'd like to have all this working before writing the docs to make them be in sync from the get go :)
