### PR TITLE
feat(vite-plugin-nitro): add server event to load function and types

### DIFF
--- a/apps/analog-app/src/app/pages/(home).server.ts
+++ b/apps/analog-app/src/app/pages/(home).server.ts
@@ -1,8 +1,10 @@
+import { setCookie } from 'h3';
 import { PageServerLoad } from '@analogjs/router';
 
 import { Product } from '../products';
 
-export const load = async ({ fetch }: PageServerLoad) => {
+export const load = async ({ fetch, event }: PageServerLoad) => {
+  setCookie(event, 'test', 'test');
   const products = await fetch<Product[]>('/api/v1/products');
 
   return {

--- a/apps/analog-app/src/app/pages/shipping/index.server.ts
+++ b/apps/analog-app/src/app/pages/shipping/index.server.ts
@@ -1,5 +1,12 @@
-export const load = async () => {
+import { parseCookies } from 'h3';
+import { PageServerLoad } from '@analogjs/router';
+
+export const load = async ({ event }: PageServerLoad) => {
   console.log('shipping');
+  const cookies = parseCookies(event);
+
+  console.log('test cookie', cookies['test']);
+
   return {
     shipping: true,
   };

--- a/packages/router/src/lib/route-types.ts
+++ b/packages/router/src/lib/route-types.ts
@@ -1,11 +1,12 @@
 import type { H3Event, H3EventContext } from 'h3';
-import { $Fetch } from 'nitropack';
+import type { $Fetch } from 'nitropack';
 
 export type PageServerLoad = {
   params: H3EventContext['params'];
   req: H3Event['node']['req'];
   res: H3Event['node']['res'];
   fetch: $Fetch;
+  event: H3Event;
 };
 
 export type LoadResult<

--- a/packages/vite-plugin-nitro/src/lib/plugins/page-endpoints.ts
+++ b/packages/vite-plugin-nitro/src/lib/plugins/page-endpoints.ts
@@ -49,7 +49,8 @@ export function pageEndpointsPlugin() {
                   params: event.context.params,
                   req: event.node.req,
                   res: event.node.res,
-                  fetch: $fetch
+                  fetch: $fetch,
+                  event
                 });
               } catch(e) {
                 console.error(\` An error occurred: \$\{e\}\`)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [x] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Access to the `event` object from H3 is not available in the `load` function

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #606

## What is the new behavior?

Access to the `event` object from H3 is available in the `load` function. This allows you to set/read cookies, form data, and access other information derived from the event.

```ts
import { PageServerLoad } from '@analogjs/router';
import { parseCookies } from 'h3';

export function load({ event }: PageServerLoad) {
  const cookies = parseCookies(event);
  console.log('cookies', cookies);

  return {
    loaded: true,
  };
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/xT9C25UNTwfZuk85WP/giphy-downsized-medium.gif"/>
