### PR TITLE
feat(content): add customFilename param to injectContent

### DIFF
--- a/apps/docs-app/docs/features/routing/content.md
+++ b/apps/docs-app/docs/features/routing/content.md
@@ -182,3 +182,15 @@ export default class ProjectComponent {
   });
 }
 ```
+
+## Loading Custom Content
+
+By default, Analog uses the route params to build the filename for retrieving a content file from the `src/content` folder. Analog also supports using a custom filename for retrieving content from the `src/content` folder. This can be useful if, for instance, you have a custom markdown file that you want to load on a page.
+
+The `injectContent()` function can be used by passing an object that contains the `customFilename` property.
+
+```ts
+readonly post$ = injectContent<ProjectAttributes>({
+  customFilename: 'path/to/custom/file',
+});
+```

--- a/packages/content/src/lib/content.ts
+++ b/packages/content/src/lib/content.ts
@@ -10,6 +10,52 @@ import { CONTENT_FILES_TOKEN } from './content-files-token';
 import { parseRawContentFile } from './parse-raw-content-file';
 import { waitFor } from './utils/zone-wait-for';
 
+function getContentFile<
+  Attributes extends Record<string, any> = Record<string, any>
+>(
+  contentFiles: Record<string, () => Promise<string>>,
+  prefix: string,
+  slug: string,
+  fallback: string
+): Observable<ContentFile<Attributes | Record<string, never>>> {
+  const filePath = `/src/content/${prefix}${slug}.md`;
+  const contentFile = contentFiles[filePath];
+  if (!contentFile) {
+    return of({
+      filename: filePath,
+      attributes: {},
+      slug: '',
+      content: fallback,
+    });
+  }
+
+  return new Observable<string>((observer) => {
+    const contentResolver = contentFile();
+
+    if (import.meta.env.SSR === true) {
+      waitFor(contentResolver).then((content) => {
+        observer.next(content);
+      });
+    } else {
+      contentResolver.then((content) => {
+        observer.next(content);
+      });
+    }
+  }).pipe(
+    map((rawContentFile) => {
+      const { content, attributes } =
+        parseRawContentFile<Attributes>(rawContentFile);
+
+      return {
+        filename: filePath,
+        slug,
+        attributes,
+        content,
+      };
+    })
+  );
+}
+
 /**
  * Retrieves the static content using the provided param and/or prefix.
  *
@@ -24,52 +70,44 @@ export function injectContent<
     | {
         param: string;
         subdirectory: string;
+      }
+    | {
+        customFilename: string;
       } = 'slug',
   fallback = 'No Content Found'
 ): Observable<ContentFile<Attributes | Record<string, never>>> {
-  const route = inject(ActivatedRoute);
   const contentFiles = inject(CONTENT_FILES_TOKEN);
-  const prefix = typeof param === 'string' ? '' : `${param.subdirectory}/`;
 
-  const paramKey = typeof param === 'string' ? param : param.param;
-  return route.paramMap.pipe(
-    map((params) => params.get(paramKey)),
-    switchMap((slug) => {
-      const filename = `/src/content/${prefix}${slug}.md`;
-      const contentFile = contentFiles[filename];
-
-      if (!contentFile) {
-        return of({
-          attributes: {},
-          filename: filename,
-          slug: slug || '',
-          content: fallback,
-        });
-      }
-
-      return new Promise<string>((resolve) => {
-        const contentResolver = contentFile();
-
-        if (import.meta.env.SSR === true) {
-          waitFor(contentResolver).then((content) => {
-            resolve(content);
-          });
+  if (typeof param === 'string' || 'param' in param) {
+    const prefix = typeof param === 'string' ? '' : `${param.subdirectory}/`;
+    const route = inject(ActivatedRoute);
+    const paramKey = typeof param === 'string' ? param : param.param;
+    return route.paramMap.pipe(
+      map((params) => params.get(paramKey)),
+      switchMap((slug) => {
+        if (slug) {
+          return getContentFile<Attributes>(
+            contentFiles,
+            prefix,
+            slug,
+            fallback
+          );
         } else {
-          contentResolver.then((content) => {
-            resolve(content);
+          return of({
+            filename: '',
+            slug: '',
+            attributes: {},
+            content: fallback,
           });
         }
-      }).then((rawContentFile) => {
-        const { content, attributes } =
-          parseRawContentFile<Attributes>(rawContentFile);
-
-        return {
-          filename,
-          slug: slug || '',
-          attributes,
-          content,
-        };
-      });
-    })
-  );
+      })
+    );
+  } else {
+    return getContentFile<Attributes>(
+      contentFiles,
+      '',
+      param.customFilename,
+      fallback
+    );
+  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [x] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #595

## What is the new behavior?

injectContent now supports a new argument { customFilename: string } that allows a hardcoded md file to be loaded from `/src/content`.

Example usage

```javascript
post$ = injectContent<PostAttributes>({ customFilename: 'index' });
```

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Previously, if `injectContent` was used but a slug is not present, it will default to use `null.md`. Now, not providing a slug will throw an Error. Although breaking, this does not seem like intended behavior anyways.

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
