### PR TITLE
fix(vite-plugin-nitro): pass public output path to sitemap builder

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/build-sitemap.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-sitemap.spec.ts
@@ -11,7 +11,7 @@ describe('build sitemap', () => {
 
   it('should not perform functionality if no predefined routes are present', () => {
     const spy = vi.spyOn(fs, 'writeFileSync');
-    buildSitemap(config, sitemapConfig, []);
+    buildSitemap(config, sitemapConfig, [], '');
 
     expect(spy).not.toHaveBeenCalled();
   });

--- a/packages/vite-plugin-nitro/src/lib/build-sitemap.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-sitemap.ts
@@ -13,7 +13,8 @@ export type PagesJson = {
 export async function buildSitemap(
   config: UserConfig,
   sitemapConfig: SitemapConfig,
-  routes: string[] | (() => Promise<(string | undefined)[]>)
+  routes: string[] | (() => Promise<(string | undefined)[]>),
+  outputDir: string
 ) {
   const routeList: string[] = await optionHasRoutes(routes);
 
@@ -32,11 +33,7 @@ export async function buildSitemap(
       page.ele('lastmod').txt(item.lastMod);
     }
 
-    const mapPath = `${path.resolve(
-      'dist',
-      config.root || '.',
-      'analog/public'
-    )}/sitemap.xml`;
+    const mapPath = `${path.resolve(outputDir)}/sitemap.xml`;
     try {
       console.log(`Writing sitemap at ${mapPath}`);
       fs.writeFileSync(mapPath, sitemap.end({ prettyPrint: true }));

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
@@ -125,7 +125,8 @@ describe('nitro', () => {
     expect(buildSitemapImportSpy).toHaveBeenCalledWith(
       {},
       { host: 'example.com' },
-      prerenderRoutes.prerender.routes
+      prerenderRoutes.prerender.routes,
+      expect.anything()
     );
   });
 
@@ -171,7 +172,8 @@ describe('nitro', () => {
     expect(buildSitemapImportSpy).toHaveBeenCalledWith(
       {},
       { host: 'example.com' },
-      prerenderRoutes.prerender.routes
+      prerenderRoutes.prerender.routes,
+      expect.anything()
     );
   });
 

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -184,7 +184,8 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
             await buildSitemap(
               config,
               options.prerender.sitemap,
-              options.prerender.routes!
+              options.prerender.routes!,
+              nitroConfig.output?.publicDir!
             );
           }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

When building the sitemap, the output directory uses a standard path. This would fail on Vercel as it outputs to a top-level directory.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When building the sitemap, the output directory uses public output path. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/cjbfyJrICOaKIXBWyG/giphy.gif"/>