### PR TITLE
feat(vite-plugin-nitro): add support for XML content in API routes

### DIFF
--- a/apps/blog-app-e2e-cypress/src/e2e/app.cy.ts
+++ b/apps/blog-app-e2e-cypress/src/e2e/app.cy.ts
@@ -4,4 +4,14 @@ describe('blog-app', () => {
   it('should redirect us to /blog', () => {
     cy.url().should('be.equal', `${Cypress.config('baseUrl')}/blog`);
   });
+  it('should serve up HTML for pre-rendered markdown route', () => {
+    cy.visit('/blog/2022-12-27-my-first-post');
+    cy.get('h1').should('contain', 'My First Post');
+  });
+  it('should serve up XML for pre-rendered XML route from vite.config at /api/rss.xml', () => {
+    cy.request('/api/rss.xml')
+      .its('headers')
+      .its('content-type')
+      .should('include', 'application/xml');
+  });
 });

--- a/apps/blog-app/src/server/routes/rss.xml.ts
+++ b/apps/blog-app/src/server/routes/rss.xml.ts
@@ -1,0 +1,9 @@
+import { defineEventHandler } from 'h3';
+export default defineEventHandler((event) => {
+  const feedString = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+</rss>
+  `;
+  event.node.res.setHeader('content-type', 'text/xml');
+  event.node.res.end(feedString);
+});

--- a/apps/blog-app/vite.config.ts
+++ b/apps/blog-app/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig(() => {
               '/',
               '/blog',
               '/about',
+              '/api/rss.xml',
               '/blog/2022-12-27-my-first-post',
               '/blog/2022-12-31-my-second-post',
             ];

--- a/apps/docs-app/docs/features/api/overview.md
+++ b/apps/docs-app/docs/features/api/overview.md
@@ -13,7 +13,45 @@ import { defineEventHandler } from 'h3';
 export default defineEventHandler(() => ({ message: 'Hello World' }));
 ```
 
-API routes are powered by [Nitro](https://nitro.unjs.io). See the Nitro docs for more examples around building API routes.
+## Defining XML Content
+
+To create an RSS feed for your site, set the `content-type` to be `text/xml` and Analog serves up the correct content type for the route.
+
+```ts
+//server/routes/rss.xml.ts
+
+import { defineEventHandler } from 'h3';
+export default defineEventHandler((event) => {
+  const feedString = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+</rss>
+  `;
+  event.node.res.setHeader('content-type', 'text/xml');
+  event.node.res.end(feedString);
+});
+```
+
+**Note:** For SSG content, set Analog to prerender an API route to make it available as prerendered content:
+
+```ts
+// vite.config.ts
+...
+prerender: {
+  routes: async () => {
+    return [
+      ...
+      '/api/rss.xml',
+      ...
+      .
+    ];
+  },
+  sitemap: {
+    host: 'https://analog-blog.netlify.app',
+  },
+},
+```
+
+The XML is available as a static XML document at `/dist/analog/public/api/rss.xml`
 
 ## Custom API prefix
 
@@ -35,3 +73,7 @@ export default defineConfig(({ mode }) => {
 With this configuration, Analog exposes the API routes under the `/services` prefix.
 
 A route defined in `src/server/routes/v1/hello.ts` can now be accessed at `/services/v1/hello`.
+
+## More Info
+
+API routes are powered by [Nitro](https://nitro.unjs.io). See the Nitro docs for more examples around building API routes.

--- a/packages/vite-plugin-nitro/src/lib/runtime/api-middleware.js
+++ b/packages/vite-plugin-nitro/src/lib/runtime/api-middleware.js
@@ -13,7 +13,12 @@ export default eventHandler(async (event) => {
   if (event.node.req.url?.startsWith(apiPrefix)) {
     const reqUrl = event.node.req.url?.replace(apiPrefix, '');
 
-    if (event.node.req.method === 'GET') {
+    if (
+      event.node.req.method === 'GET' &&
+      // in the case of XML routes, we want to proxy the request so that nitro gets the correct headers
+      // and can render the XML correctly as a static asset
+      !event.node.req.url?.endsWith('.xml')
+    ) {
       return $fetch(reqUrl);
     }
 


### PR DESCRIPTION
Add the ability to set content-type as XJML in server routes and to have SSG correctly pre-render the data

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

When defining an API route with a `content-type` other than `applicaton/json`, nitro interprets all responses as `text/html` and renders a `.html` document for the data. If you would like to serve up something like XML for an RSS feed, this doesn't work.

## What is the new behavior?
If you set the headers to `content-type: text/xml` (or anything non-json) it re-proxies the request to allow nitro to interpret the result as intended.

Note: This is a bit wasteful to re-proxy the request, but I was unable to bet nitro to be happy with any other approach. I am totally willing to try other approaches, but this was the most consistent way I could get the desired behavior

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/a7ZvDb2NfbQvS/giphy.gif"/>