### PR TITLE
feat(vite-plugin-nitro): adjust output paths for vercel preset

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/vite-nitro-plugin.spec.data.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-nitro-plugin.spec.data.ts
@@ -38,10 +38,7 @@ export const mockNitroConfig: NitroConfig = {
   },
 };
 
-export async function mockBuildFunctions(): Promise<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [Mock<any, any>, Mock<any, any>, Mock<any, any>]
-> {
+export async function mockBuildFunctions() {
   const buildServerImport = await import('./build-server');
   const buildServerImportSpy = vi.fn();
   buildServerImport.buildServer = buildServerImportSpy;
@@ -54,7 +51,7 @@ export async function mockBuildFunctions(): Promise<
   const buildSitemapImportSpy = vi.fn();
   buildSitemapImport.buildSitemap = buildSitemapImportSpy;
 
-  return [buildSSRAppImportSpy, buildServerImportSpy, buildSitemapImportSpy];
+  return { buildSSRAppImportSpy, buildServerImportSpy, buildSitemapImportSpy };
 }
 
 export async function runConfigAndCloseBundle(plugin: Plugin): Promise<void> {

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
@@ -175,72 +175,98 @@ describe('nitro', () => {
     );
   });
 
-  it('should use the analog output paths when preset is not vercel', async () => {
-    // Arrange
-    vi.mock('process');
-    process.cwd = vi.fn().mockReturnValue('/custom-root-directory');
-    const { buildServerImportSpy } = await mockBuildFunctions();
+  describe('preset output', () => {
+    it('should use the analog output paths when preset is not vercel', async () => {
+      // Arrange
+      vi.mock('process');
+      process.cwd = vi.fn().mockReturnValue('/custom-root-directory');
+      const { buildServerImportSpy } = await mockBuildFunctions();
 
-    const plugin = nitro({}, {});
+      const plugin = nitro({}, {});
 
-    // Act
-    await runConfigAndCloseBundle(plugin);
+      // Act
+      await runConfigAndCloseBundle(plugin);
 
-    // Assert
-    expect(buildServerImportSpy).toHaveBeenCalledWith(
-      {},
-      expect.objectContaining({
-        output: {
-          dir: '/custom-root-directory/dist/analog',
-          publicDir: '/custom-root-directory/dist/analog/public',
-        },
-      })
-    );
-  });
+      // Assert
+      expect(buildServerImportSpy).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          output: {
+            dir: '/custom-root-directory/dist/analog',
+            publicDir: '/custom-root-directory/dist/analog/public',
+          },
+        })
+      );
+    });
 
-  it('should use the .vercel output paths when preset is vercel', async () => {
-    // Arrange
-    vi.mock('process');
-    process.cwd = vi.fn().mockReturnValue('/custom-root-directory');
-    const { buildServerImportSpy } = await mockBuildFunctions();
+    it('should use the .vercel output paths when preset is vercel', async () => {
+      // Arrange
+      vi.mock('process');
+      process.cwd = vi.fn().mockReturnValue('/custom-root-directory');
+      const { buildServerImportSpy } = await mockBuildFunctions();
 
-    const plugin = nitro({}, { preset: 'vercel' });
+      const plugin = nitro({}, { preset: 'vercel' });
 
-    // Act
-    await runConfigAndCloseBundle(plugin);
+      // Act
+      await runConfigAndCloseBundle(plugin);
 
-    // Assert
-    expect(buildServerImportSpy).toHaveBeenCalledWith(
-      {},
-      expect.objectContaining({
-        output: {
-          dir: '/custom-root-directory/.vercel/output',
-          publicDir: '/custom-root-directory/.vercel/output/static',
-        },
-      })
-    );
-  });
+      // Assert
+      expect(buildServerImportSpy).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          output: {
+            dir: '/custom-root-directory/.vercel/output',
+            publicDir: '/custom-root-directory/.vercel/output/static',
+          },
+        })
+      );
+    });
 
