### PR TITLE
fix(nx-plugin): remove dependency of nx-plugin to linter

### DIFF
--- a/packages/nx-plugin/src/generators/app/generator.ts
+++ b/packages/nx-plugin/src/generators/app/generator.ts
@@ -142,7 +142,7 @@ export async function appGenerator(
 
   addHomePage(tree, normalizedOptions);
 
-  await addEslint(tree, normalizedOptions);
+  await addEslint(tree, majorNxVersion, normalizedOptions);
 
   if (!normalizedOptions.skipFormat) {
     await formatFiles(tree);

--- a/packages/nx-plugin/src/generators/app/lib/add-eslint.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-eslint.ts
@@ -1,15 +1,33 @@
 import { Tree } from '@nx/devkit';
-import { Linter, lintProjectGenerator } from '@nx/linter';
 import { NormalizedOptions } from '../generator';
 
 export async function addEslint(
   tree: Tree,
+  majorNxVersion: number,
   options: NormalizedOptions
 ): Promise<void> {
-  await lintProjectGenerator(tree, {
-    linter: Linter.EsLint,
+  const linterOptions = {
+    // needed to not depend on linter package
+    linter: 'eslint' as any,
     project: options.projectName,
     eslintFilePatterns: [`${options.projectRoot}/**/*.{ts,html}`],
     skipFormat: true,
-  });
+  };
+  if (majorNxVersion === 16) {
+    await (
+      await import(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        '@nx/linter'
+      )
+    ).lintProjectGenerator(tree, linterOptions);
+  } else {
+    await (
+      await import(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        '@nrwl/linter'
+      )
+    ).lintProjectGenerator(tree, linterOptions);
+  }
 }


### PR DESCRIPTION
I barked up the wrong tree...
The issue stemmed from the nx-plugin being dependent on @nx/linter with the way it was set up. Instead, we are just creating a Nx workspace with the preset, which means the dependency is not installed. We need to import the @nx/linter dependency during runtime to avoid the preset to error out.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [x] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Even when forcing the @nx/linter dependency to be installed during the preset the execution fails. This is due to the nx-plugin having a direct
dependency on @nx/linter instead of importing it during runtime.
This time for real:

Closes #567

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I am not sure exactly how to add a test for this? 
I thought the e2e test would catch this but it seems like it did not and somehow resolved @nx/linter correctly?

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
![Sorry](https://media1.giphy.com/media/3oEjHZbxILEkHKyF7W/giphy.gif)