### PR TITLE
docs: add additional render.com details

### DIFF
--- a/apps/docs-app/docs/features/deployment/providers.md
+++ b/apps/docs-app/docs/features/deployment/providers.md
@@ -6,17 +6,33 @@ Analog supports deployment to many providers with little or no additional config
 
 Analog supports deploying on [Render](https://render.com/) with minimal configuration.
 
+### Web Service Deployment
+
 1. [Create a new Web Service](https://dashboard.render.com/select-repo?type=web) and select the repository that contains your code.
 
 2. Ensure the 'Node' environment is selected.
 
-3. Depending on your package manager, set the build command to `yarn && yarn build`, `npm install && npm run build`, or `pnpm i --shamefully-hoist && pnpm build`.
+3. [Specify your Node version for Render to use](https://render.com/docs/node-version) (v18.13.0 or higher recommended) - Render by default uses Node 14, which fails to correctly build an Analog site
 
-4. Update the start command to `node dist/analog/server/index.mjs`
+4. Depending on your package manager, set the build command to `yarn && yarn build`, `npm install && npm run build`, or `pnpm i --shamefully-hoist && pnpm build`.
 
-5. Click 'Advanced' and add an environment variable with `BUILD_PRESET` set to `render-com`.
+5. Update the start command to `node dist/analog/server/index.mjs`
 
-6. Click 'Create Web Service'.
+6. Click 'Advanced' and add an environment variable with `BUILD_PRESET` set to `render-com`.
+
+7. Click 'Create Web Service'.
+
+### Static Site Deployment
+
+If using Analog to pre-render static content, you can deploy a static site on Render with minimal configuration
+
+1. [Create a new Static Site](https://dashboard.render.com/select-repo?type=static) and select the repository that contains your code.
+
+2. Depending on your package manager, set the build command to `yarn && yarn build`, `npm install && npm run build`, or `pnpm i --shamefully-hoist && pnpm build`..
+
+3. Set the publish directory to the `public` directory inside of the `dist` build directory (e.g. `dist/analog/public`)
+
+4. Click 'Create Static Site'
 
 ## Edgio
 


### PR DESCRIPTION
Add documentation to specify a Node version when using render.com as well as documentation for hosting a static site

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

In setting up Render.com for my personal site, I got hung up on the build and deploy because the default node version was too low for Analog

Closes #

## What is the new behavior?
Add some new documentation for render.com setup as well as how to setup Render for static site hosting

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/lMsT2f47tDxFMYdJMC/giphy-downsized-medium.gif"/>