-  it('should use the .vercel output paths when preset is vercel-edge', async () => {
-    // Arrange
-    vi.mock('process');
-    process.cwd = vi.fn().mockReturnValue('/custom-root-directory');
-    const { buildServerImportSpy } = await mockBuildFunctions();
+    it('should use the .vercel output paths when preset is vercel-edge', async () => {
+      // Arrange
+      vi.mock('process');
+      process.cwd = vi.fn().mockReturnValue('/custom-root-directory');
+      const { buildServerImportSpy } = await mockBuildFunctions();
 
-    const plugin = nitro({}, { preset: 'vercel-edge' });
+      const plugin = nitro({}, { preset: 'vercel-edge' });
 
-    // Act
-    await runConfigAndCloseBundle(plugin);
+      // Act
+      await runConfigAndCloseBundle(plugin);
 
-    // Assert
-    expect(buildServerImportSpy).toHaveBeenCalledWith(
-      {},
-      expect.objectContaining({
-        output: {
-          dir: '/custom-root-directory/.vercel/output',
-          publicDir: '/custom-root-directory/.vercel/output/static',
-        },
-      })
-    );
+      // Assert
+      expect(buildServerImportSpy).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          output: {
+            dir: '/custom-root-directory/.vercel/output',
+            publicDir: '/custom-root-directory/.vercel/output/static',
+          },
+        })
+      );
+    });
+
+    it('should use the .vercel output paths when preset is VERCEL environment variable is set', async () => {
+      // Arrange
+      vi.stubEnv('VERCEL', '1');
+      vi.mock('process');
+      process.cwd = vi.fn().mockReturnValue('/custom-root-directory');
+      const { buildServerImportSpy } = await mockBuildFunctions();
+
+      const plugin = nitro({}, {});
+
+      // Act
+      await runConfigAndCloseBundle(plugin);
+
+      // Assert
+      expect(buildServerImportSpy).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          output: {
+            dir: '/custom-root-directory/.vercel/output',
+            publicDir: '/custom-root-directory/.vercel/output/static',
+          },
+        })
+      );
+    });
   });
 });

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
@@ -34,8 +34,11 @@ describe('nitro', () => {
 
   it('should build the server with prerender route "/" if nothing was provided', async () => {
     // Arrange
-    const [buildSSRAppImportSpy, buildServerImportSpy, buildSitemapImportSpy] =
-      await mockBuildFunctions();
+    const {
+      buildSSRAppImportSpy,
+      buildServerImportSpy,
+      buildSitemapImportSpy,
+    } = await mockBuildFunctions();
     const plugin = nitro({
       ssr: true,
     });
@@ -59,8 +62,11 @@ describe('nitro', () => {
 
   it('should build the server with prerender route "/" even if ssr is false', async () => {
     // Arrange
-    const [buildSSRAppImportSpy, buildServerImportSpy, buildSitemapImportSpy] =
-      await mockBuildFunctions();
+    const {
+      buildSSRAppImportSpy,
+      buildServerImportSpy,
+      buildSitemapImportSpy,
+    } = await mockBuildFunctions();
     const plugin = nitro({
       ssr: false,
     });
@@ -84,12 +90,15 @@ describe('nitro', () => {
 
   it('should build the server without prerender route when an empty array was passed', async () => {
     // Arrange
-    const [buildSSRAppImportSpy, buildServerImportSpy, buildSitemapImportSpy] =
-      await mockBuildFunctions();
+    const {
+      buildSSRAppImportSpy,
+      buildServerImportSpy,
+      buildSitemapImportSpy,
+    } = await mockBuildFunctions();
     const prerenderRoutes = {
       prerender: {
         routes: [],
-        sitemap: { domain: 'example.com' },
+        sitemap: { host: 'example.com' },
       },
     };
     const plugin = nitro({
@@ -115,19 +124,22 @@ describe('nitro', () => {
     );
     expect(buildSitemapImportSpy).toHaveBeenCalledWith(
       {},
-      { domain: 'example.com' },
+      { host: 'example.com' },
       prerenderRoutes.prerender.routes
     );
   });
 
   it('should build the server with provided routes', async () => {
     // Arrange
-    const [buildSSRAppImportSpy, buildServerImportSpy, buildSitemapImportSpy] =
-      await mockBuildFunctions();
+    const {
+      buildSSRAppImportSpy,
+      buildServerImportSpy,
+      buildSitemapImportSpy,
+    } = await mockBuildFunctions();
     const prerenderRoutes = {
       prerender: {
         routes: ['/blog', '/about'],
-        sitemap: { domain: 'example.com' },
+        sitemap: { host: 'example.com' },
       },
     };
     const plugin = nitro({
@@ -158,8 +170,77 @@ describe('nitro', () => {
 
     expect(buildSitemapImportSpy).toHaveBeenCalledWith(
       {},
-      { domain: 'example.com' },
+      { host: 'example.com' },
       prerenderRoutes.prerender.routes
+    );
+  });
+
+  it('should use the analog output paths when preset is not vercel', async () => {
+    // Arrange
+    vi.mock('process');
+    process.cwd = vi.fn().mockReturnValue('/custom-root-directory');
+    const { buildServerImportSpy } = await mockBuildFunctions();
+
+    const plugin = nitro({}, {});
+
+    // Act
+    await runConfigAndCloseBundle(plugin);
+
+    // Assert
+    expect(buildServerImportSpy).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        output: {
+          dir: '/custom-root-directory/dist/analog',
+          publicDir: '/custom-root-directory/dist/analog/public',
+        },
+      })
+    );
+  });
+
+  it('should use the .vercel output paths when preset is vercel', async () => {
+    // Arrange
+    vi.mock('process');
+    process.cwd = vi.fn().mockReturnValue('/custom-root-directory');
+    const { buildServerImportSpy } = await mockBuildFunctions();
+
+    const plugin = nitro({}, { preset: 'vercel' });
+
+    // Act
+    await runConfigAndCloseBundle(plugin);
+
+    // Assert
+    expect(buildServerImportSpy).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        output: {
+          dir: '/custom-root-directory/.vercel/output',
+          publicDir: '/custom-root-directory/.vercel/output/static',
+        },
+      })
+    );
+  });
+
+  it('should use the .vercel output paths when preset is vercel-edge', async () => {
+    // Arrange
+    vi.mock('process');
+    process.cwd = vi.fn().mockReturnValue('/custom-root-directory');
+    const { buildServerImportSpy } = await mockBuildFunctions();
+
+    const plugin = nitro({}, { preset: 'vercel-edge' });
+
+    // Act
+    await runConfigAndCloseBundle(plugin);
+
+    // Assert
+    expect(buildServerImportSpy).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        output: {
+          dir: '/custom-root-directory/.vercel/output',
+          publicDir: '/custom-root-directory/.vercel/output/static',
+        },
+      })
     );
   });
 });

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -81,12 +81,8 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin {
         ],
       };
 
-      if (buildPreset && buildPreset.toLowerCase().includes('vercel')) {
-        nitroConfig = withVercelOutputAPI(
-          nitroConfig,
-          buildPreset,
-          workspaceRoot
-        );
+      if (isVercelPreset(buildPreset)) {
+        nitroConfig = withVercelOutputAPI(nitroConfig, workspaceRoot);
       }
 
       if (!ssrBuild && !isTest) {
@@ -204,9 +200,13 @@ function isEmptyPrerenderRoutes(options?: Options): boolean {
 function isArrayWithElements<T>(arr: unknown): arr is [T, ...T[]] {
   return !!(Array.isArray(arr) && arr.length);
 }
+
+const isVercelPreset = (buildPreset: string | undefined) =>
+  process.env['VERCEL'] ||
+  (buildPreset && buildPreset.toLowerCase().includes('vercel'));
+
 const withVercelOutputAPI = (
   nitroConfig: NitroConfig | undefined,
-  buildPreset: string,
   workspaceRoot: string
 ) => ({
   ...nitroConfig,

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -33,11 +33,15 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin {
       ssrBuild = _config.build?.ssr === true;
       config = _config;
       const rootDir = config.root || '.';
+      const buildPreset =
+        process.env['BUILD_PRESET'] ??
+        (nitroOptions?.preset as string | undefined);
 
-      let pageHandlers = getPageHandlers({ workspaceRoot, rootDir });
+      const pageHandlers = getPageHandlers({ workspaceRoot, rootDir });
 
       nitroConfig = {
         rootDir,
+        preset: buildPreset,
         logLevel: nitroOptions?.logLevel || 0,
         srcDir: normalizePath(`${rootDir}/src/server`),
         scanDirs: [normalizePath(`${rootDir}/src/server`)],
@@ -76,6 +80,14 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin {
           ...pageHandlers,
         ],
       };
+
+      if (buildPreset && buildPreset.toLowerCase().includes('vercel')) {
+        nitroConfig = withVercelOutputAPI(
+          nitroConfig,
+          buildPreset,
+          workspaceRoot
+        );
+      }
 
       if (!ssrBuild && !isTest) {
         // store the client output path for the SSR build config
@@ -192,3 +204,17 @@ function isEmptyPrerenderRoutes(options?: Options): boolean {
 function isArrayWithElements<T>(arr: unknown): arr is [T, ...T[]] {
   return !!(Array.isArray(arr) && arr.length);
 }
+const withVercelOutputAPI = (
+  nitroConfig: NitroConfig | undefined,
+  buildPreset: string,
+  workspaceRoot: string
+) => ({
+  ...nitroConfig,
+  output: {
+    ...nitroConfig?.output,
+    dir: normalizePath(path.resolve(workspaceRoot, '.vercel', 'output')),
+    publicDir: normalizePath(
+      path.resolve(workspaceRoot, '.vercel', 'output/static')
+    ),
+  },
+});


### PR DESCRIPTION
we change the output paths to be in a .vercel folder at the root of the workspace. this allows for zero config to be necessary when deploying analog with vercel

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Need to manually adjust the build output for Vercel preset to use .vercel output API

Closes #491

## What is the new behavior?

Vercel presets work with 0 additional config necessary.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

![Magic](https://media1.giphy.com/media/NmerZ36iBkmKk/giphy.gif?cid=ecf05e47u9wn7e300m2ywja73yamwyqa5qf5l7b6t1zacvex&ep=v1_gifs_search&rid=giphy.gif&ct=g)