### PR TITLE
fix(vite-plugin-angular): remove caching of watched component templates

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -109,8 +109,6 @@ export function angular(options?: PluginOptions): Plugin[] {
   const templateUrlsResolver = new TemplateUrlsResolver();
 
   function angularPlugin(): Plugin {
-    const watchedFiles = new Set<string>();
-
     return {
       name: '@analogjs/vite-plugin-angular',
       async config(config, { command }) {
@@ -278,15 +276,6 @@ export function angular(options?: PluginOptions): Plugin[] {
               // absolute path using the `|` symbol.
               // For example: `./app.component.html|/home/projects/analog/src/app/app.component.html`.
               const [, absoluteFileUrl] = urlSet.split('|');
-              if (watchedFiles.has(absoluteFileUrl)) {
-                continue;
-              }
-              // Vite also has a set of internally watched files, but it doesn't check if the
-              // file is already watched when calling `ensureWatchedFile`. Vite uses the Rollup
-              // file watcher, which invokes system calls to the filesystem, such as `existsSync`,
-              // `resolve`, etc. Our local set ensures we don't trigger redudant system calls if
-              // the file is already watched.
-              watchedFiles.add(absoluteFileUrl);
               this.addWatchFile(absoluteFileUrl);
             }
           }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Caching the template watchers causes issues when the component has multiple templateUrls

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Page reloads happen when external templates are changed, whether it be single or multiple.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
