### PR TITLE
fix(nx-plugin): add linter dependency for nx app generator, preset

### DIFF
--- a/packages/nx-plugin/src/generators/app/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/app/generator.spec.ts
@@ -41,6 +41,9 @@ describe('nx-plugin generator', () => {
 
     expect(devDependencies['@nx/devkit']).toBe('~16.0.0');
     expect(devDependencies['@nx/angular']).toBe('~16.0.0');
+    // we just check for truthy because @nx/linter generator
+    // will install the correct version based on Nx version
+    expect(devDependencies['@nx/linter']).toBeTruthy();
     expect(devDependencies['@analogjs/platform']).toBe('0.1.0-beta.22');
     expect(devDependencies['@analogjs/vite-plugin-angular']).toBe(
       '0.2.0-alpha.29'
@@ -69,6 +72,9 @@ describe('nx-plugin generator', () => {
 
     expect(devDependencies['@nx/devkit']).toBe('^16.4.0');
     expect(devDependencies['@nx/angular']).toBe('^16.4.0');
+    // we just check for truthy because @nx/linter generator
+    // will install the correct version based on Nx version
+    expect(devDependencies['@nx/linter']).toBeTruthy();
     expect(devDependencies['@analogjs/platform']).toBe('^0.2.0-beta.26');
     expect(devDependencies['@analogjs/vite-plugin-angular']).toBe(
       '^0.2.0-beta.26'

--- a/packages/nx-plugin/src/generators/app/lib/initialize-analog-workspace.ts
+++ b/packages/nx-plugin/src/generators/app/lib/initialize-analog-workspace.ts
@@ -58,6 +58,7 @@ const initWithNxNamespace = async (
   try {
     ensurePackage('@nx/devkit', versions['@nx/devkit']);
     ensurePackage('@nx/angular', versions['@nx/angular']);
+    ensurePackage('@nx/linter', versions['@nx/linter']);
   } catch {
     // @nx/angular cannot be required so this fails but this will still allow executing the nx angular init later on
   }
@@ -67,6 +68,7 @@ const initWithNxNamespace = async (
     {
       '@nx/devkit': versions['@nx/devkit'],
       '@nx/angular': versions['@nx/angular'],
+      '@nx/linter': versions['@nx/linter'],
     }
   );
 
@@ -94,6 +96,7 @@ const initWithNrwlNamespace = async (
   try {
     ensurePackage('@nrwl/devkit', versions['@nrwl/devkit']);
     ensurePackage('@nrwl/angular', versions['@nrwl/angular']);
+    ensurePackage('@nrwl/linter', versions['@nrwl/linter']);
   } catch {
     // @nx/angular cannot be required so this fails but this will still allow executing the nx angular init later on
   }
@@ -103,6 +106,7 @@ const initWithNrwlNamespace = async (
     {
       '@nrwl/devkit': versions['@nrwl/devkit'],
       '@nrwl/angular': versions['@nrwl/angular'],
+      '@nrwl/linter': versions['@nrwl/linter'],
     }
   );
   await (

--- a/packages/nx-plugin/src/generators/app/versions/nx-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx-dependencies.ts
@@ -1,14 +1,24 @@
 import { clean, lt } from 'semver';
 import { stripIndents } from '@nx/devkit';
-import { V16_X_NX_DEVKIT, V16_X_NX_ANGULAR } from './nx_16_X/versions';
+import {
+  V16_X_NX_DEVKIT,
+  V16_X_NX_ANGULAR,
+  V16_X_NX_LINTER,
+} from './nx_16_X/versions';
 import {
   V15_X_NRWL_DEVKIT,
   V15_X_NX_DEVKIT,
   V15_X_NRWL_ANGULAR,
   V15_X_NX_ANGULAR,
+  V15_X_NX_LINTER,
+  V15_X_NRWL_LINTER,
 } from './nx_15_X/versions';
 
-const nrwlDependencyKeys = ['@nrwl/devkit', '@nrwl/angular'] as const;
+const nrwlDependencyKeys = [
+  '@nrwl/devkit',
+  '@nrwl/angular',
+  '@nrwl/linter',
+] as const;
 export type NrwlDependency = (typeof nrwlDependencyKeys)[number];
 export const getNrwlDependencies = (
   nxVersion: string
@@ -27,6 +37,7 @@ export const getNrwlDependencies = (
     return {
       '@nrwl/angular': V15_X_NRWL_ANGULAR,
       '@nrwl/devkit': V15_X_NRWL_DEVKIT,
+      '@nrwl/linter': V15_X_NRWL_LINTER,
     };
   }
 
@@ -36,7 +47,7 @@ export const getNrwlDependencies = (
   );
 };
 
-const nxDependencyKeys = ['@nx/devkit', '@nx/angular'] as const;
+const nxDependencyKeys = ['@nx/devkit', '@nx/angular', '@nx/linter'] as const;
 export type NxDependency = (typeof nxDependencyKeys)[number];
 export const getNxDependencies = (
   nxVersion: string
@@ -55,6 +66,7 @@ export const getNxDependencies = (
     return {
       '@nx/angular': V15_X_NX_ANGULAR,
       '@nx/devkit': V15_X_NX_DEVKIT,
+      '@nx/linter': V15_X_NX_LINTER,
     };
   }
 
@@ -62,5 +74,6 @@ export const getNxDependencies = (
   return {
     '@nx/angular': V16_X_NX_ANGULAR,
     '@nx/devkit': V16_X_NX_DEVKIT,
+    '@nx/linter': V16_X_NX_LINTER,
   };
 };

--- a/packages/nx-plugin/src/generators/app/versions/nx_15_X/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx_15_X/versions.ts
@@ -18,6 +18,8 @@ export const V15_X_PRISMJS = '^1.29.0';
 
 // devDependencies
 export const V15_X_ANALOG_JS_PLATFORM = '0.1.0-beta.22';
+export const V15_X_NRWL_LINTER = '~15.9.0';
+export const V15_X_NX_LINTER = '~16.0.0';
 export const V15_X_NRWL_VITE = '~15.9.0';
 export const V15_X_NX_VITE = '~16.0.0';
 export const V15_X_JSDOM = '^20.0.0';

--- a/packages/nx-plugin/src/generators/app/versions/nx_16_X/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx_16_X/versions.ts
@@ -19,6 +19,7 @@ export const V16_X_PRISMJS = '^1.29.0';
 // devDependencies
 export const V16_X_ANALOG_JS_PLATFORM = '^0.2.0-beta.26';
 export const V16_X_NX_VITE = '^16.4.0';
+export const V16_X_NX_LINTER = '^16.4.0';
 export const V16_X_JSDOM = '^22.0.0';
 export const V16_X_VITE = '^4.3.9';
 export const V16_X_VITE_TSCONFIG_PATHS = '^4.2.0';


### PR DESCRIPTION
currently the preset fails due to the @nx/linter dependency missing. this adds the dependency.

closes #567

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [x] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

preset fails. is missing.

Closes #567 

## What is the new behavior?

@nx/linter or @nrwl/linter are included as dependencies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
![Gotta fix it](https://media4.giphy.com/media/PX1hquEJXf8XhW2c00/giphy.gif)
