### PR TITLE
fix: allow dynamic routes in the root route array

### DIFF
--- a/packages/router/src/lib/routes.spec.ts
+++ b/packages/router/src/lib/routes.spec.ts
@@ -161,6 +161,49 @@ describe('routes', () => {
     });
   });
 
+  describe('a root dynamic route', () => {
+    const files: Files = {
+      '/app/pages/[productId].[partId].page.ts': () =>
+        Promise.resolve({ default: RouteComponent }),
+    };
+
+    const routes = getRoutes(files);
+    const route: ModuleRoute = routes[0];
+
+    it('should have a path', () => {
+      expect(route.path).toBe(':productId/:partId');
+    });
+
+    it('should have a pathMatch set to prefix', () => {
+      expect(route.pathMatch).toBe('prefix');
+    });
+
+    it('should have a _module property', () => {
+      expect(route._module).toBeDefined();
+
+      expect(typeof route._module).toBe('function');
+    });
+
+    it('should have a loadChildren property', () => {
+      expect(route.loadChildren).toBeDefined();
+
+      expect(typeof route.loadChildren).toBe('function');
+    });
+
+    it('should return an array of one route config from the loadChildren property', async () => {
+      expect(route.loadChildren).toBeDefined();
+
+      const routes = (await route.loadChildren()) as Route[];
+
+      expect(routes.length).toBe(1);
+
+      const innerRoute = routes.shift();
+
+      expect(innerRoute.path).toBe('');
+      expect(innerRoute.component).toBe(RouteComponent);
+    });
+  });
+
   describe('an index route', () => {
     const files: Files = {
       '/app/routes/index.ts': () =>

--- a/packages/router/src/lib/routes.ts
+++ b/packages/router/src/lib/routes.ts
@@ -60,9 +60,6 @@ export function getRoutes(
         const insert = /^\w|\//.test(path) && !isCatchall ? 'unshift' : 'push';
 
         if (root) {
-          const dynamic = path.startsWith(':');
-          if (dynamic) return parent;
-
           const last = segments.length === 1;
           if (last) {
             const newRoute = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [x] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Routes with dynamic params defined at the root of the `pages` directory aren't recognized

Closes https://github.com/analogjs/analog/issues/367

## What is the new behavior?

Routes with dynamic params defined at the root of the `pages` directory are recognized.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
