### PR TITLE
fix(trpc): cache-state turns to inactive once app is stable

### DIFF
--- a/packages/trpc/src/lib/client/cache-state.ts
+++ b/packages/trpc/src/lib/client/cache-state.ts
@@ -4,7 +4,6 @@ import {
   ApplicationRef,
   inject,
   InjectionToken,
-  ɵInitialRenderPendingTasks as InitialRenderPendingTasks,
 } from '@angular/core';
 
 export const tRPC_CACHE_STATE = new InjectionToken<{
@@ -22,20 +21,11 @@ export const provideTrpcCacheStateStatusManager = () => ({
   useFactory: () => {
     const appRef = inject(ApplicationRef);
     const cacheState = inject(tRPC_CACHE_STATE);
-    const pendingTasks = inject(InitialRenderPendingTasks);
 
-    return () => {
-      const isStablePromise = appRef.isStable
+    return () =>
+      appRef.isStable
         .pipe(first((isStable) => isStable))
-        .toPromise();
-      const pendingTasksPromise = pendingTasks.hasPendingTasks.toPromise();
-
-      (Promise as any)
-        .allSettled([isStablePromise, pendingTasksPromise])
-        .then(() => {
-          cacheState.isCacheActive.next(false);
-        });
-    };
+        .subscribe(() => cacheState.isCacheActive.next(false));
   },
-  deps: [ApplicationRef, tRPC_CACHE_STATE, InitialRenderPendingTasks],
+  deps: [ApplicationRef, tRPC_CACHE_STATE],
 });


### PR DESCRIPTION
tRPC cache state is now active as long as the cache for the HttpClient is active in angular 16.1: Until the application is stable

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [x] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Cache state is active indefinitely, which means that tRPC client never fetches a new request

## What is the new behavior?

Cache is only active while app is not stable. Then tRPC issues requests to the BE as expected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Change is covered by e2e tests of the trpc-app. Currently, they are blocked by https://github.com/analogjs/analog/issues/468

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media1.giphy.com/media/9OjPIZ8skr9j7BgkDW/giphy.gif?cid=ecf05e47re35mtlt7ltbhhtv8sd63kvdvjrqrj3g9itibtm7&ep=v1_gifs_search&rid=giphy.gif&ct=g">