### PR TITLE
refactor(platform): remove plugin to check for @analogjs/content package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Analog
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-45-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![Discord server](https://dcbadge.vercel.app/api/server/mKC2Ec48U5?style=flat-square)](https://chat.analogjs.org/) [![Twitter](https://img.shields.io/twitter/follow/analogjs?color=%231DA1F2&style=flat-square)](https://twitter.com/analogjs)

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "apps/docs-app"
   ],
   "dependencies": {
-    "@analogjs/content": "latest",
     "@angular/animations": "^16.1.0",
     "@angular/common": "^16.1.0",
     "@angular/compiler": "^16.1.0",

--- a/packages/platform/src/lib/content-plugin.ts
+++ b/packages/platform/src/lib/content-plugin.ts
@@ -1,47 +1,8 @@
 import { Plugin } from 'vite';
 import * as fs from 'fs';
-import * as path from 'path';
 
-/**
- * This excludes the build from including the
- * @analogjs/content package because it is
- * dynamically imported at runtime.
- *
- * This prevents a dependency on @analogjs/router
- * to @analogjs/content
- *
- * @returns
- */
 export function contentPlugin(): Plugin[] {
-  let excludeContent = true;
-
-  const pkgJsonPath = path.resolve(process.cwd(), './package.json');
-  const packageJsonExists = fs.existsSync(pkgJsonPath);
-
-  if (packageJsonExists) {
-    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
-
-    if (pkg.dependencies['@analogjs/content']) {
-      excludeContent = false;
-    }
-  }
-
   return [
-    {
-      name: 'analogjs-content-build-plugin',
-      config() {
-        return {
-          optimizeDeps: {
-            include: excludeContent ? [] : ['@analogjs/content'],
-          },
-          build: {
-            rollupOptions: {
-              external: excludeContent ? ['@analogjs/content'] : [],
-            },
-          },
-        };
-      },
-    },
     {
       name: 'analogjs-content-frontmatter',
       async transform(_code, id) {

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -1,11 +1,12 @@
 import { Plugin } from 'vite';
+import viteNitroPlugin from '@analogjs/vite-plugin-nitro';
+import angular from '@analogjs/vite-plugin-angular';
+
 import { Options } from './options';
 import { routerPlugin } from './router-plugin';
 import { devServerPlugin } from './ssr/dev-server-plugin';
 import { ssrBuildPlugin } from './ssr/ssr-build-plugin';
 import { contentPlugin } from './content-plugin';
-import viteNitroPlugin from '@analogjs/vite-plugin-nitro';
-import angular from '@analogjs/vite-plugin-angular';
 import { clearClientPageEndpointsPlugin } from './clear-client-page-endpoint';
 
 export function platformPlugin(opts: Options = {}): Plugin[] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ importers:
 
   .:
     dependencies:
-      '@analogjs/content':
-        specifier: latest
-        version: 0.2.0-beta.15(@angular/common@16.1.0)(@angular/core@16.1.0)(@angular/platform-browser@16.1.0)(@angular/router@16.1.0)(front-matter@4.0.2)(marked@5.0.2)(prismjs@1.29.0)(rxjs@7.8.0)
       '@angular/animations':
         specifier: ^16.1.0
         version: 16.1.0(@angular/core@16.1.0)
@@ -485,29 +482,6 @@ packages:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
 
-  /@analogjs/content@0.2.0-beta.15(@angular/common@16.1.0)(@angular/core@16.1.0)(@angular/platform-browser@16.1.0)(@angular/router@16.1.0)(front-matter@4.0.2)(marked@5.0.2)(prismjs@1.29.0)(rxjs@7.8.0):
-    resolution: {integrity: sha512-wz+uduRJ/ljtgmrM1x14RFe17NCa8BXcPGkxYH3n+KBjxBVBVytFL0hBuCGNLG8aKP6g+kyFE5QKdCTu54vc1Q==}
-    peerDependencies:
-      '@angular/common': ^15.0.0 || ^16.0.0
-      '@angular/core': ^15.0.0 || ^16.0.0
-      '@angular/platform-browser': ^15.0.0 || ^16.0.0
-      '@angular/router': ^15.0.0 || ^16.0.0
-      front-matter: ^4.0.2
-      marked: ^5.0.2
-      prismjs: ^1.29.0
-      rxjs: ^6.5.0 || ^7.5.0
-    dependencies:
-      '@angular/common': 16.1.0(@angular/core@16.1.0)(rxjs@7.8.0)
-      '@angular/core': 16.1.0(rxjs@7.8.0)(zone.js@0.13.0)
-      '@angular/platform-browser': 16.1.0(@angular/animations@16.1.0)(@angular/common@16.1.0)(@angular/core@16.1.0)
-      '@angular/router': 16.1.0(@angular/common@16.1.0)(@angular/core@16.1.0)(@angular/platform-browser@16.1.0)(rxjs@7.8.0)
-      front-matter: 4.0.2
-      marked: 5.0.2
-      prismjs: 1.29.0
-      rxjs: 7.8.0
-      tslib: 2.5.3
-    dev: false
-
   /@angular-devkit/architect@0.1601.0(chokidar@3.5.3):
     resolution: {integrity: sha512-lrO++pcB+NFGXLZrFBhRMPbGCMpZuJyJEKSK8zknw9/7ipRz1MSlRaJFWUKEHRlVI/+hsBTWtBRUnR5WcgqvvA==}
     engines: {node: ^16.14.0 || >=18.10.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -796,6 +770,7 @@ packages:
   /@angular/compiler-cli@16.1.0(@angular/compiler@16.1.0)(typescript@5.0.3):
     resolution: {integrity: sha512-t/fam7YdY6sINP0IAmt3cWQ0KUndhm457i4e0uZH+NVeBzItvBQggmrl+UhXslg/iFEyHohtyrjZKnGSzgkzKg==}
     engines: {node: ^16.14.0 || >=18.10.0}
+    hasBin: true
     peerDependencies:
       '@angular/compiler': 16.1.0
       typescript: '>=4.9.3 <5.2'
@@ -4264,6 +4239,7 @@ packages:
   /@docusaurus/core@2.2.0(@docusaurus/types@2.2.0)(@swc/core@1.3.42)(@types/node@18.11.18)(esbuild@0.17.19)(eslint@8.33.0)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.1)(typescript@5.0.3):
     resolution: {integrity: sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==}
     engines: {node: '>=16.14'}
+    hasBin: true
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
@@ -7113,6 +7089,7 @@ packages:
   /@swc/cli@0.1.62(@swc/core@1.3.42):
     resolution: {integrity: sha512-kOFLjKY3XH1DWLfXL1/B5MizeNorHR8wHKEi92S/Zi9Md/AK17KSqR8MgyRJ6C1fhKHvbBCl8wboyKAFXStkYw==}
     engines: {node: '>= 12.13'}
+    hasBin: true
     peerDependencies:
       '@swc/core': ^1.2.66
       chokidar: ^3.5.1
@@ -8531,6 +8508,7 @@ packages:
   /autoprefixer@10.4.14(postcss@8.4.21):
     resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
     engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -8545,6 +8523,7 @@ packages:
   /autoprefixer@10.4.14(postcss@8.4.23):
     resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
     engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -8560,6 +8539,7 @@ packages:
   /autoprefixer@10.4.14(postcss@8.4.24):
     resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
     engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -11184,6 +11164,7 @@ packages:
 
   /eslint-config-prettier@8.6.0(eslint@8.33.0):
     resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
+    hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
@@ -13555,6 +13536,7 @@ packages:
   /jest-cli@29.5.0(@types/node@18.11.18)(ts-node@10.9.1):
     resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
@@ -13915,6 +13897,7 @@ packages:
   /jest@29.5.0(@types/node@18.11.18)(ts-node@10.9.1):
     resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
@@ -15505,6 +15488,7 @@ packages:
   /ng-packagr@16.1.0(@angular/compiler-cli@16.1.0)(tailwindcss@3.0.2)(tslib@2.4.0)(typescript@5.0.3):
     resolution: {integrity: sha512-NbgzDRtRiYJi98Ssky7U5GoicZz7VkR3OW5qd9q3dt3H/JNqLh2PwB745NFG2cT00lEvfrY6LJ1NAcOjoWDibA==}
     engines: {node: ^16.14.0 || >=18.10.0}
+    hasBin: true
     peerDependencies:
       '@angular/compiler-cli': ^16.0.0 || ^16.1.0-next.0
       tailwindcss: ^2.0.0 || ^3.0.0
@@ -15978,6 +15962,7 @@ packages:
 
   /nx@16.1.0(@swc-node/register@1.6.2)(@swc/core@1.3.42):
     resolution: {integrity: sha512-f5QAWMLZSKRZuSF8sT8E/Ox/6fq1S+nvOb+lL+jpm+LI1HO6VATpDZpzoPYrb/+wnam+8jxCFDwuSWQ9JfA6rw==}
+    hasBin: true
     requiresBuild: true
     peerDependencies:
       '@swc-node/register': ^1.4.2
@@ -18806,6 +18791,7 @@ packages:
   /rollup-plugin-visualizer@5.9.0(rollup@3.21.4):
     resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}
     engines: {node: '>=14'}
+    hasBin: true
     peerDependencies:
       rollup: 2.x || 3.x
     peerDependenciesMeta:
@@ -19857,6 +19843,7 @@ packages:
   /tailwindcss@3.0.2(autoprefixer@10.4.14)(postcss@8.4.21)(ts-node@10.9.1):
     resolution: {integrity: sha512-i1KpjYnGYftjzdAth6jA5iMPjhxpUkk5L6DafhfnQs+KiiWaThYxmk47Weh4oFH1mZqP6MuiQNHxtoRVPOraLg==}
     engines: {node: '>=12.13.0'}
+    hasBin: true
     peerDependencies:
       autoprefixer: ^10.0.2
       postcss: ^8.0.9
@@ -20188,6 +20175,7 @@ packages:
   /ts-jest@29.1.0(@babel/core@7.21.8)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.3):
     resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
     peerDependencies:
       '@babel/core': '>=7.0.0-beta.0 <8'
       '@jest/types': ^29.0.0
@@ -20236,6 +20224,7 @@ packages:
 
   /ts-node@10.9.1(@swc/core@1.3.42)(@types/node@18.11.18)(typescript@4.8.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
@@ -20267,6 +20256,7 @@ packages:
 
   /ts-node@10.9.1(@swc/core@1.3.42)(@types/node@18.11.18)(typescript@5.0.3):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
@@ -20298,6 +20288,7 @@ packages:
   /tsconfck@2.1.1(typescript@5.0.3):
     resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
     engines: {node: ^14.13.1 || ^16 || >=18}
+    hasBin: true
     peerDependencies:
       typescript: ^4.3.5 || ^5.0.0
     peerDependenciesMeta:
@@ -20755,6 +20746,7 @@ packages:
 
   /update-browserslist-db@1.0.10(browserslist@4.21.5):
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
@@ -20765,6 +20757,7 @@ packages:
 
   /update-browserslist-db@1.0.11(browserslist@4.21.7):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
@@ -21054,6 +21047,7 @@ packages:
   /vite@4.3.4(@types/node@18.11.18)(less@4.1.3)(stylus@0.55.0):
     resolution: {integrity: sha512-f90aqGBoxSFxWph2b39ae2uHAxm5jFBBdnfueNxZAT1FTpM13ccFQExCaKbR2xFW5atowjleRniQ7onjJ22QEg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
@@ -21088,6 +21082,7 @@ packages:
   /vite@4.3.9(@types/node@18.11.18)(less@4.1.3)(sass@1.63.2)(stylus@0.55.0)(terser@5.17.7):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
@@ -21134,6 +21129,7 @@ packages:
   /vitest@0.31.0(jsdom@21.1.0)(less@4.1.3)(playwright@1.30.0)(stylus@0.55.0):
     resolution: {integrity: sha512-JwWJS9p3GU9GxkG7eBSmr4Q4x4bvVBSswaCFf1PBNHiPx00obfhHRJfgHcnI0ffn+NMlIh9QGvG75FlaIBdKGA==}
     engines: {node: '>=v14.18.0'}
+    hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@vitest/browser': '*'
@@ -21393,6 +21389,7 @@ packages:
   /webpack-dev-server@4.13.2(webpack@5.82.0):
     resolution: {integrity: sha512-5i6TrGBRxG4vnfDpB6qSQGfnB6skGBXNL5/542w2uRGLimX6qeE5BQMLrzIC3JYV/xlGOv+s+hTleI9AZKUQNw==}
     engines: {node: '>= 12.13.0'}
+    hasBin: true
     peerDependencies:
       webpack: ^4.37.0 || ^5.0.0
       webpack-cli: '*'
@@ -21443,6 +21440,7 @@ packages:
   /webpack-dev-server@4.15.0(webpack@5.86.0):
     resolution: {integrity: sha512-HmNB5QeSl1KpulTBQ8UT4FPrByYyaLxpJoQ0+s7EvUrMc16m0ZS1sgb1XGqzmgCPk0c9y+aaXxn11tbLzuM7NQ==}
     engines: {node: '>= 12.13.0'}
+    hasBin: true
     peerDependencies:
       webpack: ^4.37.0 || ^5.0.0
       webpack-cli: '*'
@@ -21541,6 +21539,7 @@ packages:
   /webpack@5.82.0(@swc/core@1.3.42)(esbuild@0.17.19):
     resolution: {integrity: sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
     peerDependencies:
       webpack-cli: '*'
     peerDependenciesMeta:
@@ -21580,6 +21579,7 @@ packages:
   /webpack@5.86.0(@swc/core@1.3.42)(esbuild@0.17.19):
     resolution: {integrity: sha512-3BOvworZ8SO/D4GVP+GoRC3fVeg5MO4vzmq8TJJEkdmopxyazGDxN8ClqN12uzrZW9Tv8EED8v5VSb6Sqyi0pg==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
     peerDependencies:
       webpack-cli: '*'
     peerDependenciesMeta:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [x] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The `@analogjs/content` package is already included with new projects, so this workaround is no longer needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
