### PR TITLE
chore(docs): fix StackBlitz link color on Safari

### DIFF
--- a/apps/docs-app/src/components/StackblitzButton/styles.module.css
+++ b/apps/docs-app/src/components/StackblitzButton/styles.module.css
@@ -6,6 +6,7 @@
 .stackblitzLink {
   display: flex;
   border: var(--ifm-global-border-width) solid var(--ifm-color-secondary);
+  color: var(--ifm-color-secondary);
 }
 
 .stackblitzLink:hover {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Stackblitz link color on Safari is black in dark mode:

<img alt="analog on safari" src="https://github.com/analogjs/analog/assets/17877290/aa27266d-9ff2-4e4b-9b9c-1f9b6eb51696" height="500" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

![giphy](https://github.com/analogjs/analog/assets/17877290/1684ee38-bd7d-4ca8-beb2-80a8743c9241)
