### PR TITLE
fix(nx-plugin): don't hardcode trpc url to http://127.0.0.1:4200

### DIFF
--- a/packages/nx-plugin/src/generators/app/files/trpc/src/trpc-client.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/trpc/src/trpc-client.ts__template__
@@ -3,7 +3,7 @@ import { createTrpcClient } from '@analogjs/trpc';
 import { inject } from '@angular/core';
 
 export const { provideTrpcClient, TrpcClient } = createTrpcClient<AppRouter>({
-  url: 'http://127.0.0.1:4200/api/trpc',
+  url: 'api/trpc',
 });
 
 export function injectTrpcClient() {


### PR DESCRIPTION
Hardcoding the trpc url+port will lead to errors when building or deploying the application

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [x] nx-plugin
- [ ] trpc

## What is the current behavior?

When building a default analogjs application with trpc, the client can't connect to the server after building because the server is configured to run on port 3000 and not on the hardcoded 4200.

## What is the new behavior?

The client will now connect to `api/trpc` independently of where it runs, (http://localhost:3000, https://app.example.com)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
