### PR TITLE
docs(nx-plugin): add Nx plugin documentation to getting-started.md

### DIFF
--- a/apps/docs-app/docs/getting-started.md
+++ b/apps/docs-app/docs/getting-started.md
@@ -16,6 +16,14 @@ Analog requires the following Node and Angular versions:
 
 ## Creating a New Application
 
+There are two methods for creating an Analog application. You have the option to utilize the `create-analog` command
+to scaffold a standalone project, or you can make use of the Nx plugin, which is included in the `@analogjs/platform` package.
+
+<Tabs groupId="app-creator">
+  <TabItem label="create-analog" value="create-analog">
+
+## create-analog
+
 Scaffold an Analog project with the following `create-analog` command:
 
 <Tabs groupId="package-manager">
@@ -44,7 +52,7 @@ pnpm create analog
   </TabItem>
 </Tabs>
 
-## Serving the application
+### Serving the application
 
 To start the development server for the application, run the `start` command.
 
@@ -78,7 +86,7 @@ Visit [http://localhost:5173](http://localhost:5173) in your browser to view the
 
 Next, you can [define additional routes using components](/docs/features/routing/overview) for navigation.
 
-## Building the Application
+### Building the Application
 
 To build the application for deployment
 
@@ -105,11 +113,57 @@ yarn build
 pnpm run build
 ```
 
+### Build Artifacts
+
+By default, Analog comes with [Server-Side Rendering](/docs/features/server/server-side-rendering) enabled.
+Client artifacts are located in the `dist/analog/public` directory.
+The server for the API/SSR build artifacts is located in the `dist/analog/server` directory.
+
+
   </TabItem>
 </Tabs>
 
-## Build Artifacts
+  </TabItem>
 
-The client build artifacts are located in the `dist/client` directory. The server for the API routes is located in the `dist/server` directory.
+  <TabItem label="Nx" value="nx">
 
-If you have [server side rendering](/docs/features/server/server-side-rendering) enabled, the client build artifacts are located in the `dist/analog/public` directory. The server for the API/SSR build artifacts is located in the `dist/analog/server` directory.
+## Nx
+
+Create a new Nx workspace with a preconfigured Analog application:
+
+```shell
+npx create-nx-workspace --preset=@analogjs/platform
+```
+
+The Analog preset prompts you to provide the name of your application. In this example, we simply use `analog-app`.
+Additionally, asks whether you would like to include [TailwindCSS](https://tailwindcss.com) and [tRPC](https://trpc.io) in your new project.
+If you choose to include either of them, all the required dependencies are installed automatically,
+and any necessary configurations is added.
+
+### Serving the application
+
+To start the development server for your application, run the `nx serve` command.
+
+```shell
+nx serve analog-app
+```
+
+### Building the Application
+
+To build the application for deployment run:
+
+```shell
+nx build analog-app
+```
+
+### Build Artifacts
+
+The client build artifacts are located in the dist folder of your Nx workspace.
+
+By default, Analog comes with [Server-Side Rendering](/docs/features/server/server-side-rendering) enabled.
+In the common apps/libs workspace layout, the `analog-app`'s client artifacts are located in the `dist/apps/analog-app/analog/public` directory.
+The server for the API/SSR build artifacts is located in the `dist/apps/analog-app/analog/server` directory.
+
+
+</TabItem>
+</Tabs>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [x] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #320

## What is the new behavior?

This adds documentation for the Nx plugin to the getting started page.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Should I create a separate page for the plugin when not used as a preset?