### PR TITLE
fix(create-analog): restrain node 16 to `16.17`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prettify": "prettier --write ."
   },
   "engines": {
-    "node": "^16.14.0 || >=18.10.0",
+    "node": "~16.17.0 || >=18.13.0",
     "pnpm": "^8.0.0"
   },
   "packageManager": "pnpm@8.0.0",

--- a/packages/create-analog/package.json
+++ b/packages/create-analog/package.json
@@ -15,7 +15,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": "^16.14.0 || >=18.10.0"
+    "node": "~16.17.0 || >=18.13.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Using `16.18` & `16.19` breaks Analog, let's retrains the version to the latest working Node16: `16.17`

Fixes #532