### PR TITLE
fix(vite-plugin-angular): do not execute hot module update if host is not set

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -169,6 +169,14 @@ export function angular(options?: PluginOptions): Plugin[] {
         await buildAndAnalyze();
       },
       async handleHotUpdate(ctx) {
+        // The `handleHotUpdate` hook may be called before the `buildStart`,
+        // which sets the compilation. As a result, the `host` may not be available
+        // yet for use, leading to build errors such as "cannot read properties of undefined"
+        // (because `host` is undefined).
+        if (!host) {
+          return;
+        }
+
         if (TS_EXT_REGEX.test(ctx.file)) {
           sourceFileCache.invalidate([ctx.file.replace(/\?(.*)/, '')]);
           await buildAndAnalyze();


### PR DESCRIPTION
This commit updates the implementation of the `handleHotUpdate` Vite plugin hook and includes a check to return if the `host` is not set. The `handleHotUpdate` hook may be called before the `buildStart` hook, which sets the compilation and the compiler host.

I've been having this error frequently:

![Screenshot from 2023-07-23 20-59-40](https://github.com/analogjs/analog/assets/7337691/50b40af8-b2d8-4985-bda3-781d2d9a99a9)
