### PR TITLE
docs: add .page suffix on nested routes exemple

### DIFF
--- a/apps/docs-app/docs/features/routing/overview.md
+++ b/apps/docs-app/docs/features/routing/overview.md
@@ -100,9 +100,9 @@ src/
 └── app/
     └── pages/
         │   └── products/
-        │      ├──[productId].ts
-        │      └──(products-list).ts
-        └── products.ts
+        │      ├──[productId].page.ts
+        │      └──(products-list).page.ts
+        └── products.page.ts
 ```
 
 This defines two routes with a shared layout:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

The current documentation example is missing the correct page suffix 

Issue Number: N/A

## What is the new behavior?

Add the page suffix to better comprehension 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
