### PR TITLE
feat(vite-plugin-nitro): add BUILD_PRESET as a server preset alias

### DIFF
--- a/apps/docs-app/docs/features/deployment/overview.md
+++ b/apps/docs-app/docs/features/deployment/overview.md
@@ -27,10 +27,10 @@ Analog can generate different output formats suitable for different [hosting pro
 
 Using environment variable is recommended for deployments depending on CI/CD.
 
-**Example:** Using `NITRO_PRESET`
+**Example:** Using `BUILD_PRESET`
 
 ```bash
-NITRO_PRESET=node-server
+BUILD_PRESET=node-server
 ```
 
 **Example:** Using `vite.config.ts`

--- a/apps/docs-app/docs/features/deployment/providers.md
+++ b/apps/docs-app/docs/features/deployment/providers.md
@@ -14,7 +14,7 @@ Analog supports deploying on [Render](https://render.com/) with minimal configur
 
 4. Update the start command to `node dist/analog/server/index.mjs`
 
-5. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render-com`.
+5. Click 'Advanced' and add an environment variable with `BUILD_PRESET` set to `render-com`.
 
 6. Click 'Create Web Service'.
 
@@ -112,7 +112,7 @@ You can find more details in the [Firebase documentation](https://firebase.googl
 You can preview a local version of your site to test things out without deploying.
 
 ```bash
-NITRO_PRESET=firebase npm run build
+BUILD_PRESET=firebase npm run build
 firebase emulators:start
 ```
 
@@ -121,6 +121,6 @@ firebase emulators:start
 To deploy to Firebase Hosting, run the `firebase deploy` command.
 
 ```bash
-NITRO_PRESET=firebase npm run build
+BUILD_PRESET=firebase npm run build
 firebase deploy
 ```

--- a/packages/vite-plugin-nitro/src/lib/build-server.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-server.ts
@@ -11,6 +11,7 @@ export async function buildServer(
 
   const nitro = await createNitro({
     dev: false,
+    preset: process.env['BUILD_PRESET'],
     ...nitroConfig,
   });
   await prepare(nitro);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Adds the `BUILD_PRESET` environment variable as alternative to `NITRO_PRESET` for defining a server preset to use for Nitro.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
