### PR TITLE
feat: add ng update support

### DIFF
--- a/packages/astro-angular/migrations/migration.json
+++ b/packages/astro-angular/migrations/migration.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {}
+}

--- a/packages/astro-angular/package.json
+++ b/packages/astro-angular/package.json
@@ -43,5 +43,17 @@
     "rxjs": "^7.5.6",
     "zone.js": "^0.13.0",
     "tslib": "^2.4.0"
+  },
+  "ng-update": {
+    "packageGroup": [
+      "@analogjs/astro-angular",
+      "@analogjs/platform",
+      "@analogjs/content",
+      "@analogjs/router",
+      "@analogjs/trpc",
+      "@analogjs/vite-plugin-angular",
+      "@analogjs/vite-plugin-nitro"
+    ],
+    "migrations": "./migrations/migration.json"
   }
 }

--- a/packages/content/migrations/migration.json
+++ b/packages/content/migrations/migration.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {}
+}

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -29,5 +29,17 @@
   },
   "dependencies": {
     "tslib": "^2.3.0"
+  },
+  "ng-update": {
+    "packageGroup": [
+      "@analogjs/astro-angular",
+      "@analogjs/platform",
+      "@analogjs/content",
+      "@analogjs/router",
+      "@analogjs/trpc",
+      "@analogjs/vite-plugin-angular",
+      "@analogjs/vite-plugin-nitro"
+    ],
+    "migrations": "./migrations/migration.json"
   }
 }

--- a/packages/platform/migrations/migration.json
+++ b/packages/platform/migrations/migration.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {}
+}

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -30,5 +30,17 @@
     "@nx/devkit": "^16.0.0"
   },
   "generators": "./src/lib/nx-plugin/generators.json",
-  "schematics": "./src/lib/nx-plugin/generators.json"
+  "schematics": "./src/lib/nx-plugin/generators.json",
+  "ng-update": {
+    "packageGroup": [
+      "@analogjs/astro-angular",
+      "@analogjs/platform",
+      "@analogjs/content",
+      "@analogjs/router",
+      "@analogjs/trpc",
+      "@analogjs/vite-plugin-angular",
+      "@analogjs/vite-plugin-nitro"
+    ],
+    "migrations": "./migrations/migration.json"
+  }
 }

--- a/packages/router/migrations/migration.json
+++ b/packages/router/migrations/migration.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {}
+}

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -27,5 +27,17 @@
   },
   "dependencies": {
     "tslib": "^2.0.0"
+  },
+  "ng-update": {
+    "packageGroup": [
+      "@analogjs/astro-angular",
+      "@analogjs/platform",
+      "@analogjs/content",
+      "@analogjs/router",
+      "@analogjs/trpc",
+      "@analogjs/vite-plugin-angular",
+      "@analogjs/vite-plugin-nitro"
+    ],
+    "migrations": "./migrations/migration.json"
   }
 }

--- a/packages/trpc/migrations/migration.json
+++ b/packages/trpc/migrations/migration.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {}
+}

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -27,5 +27,17 @@
   },
   "dependencies": {
     "tslib": "^2.3.0"
+  },
+  "ng-update": {
+    "packageGroup": [
+      "@analogjs/astro-angular",
+      "@analogjs/platform",
+      "@analogjs/content",
+      "@analogjs/router",
+      "@analogjs/trpc",
+      "@analogjs/vite-plugin-angular",
+      "@analogjs/vite-plugin-nitro"
+    ],
+    "migrations": "./migrations/migration.json"
   }
 }

--- a/packages/vite-plugin-angular/migrations/migration.json
+++ b/packages/vite-plugin-angular/migrations/migration.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {}
+}

--- a/packages/vite-plugin-angular/package.json
+++ b/packages/vite-plugin-angular/package.json
@@ -20,5 +20,17 @@
   },
   "peerDependencies": {
     "@angular-devkit/build-angular": "^15.0.0 || ^16.0.0"
+  },
+  "ng-update": {
+    "packageGroup": [
+      "@analogjs/astro-angular",
+      "@analogjs/platform",
+      "@analogjs/content",
+      "@analogjs/router",
+      "@analogjs/trpc",
+      "@analogjs/vite-plugin-angular",
+      "@analogjs/vite-plugin-nitro"
+    ],
+    "migrations": "./migrations/migration.json"
   }
 }

--- a/packages/vite-plugin-nitro/migrations/migration.json
+++ b/packages/vite-plugin-nitro/migrations/migration.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {}
+}

--- a/packages/vite-plugin-nitro/package.json
+++ b/packages/vite-plugin-nitro/package.json
@@ -25,5 +25,17 @@
   },
   "dependencies": {
     "nitropack": "^1.0.0"
+  },
+  "ng-update": {
+    "packageGroup": [
+      "@analogjs/astro-angular",
+      "@analogjs/platform",
+      "@analogjs/content",
+      "@analogjs/router",
+      "@analogjs/trpc",
+      "@analogjs/vite-plugin-angular",
+      "@analogjs/vite-plugin-nitro"
+    ],
+    "migrations": "./migrations/migration.json"
   }
 }


### PR DESCRIPTION
New ng-update object was added to the package.json files for the @analogjs packages

Closes analogjs#360

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Add `ng-update` property to the `package.json` in the platform page that contains the `packageGroup` with the packages that should be updated.

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [x] vite-plugin-nitro
- [x] astro-angular
- [ ] create-analog
- [x] router
- [x] platform
- [x] content
- [ ] nx-plugin
- [x] trpc

## What is the current behavior?

Currently there is no support for this feature.

Issue Number: 360

## What is the new behavior?

Now it will support the command, but currently there will be no rule to do any migration.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
