### PR TITLE
fix(nx-plugin): make nx plugin use 16.1

### DIFF
--- a/apps/nx-plugin-e2e/tests/nx-plugin.spec.ts
+++ b/apps/nx-plugin-e2e/tests/nx-plugin.spec.ts
@@ -25,7 +25,7 @@ describe('nx-plugin e2e', () => {
 
   it('should create hello-world', async () => {
     const project = uniq('app');
-    const res = await runNxCommandAsync(
+    await runNxCommandAsync(
       `generate @analogjs/platform:app ${project} --addTailwind=true --addTRPC=true`
     );
     copyNodeModules(['@analogjs']);

--- a/packages/nx-plugin/src/generators/app/generator.ts
+++ b/packages/nx-plugin/src/generators/app/generator.ts
@@ -8,14 +8,14 @@ import {
   Tree,
 } from '@nx/devkit';
 import { AnalogNxApplicationGeneratorOptions } from './schema';
-import { major } from 'semver';
+import { major, coerce } from 'semver';
 import { getInstalledPackageVersion } from '../../utils/version-utils';
 import { addAnalogProjectConfig } from './lib/add-analog-project-config';
 import { addAnalogDependencies } from './lib/add-analog-dependencies';
 import { initializeAngularWorkspace } from './lib/initialize-analog-workspace';
 import { addFiles } from './lib/add-files';
 import { addTailwindConfig } from './lib/add-tailwind-config';
-import { addTRPC } from './lib/add-trpc';
+import { addTrpc } from './lib/add-trpc';
 import { addHomePage } from './lib/add-home-page';
 
 export interface NormalizedOptions
@@ -80,9 +80,9 @@ export async function appGenerator(
     normalizedOptions
   );
   const majorNxVersion = major(nxVersion);
-  const majorAngularVersion = major(angularVersion);
+  const majorAngularVersion = major(coerce(angularVersion));
 
-  await addAnalogDependencies(tree, majorAngularVersion, majorNxVersion);
+  await addAnalogDependencies(tree, nxVersion, angularVersion);
 
   const {
     projectRoot,
@@ -114,10 +114,10 @@ export async function appGenerator(
   }
 
   if (normalizedOptions.addTRPC) {
-    await addTRPC(
+    await addTrpc(
       tree,
       normalizedOptions.projectRoot,
-      majorAngularVersion,
+      nxVersion,
       normalizedOptions
     );
   }

--- a/packages/nx-plugin/src/generators/app/lib/add-analog-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-analog-dependencies.ts
@@ -1,79 +1,13 @@
 import { addDependenciesToPackageJson, Tree } from '@nx/devkit';
-import {
-  V15_ANALOG_JS_CONTENT,
-  V15_ANALOG_JS_PLATFORM,
-  V15_ANALOG_JS_ROUTER,
-  V15_ANGULAR_PLATFORM_SERVER,
-  V15_FRONT_MATTER,
-  V15_JSDOM,
-  V15_MARKED,
-  V15_NRWL_VITE,
-  V15_PRISMJS,
-  V15_TYPESCRIPT,
-  V15_VITE,
-  V15_VITE_TSCONFIG_PATHS,
-  V15_VITEST,
-  V16_ANALOG_JS_CONTENT,
-  V16_ANALOG_JS_PLATFORM,
-  V16_ANALOG_JS_ROUTER,
-  V16_ANGULAR_PLATFORM_SERVER,
-  V16_FRONT_MATTER,
-  V16_JSDOM,
-  V16_MARKED,
-  V16_NX_VITE,
-  V16_PRISMJS,
-  V16_TYPESCRIPT,
-  V16_VITE,
-  V16_VITE_TSCONFIG_PATHS,
-  V16_VITEST,
-} from '../versions';
+import { getAnalogDependencies } from '../versions/dependencies';
+import { getAnalogDevDependencies } from '../versions/dev-dependencies';
 
 export async function addAnalogDependencies(
   tree: Tree,
-  majorAngularVersion: number,
-  majorNxVersion: number
+  nxVersion: string,
+  angularVersion: string
 ) {
-  const dependencies = {
-    '@analogjs/content':
-      majorAngularVersion === 15
-        ? V15_ANALOG_JS_CONTENT
-        : V16_ANALOG_JS_CONTENT,
-    '@analogjs/router':
-      majorAngularVersion === 15 ? V15_ANALOG_JS_ROUTER : V16_ANALOG_JS_ROUTER,
-    '@angular/platform-server':
-      majorAngularVersion === 15
-        ? V15_ANGULAR_PLATFORM_SERVER
-        : V16_ANGULAR_PLATFORM_SERVER,
-    'front-matter':
-      majorAngularVersion === 15 ? V15_FRONT_MATTER : V16_FRONT_MATTER,
-    marked: majorAngularVersion === 15 ? V15_MARKED : V16_MARKED,
-    prismjs: majorAngularVersion === 15 ? V15_PRISMJS : V16_PRISMJS,
-  };
-
-  const nxViteDependency =
-    majorNxVersion === 15
-      ? {
-          '@nrwl/vite':
-            majorAngularVersion === 15 ? V15_NRWL_VITE : V16_NX_VITE,
-        }
-      : {
-          '@nx/vite': majorAngularVersion === 15 ? V15_NRWL_VITE : V16_NX_VITE,
-        };
-  const devDependencies = {
-    '@analogjs/platform':
-      majorAngularVersion === 15
-        ? V15_ANALOG_JS_PLATFORM
-        : V16_ANALOG_JS_PLATFORM,
-    ...nxViteDependency,
-    jsdom: majorAngularVersion === 15 ? V15_JSDOM : V16_JSDOM,
-    typescript: majorAngularVersion === 15 ? V15_TYPESCRIPT : V16_TYPESCRIPT,
-    vite: majorAngularVersion === 15 ? V15_VITE : V16_VITE,
-    'vite-tsconfig-paths':
-      majorAngularVersion === 15
-        ? V15_VITE_TSCONFIG_PATHS
-        : V16_VITE_TSCONFIG_PATHS,
-    vitest: majorAngularVersion === 15 ? V15_VITEST : V16_VITEST,
-  };
-
+  const dependencies = getAnalogDependencies(nxVersion, angularVersion);
+  const devDependencies = getAnalogDevDependencies(nxVersion);
   addDependenciesToPackageJson(tree, dependencies, devDependencies);
 }

--- a/packages/nx-plugin/src/generators/app/lib/add-trpc.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-trpc.ts
@@ -1,44 +1,16 @@
 import { addDependenciesToPackageJson, generateFiles, Tree } from '@nx/devkit';
 import * as path from 'path';
-import {
-  V15_ANALOG_JS_TRPC,
-  V15_ISOMORPHIC_FETCH,
-  V15_SUPERJSON,
-  V15_TRPC_CLIENT,
-  V15_TRPC_SERVER,
-  V15_ZOD,
-  V16_ANALOG_JS_TRPC,
-  V16_SUPERJSON,
-  V16_TRPC_CLIENT,
-  V16_TRPC_SERVER,
-  V16_ZOD,
-} from '../versions';
 import { NormalizedOptions } from '../generator';
+import { getTrpcDependencies } from '../versions/trpc-dependencies';
 
-export async function addTRPC(
+export async function addTrpc(
   tree: Tree,
   projectRoot: string,
-  majorAngularVersion: number,
+  nxVersion: string,
   options: NormalizedOptions
 ) {
-  addDependenciesToPackageJson(
-    tree,
-    {
-      '@analogjs/trpc':
-        majorAngularVersion === 15 ? V15_ANALOG_JS_TRPC : V16_ANALOG_JS_TRPC,
-      '@trpc/client':
-        majorAngularVersion === 15 ? V15_TRPC_CLIENT : V16_TRPC_CLIENT,
-      '@trpc/server':
-        majorAngularVersion === 15 ? V15_TRPC_SERVER : V16_TRPC_SERVER,
-      superjson: majorAngularVersion === 15 ? V15_SUPERJSON : V16_SUPERJSON,
-      'isomorphic-fetch':
-        majorAngularVersion === 15
-          ? V15_ISOMORPHIC_FETCH
-          : V15_ISOMORPHIC_FETCH,
-      zod: majorAngularVersion === 15 ? V15_ZOD : V16_ZOD,
-    },
-    {}
-  );
+  const dependencies = getTrpcDependencies(nxVersion);
+  addDependenciesToPackageJson(tree, dependencies, {});
 
   const templateOptions = {
     ...options,

--- a/packages/nx-plugin/src/generators/app/lib/initialize-analog-workspace.ts
+++ b/packages/nx-plugin/src/generators/app/lib/initialize-analog-workspace.ts
@@ -1,21 +1,18 @@
-import { lt, major } from 'semver';
+import { major } from 'semver';
 import {
   addDependenciesToPackageJson,
   ensurePackage,
   stripIndents,
   Tree,
 } from '@nx/devkit';
-import {
-  MINIMUM_SUPPORTED_ANGULAR_VERSION,
-  V15_ANGULAR,
-  V15_NRWL_ANGULAR,
-  V15_NRWL_DEVKIT,
-  V16_ANGULAR,
-  V16_NX_ANGULAR,
-  V16_NX_DEVKIT,
-} from '../versions';
 import { getInstalledPackageVersion } from '../../../utils/version-utils';
 import { NormalizedOptions } from '../generator';
+import { hasMinimumSupportedAngularVersion } from '../versions/minimum-supported-angular-version';
+import {
+  getNrwlDependencies,
+  getNxDependencies,
+} from '../versions/nx-dependencies';
+import { readPackageJson } from 'nx/src/project-graph/file-utils';
 
 export async function initializeAngularWorkspace(
   tree: Tree,
@@ -29,64 +26,22 @@ export async function initializeAngularWorkspace(
       'Angular has not been installed yet. Creating an Angular application'
     );
 
-    if (major(installedNxVersion) >= 16) {
-      try {
-        ensurePackage('@nx/devkit', V16_NX_DEVKIT);
-        ensurePackage('@nx/angular', V16_NX_ANGULAR);
-      } catch {
-        // @nx/angular cannot be required so this fails but this will still allow executing the nx angular init later on
-      }
-      addDependenciesToPackageJson(
+    if (major(installedNxVersion) === 16) {
+      angularVersion = await initWithNxNamespace(
         tree,
-        {},
-        {
-          '@nx/devkit': V16_NX_DEVKIT,
-          '@nx/angular': V16_NX_ANGULAR,
-        }
+        installedNxVersion,
+        normalizedOptions.skipFormat
       );
     } else {
-      try {
-        ensurePackage('@nrwl/devkit', V15_NRWL_DEVKIT);
-        ensurePackage('@nrwl/angular', V15_NRWL_ANGULAR);
-      } catch {
-        // @nx/angular cannot be required so this fails but this will still allow executing the nx angular init later on
-      }
-      addDependenciesToPackageJson(
+      angularVersion = await initWithNrwlNamespace(
         tree,
-        {},
-        {
-          '@nrwl/devkit': V15_NRWL_DEVKIT,
-          '@nrwl/angular': V15_NRWL_ANGULAR,
-        }
+        installedNxVersion,
+        normalizedOptions.skipFormat
       );
-    }
-
-    if (major(installedNxVersion) >= 16) {
-      await (
-        await import(
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          '@nx/angular/generators'
-        )
-      ).angularInitGenerator(tree, {
-        unitTestRunner: 'none' as any,
-        skipInstall: true,
-        skipFormat: normalizedOptions.skipFormat,
-      });
-      angularVersion = V16_ANGULAR;
-    } else {
-      await (
-        await import('@nx/angular/generators')
-      ).angularInitGenerator(tree, {
-        unitTestRunner: 'none' as any,
-        skipInstall: true,
-        skipFormat: normalizedOptions.skipFormat,
-      });
-      angularVersion = V15_ANGULAR;
     }
   }
 
-  if (lt(angularVersion, MINIMUM_SUPPORTED_ANGULAR_VERSION)) {
+  if (hasMinimumSupportedAngularVersion(angularVersion)) {
     throw new Error(
       stripIndents`Analog only supports an Angular version of 15 and higher`
     );
@@ -94,3 +49,72 @@ export async function initializeAngularWorkspace(
 
   return angularVersion;
 }
+
+const initWithNxNamespace = async (
+  tree: Tree,
+  installedNxVersion: string,
+  skipFormat = true
+) => {
+  const versions = getNxDependencies(installedNxVersion);
+  try {
+    ensurePackage('@nx/devkit', versions['@nx/devkit']);
+    ensurePackage('@nx/angular', versions['@nx/angular']);
+  } catch {
+    // @nx/angular cannot be required so this fails but this will still allow executing the nx angular init later on
+  }
+  addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      '@nx/devkit': versions['@nx/devkit'],
+      '@nx/angular': versions['@nx/angular'],
+    }
+  );
+
+  await (
+    await import(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      '@nx/angular/generators'
+    )
+  ).angularInitGenerator(tree, {
+    unitTestRunner: 'none' as any,
+    skipInstall: true,
+    skipFormat: skipFormat,
+  });
+  return getInstalledPackageVersion(tree, '@angular/core', null, true);
+};
+
+const initWithNrwlNamespace = async (
+  tree: Tree,
+  installedNxVersion: string,
+  skipFormat = true
+) => {
+  const versions = getNrwlDependencies(installedNxVersion);
+  try {
+    ensurePackage('@nrwl/devkit', versions['@nrwl/devkit']);
+    ensurePackage('@nrwl/angular', versions['@nrwl/angular']);
+  } catch {
+    // @nx/angular cannot be required so this fails but this will still allow executing the nx angular init later on
+  }
+  addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      '@nrwl/devkit': versions['@nrwl/devkit'],
+      '@nrwl/angular': versions['@nrwl/angular'],
+    }
+  );
+  await (
+    await import(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      '@nrwl/angular/generators'
+    )
+  ).angularInitGenerator(tree, {
+    unitTestRunner: 'none' as any,
+    skipInstall: true,
+    skipFormat: skipFormat,
+  });
+  return getInstalledPackageVersion(tree, '@angular/core', null, true);
+};

--- a/packages/nx-plugin/src/generators/app/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions.ts
@@ -1,30 +1,30 @@
 export const MINIMUM_SUPPORTED_ANGULAR_VERSION = '15.0.0';
 // V16
 // dependencies
-export const V16_ANGULAR = '16.1.0';
-export const V16_NX_DEVKIT = '~16.4.0';
-export const V16_NX_ANGULAR = '~16.4.0';
-export const V16_ANALOG_JS_CONTENT = '0.2.0-beta.19';
-export const V16_ANALOG_JS_ROUTER = '0.2.0-beta.19';
-export const V16_ANALOG_JS_TRPC = '0.2.0-beta.19';
+export const V16_ANGULAR = '16.0.0';
+export const V16_NX_DEVKIT = '~16.0.0';
+export const V16_NX_ANGULAR = '~16.0.0';
+export const V16_ANALOG_JS_CONTENT = '0.2.0-beta.15';
+export const V16_ANALOG_JS_ROUTER = '0.2.0-beta.15';
+export const V16_ANALOG_JS_TRPC = '0.2.0-beta.15';
 export const V16_TRPC_CLIENT = '^10.25.0';
 export const V16_TRPC_SERVER = '^10.25.0';
 export const V16_ISOMORPHIC_FETCH = '^3.0.0';
 export const V16_SUPERJSON = '^1.12.3';
 
-export const V16_ANGULAR_PLATFORM_SERVER = '~16.1.0';
+export const V16_ANGULAR_PLATFORM_SERVER = '~16.0.0';
 export const V16_FRONT_MATTER = '^4.0.2';
 export const V16_MARKED = '^5.0.2';
 export const V16_PRISMJS = '^1.29.0';
 
 // devDependencies
-export const V16_ANALOG_JS_PLATFORM = '0.2.0-beta.19';
-export const V16_NX_VITE = '^16.4.0';
-export const V16_JSDOM = '^22.1.0';
+export const V16_ANALOG_JS_PLATFORM = '0.2.0-beta.15';
+export const V16_NX_VITE = '^16.0.0';
+export const V16_JSDOM = '^20.0.0';
 export const V16_TYPESCRIPT = '~5.0.2';
-export const V16_VITE = '^4.3.9';
+export const V16_VITE = '^4.0.3';
 export const V16_VITE_TSCONFIG_PATHS = '^4.0.2';
-export const V16_VITEST = '^0.32.0';
+export const V16_VITEST = '^0.31.0';
 export const V16_ZOD = '^3.21.4';
 
 // V15

--- a/packages/nx-plugin/src/generators/app/versions/README.md
+++ b/packages/nx-plugin/src/generators/app/versions/README.md
@@ -1,0 +1,25 @@
+# Nx, Angular, and Analog Versions
+
+Since we rely on Nx as a way to keep our repository up to date,
+Analog also follows Nx migrations when it comes to staying in sync with the latest Angular version.
+
+This means that as Nx releases support for the next Angular version, Analog will adopt it and release support for it.
+
+## Nx, Angular, and Analog Version Compatibility Matrix
+
+Below is a reference table that matches versions of Nx and Angular with the Analog version that is compatible with it.
+The table shows the version of Nx, the recommended version of Nx to use, and the minimum version of Analog that is needed.
+
+As Analog becomes stable we will provide a recommended version. It will usually be the latest minor version of Analog
+in the range provided because there will have been bug fixes added since the first release in the range.
+
+| Nx Version _(min)_ | Angular Version | Analog Version _(range)_          |
+| ------------------ | --------------- | --------------------------------- |
+| latest             | ~16.1.0         | **0.2.0-beta.16 <= latest**       |
+| 16.1.0             | ~16.0.0         | **0.2.0-beta.1 <= 0.2.0-beta.15** |
+| 15.8.0             | ~15.2.0         | **0.2.0-beta.1 <= 0.2.0-beta.15** |
+| 15.2.0             | ~15.0.0         | **0.0.0 <= 0.1.0-beta.23**        |
+| < 15.2.0           | ~14.0.0         | **not supported**                 |
+
+Additionally, you can check this [guide from Nx](https://nx.dev/packages/angular/documents/angular-nx-version-matrix)
+to learn more about Nx and Angular compatibility.

--- a/packages/nx-plugin/src/generators/app/versions/dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/dependencies.ts
@@ -1,0 +1,87 @@
+import { gt } from 'semver';
+import {
+  V_LATEST_ANALOG_JS_CONTENT,
+  V_LATEST_ANALOG_JS_ROUTER,
+  V_LATEST_FRONT_MATTER,
+  V_LATEST_MARKED,
+  V_LATEST_PRISMJS,
+} from './latest/versions';
+import {
+  V16_1_0_ANALOG_JS_CONTENT,
+  V16_1_0_ANALOG_JS_ROUTER,
+  V16_1_0_FRONT_MATTER,
+  V16_1_0_MARKED,
+  V16_1_0_PRISMJS,
+} from './nx_16_1_0/versions';
+import {
+  V15_8_0_ANALOG_JS_CONTENT,
+  V15_8_0_ANALOG_JS_ROUTER,
+  V15_8_0_FRONT_MATTER,
+  V15_8_0_MARKED,
+  V15_8_0_PRISMJS,
+} from './nx_15_8_0/versions';
+import {
+  V15_2_0_ANALOG_JS_CONTENT,
+  V15_2_0_ANALOG_JS_ROUTER,
+  V15_2_0_FRONT_MATTER,
+  V15_2_0_MARKED,
+  V15_2_0_PRISMJS,
+} from './nx_15_2_0/versions';
+
+const dependencyKeys = [
+  '@analogjs/content',
+  '@analogjs/router',
+  '@angular/platform-server',
+  'front-matter',
+  'marked',
+  'prismjs',
+] as const;
+export type AnalogDependency = (typeof dependencyKeys)[number];
+
+export const getAnalogDependencies = (
+  nxVersion: string,
+  angularVersion: string
+): Record<AnalogDependency, string> => {
+  const escapedNxVersion = nxVersion.replace(/[~^]/, '');
+
+  if (gt(escapedNxVersion, '16.1.0')) {
+    return {
+      '@angular/platform-server': angularVersion,
+      '@analogjs/content': V_LATEST_ANALOG_JS_CONTENT,
+      '@analogjs/router': V_LATEST_ANALOG_JS_ROUTER,
+      'front-matter': V_LATEST_FRONT_MATTER,
+      marked: V_LATEST_MARKED,
+      prismjs: V_LATEST_PRISMJS,
+    };
+  }
+  if (gt(escapedNxVersion, '15.8.0')) {
+    return {
+      '@angular/platform-server': angularVersion,
+      '@analogjs/content': V16_1_0_ANALOG_JS_CONTENT,
+      '@analogjs/router': V16_1_0_ANALOG_JS_ROUTER,
+      'front-matter': V16_1_0_FRONT_MATTER,
+      marked: V16_1_0_MARKED,
+      prismjs: V16_1_0_PRISMJS,
+    };
+  }
+  if (gt(escapedNxVersion, '15.2.0')) {
+    return {
+      '@angular/platform-server': angularVersion,
+      '@analogjs/content': V15_8_0_ANALOG_JS_CONTENT,
+      '@analogjs/router': V15_8_0_ANALOG_JS_ROUTER,
+      'front-matter': V15_8_0_FRONT_MATTER,
+      marked: V15_8_0_MARKED,
+      prismjs: V15_8_0_PRISMJS,
+    };
+  }
+  if (gt(escapedNxVersion, '15.0.0')) {
+    return {
+      '@angular/platform-server': angularVersion,
+      '@analogjs/content': V15_2_0_ANALOG_JS_CONTENT,
+      '@analogjs/router': V15_2_0_ANALOG_JS_ROUTER,
+      'front-matter': V15_2_0_FRONT_MATTER,
+      marked: V15_2_0_MARKED,
+      prismjs: V15_2_0_PRISMJS,
+    };
+  }
+};

--- a/packages/nx-plugin/src/generators/app/versions/dev-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/dev-dependencies.ts
@@ -1,0 +1,127 @@
+import { gt } from 'semver';
+import {
+  V16_1_0_ANALOG_JS_PLATFORM,
+  V16_1_0_JSDOM,
+  V16_1_0_NX_VITE,
+  V16_1_0_TYPESCRIPT,
+  V16_1_0_VITE,
+  V16_1_0_VITE_TSCONFIG_PATHS,
+  V16_1_0_VITEST,
+} from './nx_16_1_0/versions';
+import {
+  V15_8_0_ANALOG_JS_PLATFORM,
+  V15_8_0_JSDOM,
+  V15_8_0_NRWL_VITE,
+  V15_8_0_TYPESCRIPT,
+  V15_8_0_VITE,
+  V15_8_0_VITE_TSCONFIG_PATHS,
+  V15_8_0_VITEST,
+} from './nx_15_8_0/versions';
+import {
+  V_LATEST_ANALOG_JS_PLATFORM,
+  V_LATEST_JSDOM,
+  V_LATEST_NX_VITE,
+  V_LATEST_TYPESCRIPT,
+  V_LATEST_VITE,
+  V_LATEST_VITE_TSCONFIG_PATHS,
+  V_LATEST_VITEST,
+} from './latest/versions';
+import {
+  V15_2_0_ANALOG_JS_PLATFORM,
+  V15_2_0_JSDOM,
+  V15_2_0_NRWL_VITE,
+  V15_2_0_TYPESCRIPT,
+  V15_2_0_VITE,
+  V15_2_0_VITE_TSCONFIG_PATHS,
+  V15_2_0_VITEST,
+} from './nx_15_2_0/versions';
+
+const devDependencyKeys = [
+  '@analogjs/platform',
+  'jsdom',
+  'typescript',
+  'vite',
+  'vite-tsconfig-paths',
+  'vitest',
+] as const;
+export type AnalogDevDependency = (typeof devDependencyKeys)[number];
+
+export const getAnalogDevDependencies = (
+  nxVersion: string
+): Record<AnalogDevDependency, string> => {
+  const escapedNxVersion = nxVersion.replace(/[~^]/, '');
+
+  const nxViteDependency = getViteDependency(escapedNxVersion);
+  const devDependencies = getDevDependencies(escapedNxVersion);
+
+  return { ...nxViteDependency, ...devDependencies };
+};
+
+const getViteDependency = (escapedNxVersion: string) => {
+  if (gt(escapedNxVersion, '16.1.0')) {
+    return {
+      '@nx/vite': V_LATEST_NX_VITE,
+    };
+  }
+  if (gt(escapedNxVersion, '15.8.0')) {
+    return {
+      '@nx/vite': V16_1_0_NX_VITE,
+    };
+  }
+  if (gt(escapedNxVersion, '15.2.0')) {
+    return {
+      '@nrwl/vite': V15_8_0_NRWL_VITE,
+    };
+  }
+  if (gt(escapedNxVersion, '15.0.0')) {
+    return {
+      '@nrwl/vite': V15_2_0_NRWL_VITE,
+    };
+  }
+  throw Error(
+    `Unsupported Nx version detected: ${escapedNxVersion}. Make sure to at least have V_LATEST.2.0 installed.`
+  );
+};
+
+const getDevDependencies = (escapedNxVersion: string) => {
+  if (gt(escapedNxVersion, '16.1.0')) {
+    return {
+      '@analogjs/platform': V_LATEST_ANALOG_JS_PLATFORM,
+      jsdom: V_LATEST_JSDOM,
+      typescript: V_LATEST_TYPESCRIPT,
+      vite: V_LATEST_VITE,
+      'vite-tsconfig-paths': V_LATEST_VITE_TSCONFIG_PATHS,
+      vitest: V_LATEST_VITEST,
+    };
+  }
+  if (gt(escapedNxVersion, '15.8.0')) {
+    return {
+      '@analogjs/platform': V16_1_0_ANALOG_JS_PLATFORM,
+      jsdom: V16_1_0_JSDOM,
+      typescript: V16_1_0_TYPESCRIPT,
+      vite: V16_1_0_VITE,
+      'vite-tsconfig-paths': V16_1_0_VITE_TSCONFIG_PATHS,
+      vitest: V16_1_0_VITEST,
+    };
+  }
+  if (gt(escapedNxVersion, '15.2.0')) {
+    return {
+      '@analogjs/platform': V15_8_0_ANALOG_JS_PLATFORM,
+      jsdom: V15_8_0_JSDOM,
+      typescript: V15_8_0_TYPESCRIPT,
+      vite: V15_8_0_VITE,
+      'vite-tsconfig-paths': V15_8_0_VITE_TSCONFIG_PATHS,
+      vitest: V15_8_0_VITEST,
+    };
+  }
+  if (gt(escapedNxVersion, '15.0.0')) {
+    return {
+      '@analogjs/platform': V15_2_0_ANALOG_JS_PLATFORM,
+      jsdom: V15_2_0_JSDOM,
+      typescript: V15_2_0_TYPESCRIPT,
+      vite: V15_2_0_VITE,
+      'vite-tsconfig-paths': V15_2_0_VITE_TSCONFIG_PATHS,
+      vitest: V15_2_0_VITEST,
+    };
+  }
+};

--- a/packages/nx-plugin/src/generators/app/versions/latest/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions/latest/versions.ts
@@ -1,0 +1,24 @@
+// V_LATEST
+// dependencies
+export const V_LATEST_NX_DEVKIT = '^16.0.0';
+export const V_LATEST_NX_ANGULAR = '^16.0.0';
+export const V_LATEST_ANALOG_JS_CONTENT = '^0.2.0-beta.16';
+export const V_LATEST_ANALOG_JS_ROUTER = '^0.2.0-beta.16';
+export const V_LATEST_ANALOG_JS_TRPC = '^0.2.0-beta.16';
+export const V_LATEST_TRPC_CLIENT = '^10.25.0';
+export const V_LATEST_TRPC_SERVER = '^10.25.0';
+export const V_LATEST_ISOMORPHIC_FETCH = '^3.0.0';
+export const V_LATEST_SUPERJSON = '^1.12.3';
+export const V_LATEST_FRONT_MATTER = '^4.0.2';
+export const V_LATEST_MARKED = '^5.0.2';
+export const V_LATEST_PRISMJS = '^1.29.0';
+
+// devDependencies
+export const V_LATEST_ANALOG_JS_PLATFORM = '^0.2.0-beta.16';
+export const V_LATEST_NX_VITE = '^16.0.0';
+export const V_LATEST_JSDOM = '^20.0.0';
+export const V_LATEST_TYPESCRIPT = '~5.0.2';
+export const V_LATEST_VITE = '^4.0.3';
+export const V_LATEST_VITE_TSCONFIG_PATHS = '^4.0.2';
+export const V_LATEST_VITEST = '^0.31.0';
+export const V_LATEST_ZOD = '^3.21.4';

--- a/packages/nx-plugin/src/generators/app/versions/minimum-supported-angular-version.ts
+++ b/packages/nx-plugin/src/generators/app/versions/minimum-supported-angular-version.ts
@@ -1,0 +1,4 @@
+import { lt, clean, coerce } from 'semver';
+export const MINIMUM_SUPPORTED_ANGULAR_VERSION = '15.0.0';
+export const hasMinimumSupportedAngularVersion = (angularVersion: string) =>
+  lt(coerce(angularVersion), MINIMUM_SUPPORTED_ANGULAR_VERSION);

--- a/packages/nx-plugin/src/generators/app/versions/nx-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx-dependencies.ts
@@ -1,0 +1,76 @@
+import { gt, clean } from 'semver';
+import { V_LATEST_NX_ANGULAR, V_LATEST_NX_DEVKIT } from './latest/versions';
+import { V16_1_0_NX_ANGULAR, V16_1_0_NX_DEVKIT } from './nx_16_1_0/versions';
+import {
+  V15_8_0_NRWL_ANGULAR,
+  V15_8_0_NRWL_DEVKIT,
+} from './nx_15_8_0/versions';
+import {
+  V15_2_0_NRWL_ANGULAR,
+  V15_2_0_NRWL_DEVKIT,
+} from './nx_15_2_0/versions';
+
+const nrwlDependencyKeys = ['@nrwl/devkit', '@nrwl/angular'] as const;
+export type NrwlDependency = (typeof nrwlDependencyKeys)[number];
+export const getNrwlDependencies = (
+  nxVersion: string
+): Record<NrwlDependency, string> => {
+  const escapedNxVersion = clean(nxVersion);
+  if (gt(escapedNxVersion, '16.1.0')) {
+    return {
+      '@nrwl/angular': V_LATEST_NX_ANGULAR,
+      '@nrwl/devkit': V_LATEST_NX_DEVKIT,
+    };
+  }
+  if (gt(escapedNxVersion, '15.8.0')) {
+    return {
+      '@nrwl/angular': V16_1_0_NX_ANGULAR,
+      '@nrwl/devkit': V16_1_0_NX_DEVKIT,
+    };
+  }
+  if (gt(escapedNxVersion, '15.2.0')) {
+    return {
+      '@nrwl/angular': V15_8_0_NRWL_ANGULAR,
+      '@nrwl/devkit': V15_8_0_NRWL_DEVKIT,
+    };
+  }
+  if (gt(escapedNxVersion, '15.0.0')) {
+    return {
+      '@nrwl/angular': V15_2_0_NRWL_ANGULAR,
+      '@nrwl/devkit': V15_2_0_NRWL_DEVKIT,
+    };
+  }
+};
+
+const nxDependencyKeys = ['@nx/devkit', '@nx/angular'] as const;
+export type NxDependency = (typeof nxDependencyKeys)[number];
+export const getNxDependencies = (
+  nxVersion: string
+): Record<NxDependency, string> => {
+  const escapedNxVersion = clean(nxVersion);
+
+  if (gt(escapedNxVersion, '16.1.0')) {
+    return {
+      '@nx/angular': V_LATEST_NX_ANGULAR,
+      '@nx/devkit': V_LATEST_NX_DEVKIT,
+    };
+  }
+  if (gt(escapedNxVersion, '15.8.0')) {
+    return {
+      '@nx/angular': V16_1_0_NX_ANGULAR,
+      '@nx/devkit': V16_1_0_NX_DEVKIT,
+    };
+  }
+  if (gt(escapedNxVersion, '15.2.0')) {
+    return {
+      '@nx/angular': V15_8_0_NRWL_ANGULAR,
+      '@nx/devkit': V15_8_0_NRWL_DEVKIT,
+    };
+  }
+  if (gt(escapedNxVersion, '15.0.0')) {
+    return {
+      '@nx/angular': V15_2_0_NRWL_ANGULAR,
+      '@nx/devkit': V15_2_0_NRWL_DEVKIT,
+    };
+  }
+};

--- a/packages/nx-plugin/src/generators/app/versions/nx_15_2_0/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx_15_2_0/versions.ts
@@ -1,0 +1,24 @@
+// V15_2_0
+// dependencies
+export const V15_2_0_NRWL_DEVKIT = '15.9.2';
+export const V15_2_0_NRWL_ANGULAR = '15.9.2';
+export const V15_2_0_ANALOG_JS_CONTENT = '^0.2.0-beta.16';
+export const V15_2_0_ANALOG_JS_ROUTER = '^0.2.0-beta.16';
+export const V15_2_0_ANALOG_JS_TRPC = '^0.2.0-beta.16';
+export const V15_2_0_TRPC_CLIENT = '^10.25.0';
+export const V15_2_0_TRPC_SERVER = '^10.25.0';
+export const V15_2_0_ISOMORPHIC_FETCH = '^3.0.0';
+export const V15_2_0_SUPERJSON = '^1.12.3';
+export const V15_2_0_FRONT_MATTER = '^4.0.2';
+export const V15_2_0_MARKED = '^5.0.2';
+export const V15_2_0_PRISMJS = '^1.29.0';
+
+// devDependencies
+export const V15_2_0_ANALOG_JS_PLATFORM = '0.1.0-beta.23';
+export const V15_2_0_NRWL_VITE = '^15.7.0';
+export const V15_2_0_JSDOM = '^20.0.0';
+export const V15_2_0_TYPESCRIPT = '~4.8.4';
+export const V15_2_0_VITE = '^4.0.3';
+export const V15_2_0_VITE_TSCONFIG_PATHS = '^4.0.2';
+export const V15_2_0_VITEST = '^0.31.0';
+export const V15_2_0_ZOD = '^3.21.4';

--- a/packages/nx-plugin/src/generators/app/versions/nx_15_8_0/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx_15_8_0/versions.ts
@@ -1,0 +1,24 @@
+// V15_8_0
+// dependencies
+export const V15_8_0_NRWL_DEVKIT = '15.9.2';
+export const V15_8_0_NRWL_ANGULAR = '15.9.2';
+export const V15_8_0_ANALOG_JS_CONTENT = '^0.2.0-beta.16';
+export const V15_8_0_ANALOG_JS_ROUTER = '^0.2.0-beta.16';
+export const V15_8_0_ANALOG_JS_TRPC = '^0.2.0-beta.16';
+export const V15_8_0_TRPC_CLIENT = '^10.25.0';
+export const V15_8_0_TRPC_SERVER = '^10.25.0';
+export const V15_8_0_ISOMORPHIC_FETCH = '^3.0.0';
+export const V15_8_0_SUPERJSON = '^1.12.3';
+export const V15_8_0_FRONT_MATTER = '^4.0.2';
+export const V15_8_0_MARKED = '^5.0.2';
+export const V15_8_0_PRISMJS = '^1.29.0';
+
+// devDependencies
+export const V15_8_0_ANALOG_JS_PLATFORM = '0.1.0-beta.23';
+export const V15_8_0_NRWL_VITE = '^15.7.0';
+export const V15_8_0_JSDOM = '^20.0.0';
+export const V15_8_0_TYPESCRIPT = '~4.8.4';
+export const V15_8_0_VITE = '^4.0.3';
+export const V15_8_0_VITE_TSCONFIG_PATHS = '^4.0.2';
+export const V15_8_0_VITEST = '^0.31.0';
+export const V15_8_0_ZOD = '^3.21.4';

--- a/packages/nx-plugin/src/generators/app/versions/nx_16_1_0/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx_16_1_0/versions.ts
@@ -1,0 +1,24 @@
+// V16_1_0
+// dependencies
+export const V16_1_0_NX_DEVKIT = '^16.0.0';
+export const V16_1_0_NX_ANGULAR = '^16.0.0';
+export const V16_1_0_ANALOG_JS_CONTENT = '^0.2.0-beta.16';
+export const V16_1_0_ANALOG_JS_ROUTER = '^0.2.0-beta.16';
+export const V16_1_0_ANALOG_JS_TRPC = '^0.2.0-beta.16';
+export const V16_1_0_TRPC_CLIENT = '^10.25.0';
+export const V16_1_0_TRPC_SERVER = '^10.25.0';
+export const V16_1_0_ISOMORPHIC_FETCH = '^3.0.0';
+export const V16_1_0_SUPERJSON = '^1.12.3';
+export const V16_1_0_FRONT_MATTER = '^4.0.2';
+export const V16_1_0_MARKED = '^5.0.2';
+export const V16_1_0_PRISMJS = '^1.29.0';
+
+// devDependencies
+export const V16_1_0_ANALOG_JS_PLATFORM = '^0.2.0-beta.16';
+export const V16_1_0_NX_VITE = '^16.0.0';
+export const V16_1_0_JSDOM = '^20.0.0';
+export const V16_1_0_TYPESCRIPT = '~5.0.2';
+export const V16_1_0_VITE = '^4.0.3';
+export const V16_1_0_VITE_TSCONFIG_PATHS = '^4.0.2';
+export const V16_1_0_VITEST = '^0.31.0';
+export const V16_1_0_ZOD = '^3.21.4';

--- a/packages/nx-plugin/src/generators/app/versions/trpc-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/trpc-dependencies.ts
@@ -1,0 +1,90 @@
+import { gt, clean } from 'semver';
+import {
+  V_LATEST_ANALOG_JS_TRPC,
+  V_LATEST_ISOMORPHIC_FETCH,
+  V_LATEST_SUPERJSON,
+  V_LATEST_TRPC_CLIENT,
+  V_LATEST_TRPC_SERVER,
+  V_LATEST_ZOD,
+} from './latest/versions';
+import {
+  V16_1_0_ANALOG_JS_TRPC,
+  V16_1_0_ISOMORPHIC_FETCH,
+  V16_1_0_SUPERJSON,
+  V16_1_0_TRPC_CLIENT,
+  V16_1_0_TRPC_SERVER,
+  V16_1_0_ZOD,
+} from './nx_16_1_0/versions';
+import {
+  V15_8_0_ANALOG_JS_TRPC,
+  V15_8_0_ISOMORPHIC_FETCH,
+  V15_8_0_SUPERJSON,
+  V15_8_0_TRPC_CLIENT,
+  V15_8_0_TRPC_SERVER,
+  V15_8_0_ZOD,
+} from './nx_15_8_0/versions';
+import {
+  V15_2_0_ANALOG_JS_TRPC,
+  V15_2_0_ISOMORPHIC_FETCH,
+  V15_2_0_SUPERJSON,
+  V15_2_0_TRPC_CLIENT,
+  V15_2_0_TRPC_SERVER,
+  V15_2_0_ZOD,
+} from './nx_15_2_0/versions';
+
+const tRPCDependencyKeys = [
+  '@analogjs/trpc',
+  '@trpc/client',
+  '@trpc/server',
+  'superjson',
+  'isomorphic-fetch',
+  'zod',
+] as const;
+export type TrpcDependency = (typeof tRPCDependencyKeys)[number];
+
+export const getTrpcDependencies = (
+  nxVersion: string
+): Record<TrpcDependency, string> => {
+  const escapedNxVersion = clean(nxVersion);
+  if (gt(escapedNxVersion, '16.1.0')) {
+    return {
+      '@analogjs/trpc': V_LATEST_ANALOG_JS_TRPC,
+      '@trpc/client': V_LATEST_TRPC_CLIENT,
+      '@trpc/server': V_LATEST_TRPC_SERVER,
+      superjson: V_LATEST_SUPERJSON,
+      'isomorphic-fetch': V_LATEST_ISOMORPHIC_FETCH,
+      zod: V_LATEST_ZOD,
+    };
+  }
+
+  if (gt(escapedNxVersion, '15.8.0')) {
+    return {
+      '@analogjs/trpc': V16_1_0_ANALOG_JS_TRPC,
+      '@trpc/client': V16_1_0_TRPC_CLIENT,
+      '@trpc/server': V16_1_0_TRPC_SERVER,
+      superjson: V16_1_0_SUPERJSON,
+      'isomorphic-fetch': V16_1_0_ISOMORPHIC_FETCH,
+      zod: V16_1_0_ZOD,
+    };
+  }
+  if (gt(escapedNxVersion, '15.2.0')) {
+    return {
+      '@analogjs/trpc': V15_8_0_ANALOG_JS_TRPC,
+      '@trpc/client': V15_8_0_TRPC_CLIENT,
+      '@trpc/server': V15_8_0_TRPC_SERVER,
+      superjson: V15_8_0_SUPERJSON,
+      'isomorphic-fetch': V15_8_0_ISOMORPHIC_FETCH,
+      zod: V15_8_0_ZOD,
+    };
+  }
+  if (gt(escapedNxVersion, '15.0.0')) {
+    return {
+      '@analogjs/trpc': V15_2_0_ANALOG_JS_TRPC,
+      '@trpc/client': V15_2_0_TRPC_CLIENT,
+      '@trpc/server': V15_2_0_TRPC_SERVER,
+      superjson: V15_2_0_SUPERJSON,
+      'isomorphic-fetch': V15_2_0_ISOMORPHIC_FETCH,
+      zod: V15_2_0_ZOD,
+    };
+  }
+};

--- a/packages/nx-plugin/src/utils/version-utils.ts
+++ b/packages/nx-plugin/src/utils/version-utils.ts
@@ -4,7 +4,8 @@ import { clean, coerce } from 'semver';
 export function getInstalledPackageVersion(
   tree: Tree,
   packageName: string,
-  defaultVersion?: string
+  defaultVersion?: string,
+  raw = false
 ): string | null {
   const pkgJson = readJson(tree, 'package.json');
   const installedPackageVersion =
@@ -23,6 +24,7 @@ export function getInstalledPackageVersion(
   }
 
   return (
-    clean(installedPackageVersion) ?? coerce(installedPackageVersion).version
+    (raw ? installedPackageVersion : clean(installedPackageVersion)) ??
+    coerce(installedPackageVersion).version
   );
 }


### PR DESCRIPTION
currently the nx plugin let the nx angular init generator pick the version of angular to be installed. this meant that when the nx angular init generator picks 16.0.0, due to ~16.0.0 version in the nx repository, our created analog application did not work anymore. this fix makes sure the correct version ^16.1.0 is picked by nx tooling. unfortunately, semver does not like ^ in its versions so we have to remove it before finding the major version or ensuring compatibility.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [x] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After upgrading to 0.2.0-beta.17 the Nx plugin breaks, due import paths that changed in Angular 16.1.
The Nx init generator we use to set up an Angular workspace under the hood currently uses ~16.0.0 as its
default version. This change ensures that ^16.1.0 is used for our Angular installation.


Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Also including some minor clean ups and additional "safe guards" that should make dependency
management easier.

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/ZZNIld3iYlJJt3yA4c/giphy.gif"/>
