### PR TITLE
docs: remove the version requirement from Edgio CLI

### DIFF
--- a/apps/docs-app/docs/features/deployment/providers.md
+++ b/apps/docs-app/docs/features/deployment/providers.md
@@ -31,7 +31,7 @@ npm i -g @edgio/cli
 2. In your project's directory, initialize Edgio:
 
 ```bash
-edgio init --connector=@edgio/analogjs --edgioVersion=6.1.4
+edgio init --connector=@edgio/analogjs
 ```
 
 3. Deploy To Edgio


### PR DESCRIPTION
We've had a release today: https://www.npmjs.com/package/@edgio/analogjs that now supports Analog with the latest Edgio v7 as well