### PR TITLE
fix(trpc): allow to pass custom headers to trpc client

### DIFF
--- a/apps/trpc-app-e2e-playwright/tests/app.spec.ts
+++ b/apps/trpc-app-e2e-playwright/tests/app.spec.ts
@@ -43,14 +43,25 @@ describe('tRPC Demo App', () => {
     ).toContain(/Analog + tRPC/i);
   });
 
-  test<TRPCTestContext>(`If user enters the first note the note should be stored
-    successfully and listed in the notes array`, async (ctx) => {
+  test<TRPCTestContext>(`
+  If user enters the first note the note should be storedsuccessfully and listed in the notes array.
+  Still unauthorized the user should not be able to delete the note and the error should be displayed.
+  After the users clicks the Login button and gets authorized, deleting the note again should work successfully,
+  and the error should disappear.
+     `, async (ctx) => {
     await ctx.notesPage.typeNote(notes.first.note);
 
     await ctx.notesPage.addNote();
     expect(await ctx.notesPage.notes().elementHandles()).toHaveLength(1);
 
     await ctx.notesPage.removeNote(0);
+    expect(await ctx.notesPage.notes().elementHandles()).toHaveLength(1);
+    expect(await ctx.notesPage.getDeleteErrorCount()).toBe(1);
+
+    await ctx.notesPage.toggleLogin();
+    await ctx.notesPage.removeNote(0);
+    await page.waitForSelector('.no-notes');
     expect(await ctx.notesPage.notes().elementHandles()).toHaveLength(0);
+    expect(await ctx.notesPage.getDeleteErrorCount()).toBe(0);
   });
 });

--- a/apps/trpc-app-e2e-playwright/tests/fixtures/notes.po.ts
+++ b/apps/trpc-app-e2e-playwright/tests/fixtures/notes.po.ts
@@ -3,6 +3,10 @@ import { Page } from 'playwright';
 export class NotesPage {
   constructor(readonly page: Page) {}
 
+  async toggleLogin() {
+    await this.page.getByTestId('loginBtn').click();
+  }
+
   async typeNote(note: string) {
     await this.page.getByTestId('newNoteInput').fill(note);
   }
@@ -16,7 +20,10 @@ export class NotesPage {
     await this.waitForTrpcResponse(
       this.page.getByTestId('removeNoteAtIndexBtn' + index).click()
     );
-    await this.page.waitForSelector('.no-notes');
+  }
+
+  async getDeleteErrorCount() {
+    return this.page.locator('[data-testid="deleteError"]').count();
   }
 
   notes() {

--- a/apps/trpc-app/src/server/trpc/context.ts
+++ b/apps/trpc-app/src/server/trpc/context.ts
@@ -1,8 +1,16 @@
 import { inferAsyncReturnType } from '@trpc/server';
+import { getRequestHeader, H3Event } from 'h3';
 
 /**
  * Creates context for an incoming request
  * @link https://trpc.io/docs/context
  */
-export const createContext = () => ({});
+export const createContext = async (event: H3Event) => {
+  // Create your context based on the request object
+  // Will be available as `ctx` in all your resolvers
+  const authorization = getRequestHeader(event, 'authorization');
+  return {
+    hasAuth: authorization && authorization.split(' ')[1]?.length > 0,
+  };
+};
 export type Context = inferAsyncReturnType<typeof createContext>;

--- a/apps/trpc-app/src/server/trpc/routers/notes.ts
+++ b/apps/trpc-app/src/server/trpc/routers/notes.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { publicProcedure, router } from '../trpc';
+import { protectedProcedure, publicProcedure, router } from '../trpc';
 import { Note } from '../../../note';
 
 let noteId = 0;
@@ -19,7 +19,7 @@ export const noteRouter = router({
       })
     ),
   list: publicProcedure.query(() => notes),
-  remove: publicProcedure
+  remove: protectedProcedure
     .input(
       z.object({
         id: z.number(),

--- a/apps/trpc-app/src/server/trpc/trpc.ts
+++ b/apps/trpc-app/src/server/trpc/trpc.ts
@@ -1,4 +1,4 @@
-import { initTRPC } from '@trpc/server';
+import { initTRPC, TRPCError } from '@trpc/server';
 import { Context } from './context';
 import superjson from 'superjson';
 
@@ -9,5 +9,16 @@ const t = initTRPC.context<Context>().create({
  * Unprotected procedure
  **/
 export const publicProcedure = t.procedure;
+
+const isAuthed = t.middleware(({ next, ctx }) => {
+  if (!ctx.hasAuth) {
+    throw new TRPCError({ code: 'UNAUTHORIZED' });
+  }
+  return next({
+    ctx,
+  });
+});
+
+export const protectedProcedure = t.procedure.use(isAuthed);
 export const router = t.router;
 export const middleware = t.middleware;

--- a/apps/trpc-app/src/trpc-client.ts
+++ b/apps/trpc-app/src/trpc-client.ts
@@ -3,12 +3,13 @@ import { createTrpcClient } from '@analogjs/trpc';
 import { inject } from '@angular/core';
 import superjson from 'superjson';
 
-export const { provideTRPCClient, tRPCClient } = createTrpcClient<AppRouter>({
-  url: 'http://localhost:4205/api/trpc',
-  options: {
-    transformer: superjson,
-  },
-});
+export const { provideTRPCClient, tRPCClient, tRPCHeaders } =
+  createTrpcClient<AppRouter>({
+    url: 'http://localhost:4205/api/trpc',
+    options: {
+      transformer: superjson,
+    },
+  });
 
 export function injectTRPCClient() {
   return inject(tRPCClient);


### PR DESCRIPTION
A tRPCHeaders signal is exposed to set/get the headers added to each tRPC call. This allows us to, e.g. add an authorization header that we can then use to create protected procedures that can only be executed when the user is authorized.

closes #394

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [x] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #394 

## What is the new behavior?

You can provide custom headers to the trpc client by setting the tRPCHeaders signal

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

It works but I feel like the way we configure the tRPC client could be much better.
I think we should aim for a way to configure the tRPC client like @markostanimirovic allows the ngrx signal store to be configured. I want to get this merged because it is essential for anyone who wants to use the client for anything that is 
not public and the DX is alright but we should definitely rethink the way we allow people to configure the tRPC client.

```ts
const { tRPCClient, provideTRPCClient, tRPCHeaders } = createTrpcClient(
  withTransformer(superjson),
  withLinks([yourCustomLink()]),
  withHttpBatchLink(
      withURL(''),
      withHeaders()
  )
);
```

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/JumHZQU0IABMI/giphy-downsized-medium.gif"/>
