### PR TITLE
ci: fix e2e suite when running on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   DOCS_APP_ARTIFACT_NAME: docs-app
   DOCS_APP_PATH: dist/apps/docs-app/
   NODE_OPTIONS: --max-old-space-size=6144
-  VITE_ANALOG_PUBLIC_BASE_URL: ${{ vars.VITE_ANALOG_PUBLIC_BASE_URL }}
+  VITE_ANALOG_PUBLIC_BASE_URL: ${{ vars.VITE_ANALOG_PUBLIC_BASE_URL || 'http://localhost:3000' }}
 
 jobs:
   commitlint:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

The e2e suite fails on CI for the analog-app-e2e-cypress suite

Closes #

## What is the new behavior?

On my fork I was able to get this to correctly work. It looks like the [router configuration](https://github.com/analogjs/analog/blob/main/packages/router/src/lib/route-config.ts?plain=1#L39) blows up when this value is undefined correctly. Adding in a fallback value looks to make my local version happy. We will see how it does on this PR.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/DQeeGxJPv3VHE7zNYD/giphy.gif"/>
