### PR TITLE
fix(router): remove assertInInjectionContext check for v15 compatibility

### DIFF
--- a/packages/router/src/lib/inject-load.ts
+++ b/packages/router/src/lib/inject-load.ts
@@ -1,4 +1,4 @@
-import { Injector, assertInInjectionContext, inject } from '@angular/core';
+import { Injector, inject } from '@angular/core';
 import { ActivatedRoute, Data } from '@angular/router';
 import { Observable, map } from 'rxjs';
 
@@ -7,8 +7,6 @@ import { PageServerLoad } from './route-types';
 export function injectLoad<
   T extends (pageServerLoad: PageServerLoad) => Promise<any>
 >(options?: { injector?: Injector }): Observable<Awaited<ReturnType<T>>> {
-  !options?.injector && assertInInjectionContext(injectLoad);
-
   const injector = options?.injector ?? inject(Injector);
   const route = injector.get(ActivatedRoute);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [x] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

When `injectLoad` is used within an Analog app with Angular v15, an error is throw because `assertInInjectionContext` is not available.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

No error is thrown for v15 projects.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/xUNd9FS6vqnzQIf9Ze/giphy.gif"/>
