### PR TITLE
fix(nx-plugin): add h3 dependency for APIs

### DIFF
--- a/packages/nx-plugin/src/generators/app/lib/add-analog-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-analog-dependencies.ts
@@ -48,6 +48,7 @@ export async function addAnalogDependencies(
       majorAngularVersion === 15 ? V15_FRONT_MATTER : V16_FRONT_MATTER,
     marked: majorAngularVersion === 15 ? V15_MARKED : V16_MARKED,
     prismjs: majorAngularVersion === 15 ? V15_PRISMJS : V16_PRISMJS,
+    h3: 'latest',
   };
 
   const nxViteDependency =


### PR DESCRIPTION
This is not added when generating an analog js application

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [x] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

When generating an NX application, install the h3 npm dependency, which is used by the API section.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
