### PR TITLE
fix(content): add markdown route component for content routes

### DIFF
--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -3,6 +3,7 @@ export { injectContentFiles } from './lib/inject-content-files';
 export { ContentFile } from './lib/content-file';
 export { ContentRenderer } from './lib/content-renderer';
 export { default as MarkdownComponent } from './lib/markdown.component';
+export { default as MarkdownRouteComponent } from './lib/markdown-route.component';
 export { MarkdownContentRendererService } from './lib/markdown-content-renderer.service';
 export {
   provideContent,

--- a/packages/content/src/lib/markdown-route.component.ts
+++ b/packages/content/src/lib/markdown-route.component.ts
@@ -1,0 +1,38 @@
+import { AsyncPipe } from '@angular/common';
+import {
+  AfterViewChecked,
+  Component,
+  inject,
+  Input,
+  ViewEncapsulation,
+} from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+
+import { ContentRenderer } from './content-renderer';
+import { AnchorNavigationDirective } from './anchor-navigation.directive';
+
+@Component({
+  selector: 'analog-markdown-route',
+  standalone: true,
+  imports: [AsyncPipe],
+  hostDirectives: [AnchorNavigationDirective],
+  preserveWhitespaces: true,
+  encapsulation: ViewEncapsulation.None,
+  template: `<div [innerHTML]="content" [class]="classes"></div>`,
+})
+export default class AnalogMarkdownRouteComponent implements AfterViewChecked {
+  private sanitizer = inject(DomSanitizer);
+  private route = inject(ActivatedRoute);
+  contentRenderer = inject(ContentRenderer);
+
+  protected content: SafeHtml = this.sanitizer.bypassSecurityTrustHtml(
+    this.route.snapshot.data['renderedAnalogContent']
+  );
+
+  @Input() classes = 'analog-markdown-route';
+
+  ngAfterViewChecked() {
+    this.contentRenderer.enhance();
+  }
+}

--- a/packages/router/src/lib/markdown-helpers.ts
+++ b/packages/router/src/lib/markdown-helpers.ts
@@ -1,3 +1,4 @@
+import { inject } from '@angular/core';
 import { RouteExport } from './models';
 
 export function toMarkdownModule(
@@ -5,13 +6,26 @@ export function toMarkdownModule(
 ): () => Promise<RouteExport> {
   return () =>
     Promise.all([import('@analogjs/content'), markdownFileFactory()]).then(
-      ([{ parseRawContentFile, MarkdownComponent }, markdownFile]) => {
+      ([
+        { parseRawContentFile, MarkdownRouteComponent, ContentRenderer },
+        markdownFile,
+      ]) => {
         const { content, attributes } = parseRawContentFile(markdownFile);
         const { title, meta } = attributes;
 
         return {
-          default: MarkdownComponent,
-          routeMeta: { data: { _analogContent: content }, title, meta },
+          default: MarkdownRouteComponent,
+          routeMeta: {
+            data: { _analogContent: content },
+            title,
+            meta,
+            resolve: {
+              renderedAnalogContent: async () => {
+                const contentRenderer = inject(ContentRenderer);
+                return contentRenderer.render(content);
+              },
+            },
+          },
         };
       }
     );


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [x] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #397 

## What is the new behavior?

Markdown files used as routes are statically prerendered

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
