### PR TITLE
refactor: remove Angular libs from forced optimization

### DIFF
--- a/apps/analog-app/index.html
+++ b/apps/analog-app/index.html
@@ -5,13 +5,12 @@
     <title>AnalogApp</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/x-icon" href="/src/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link
-    href="https://fonts.googleapis.com/icon?family=Material+Icons"
-    rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
     />
-    <link href="/src/styles.css" 
-    rel="stylesheet" />
+    <link href="/src/styles.css" rel="stylesheet" />
   </head>
   <body>
     <analogjs-root></analogjs-root>

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -110,17 +110,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
         return {
           optimizeDeps: {
-            include: [
-              '@angular/animations',
-              '@angular/common',
-              '@angular/common/http',
-              '@angular/core',
-              '@angular/platform-browser',
-              '@angular/platform-browser/animations',
-              '@angular/platform-browser-dynamic',
-              'rxjs/operators',
-              'rxjs',
-            ],
+            include: ['rxjs/operators', 'rxjs'],
             exclude: ['@angular/platform-server'],
             esbuildOptions: {
               plugins: [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Startup time is decreased by not forcing optimization of Angular packages

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
