### PR TITLE
fix(nx-plugin): normalize outputs for standalone Nx projects

### DIFF
--- a/packages/nx-plugin/src/generators/app/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/app/generator.spec.ts
@@ -14,9 +14,12 @@ import { test } from 'vitest';
 describe('nx-plugin generator', () => {
   const setup = async (
     options: AnalogNxApplicationGeneratorOptions,
-    nxVersion = '16.1.0'
+    nxVersion = '16.1.0',
+    standalone = false
   ) => {
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const tree = createTreeWithEmptyWorkspace(
+      standalone ? {} : { layout: 'apps-libs' }
+    );
     addDependenciesToPackageJson(tree, {}, { nx: nxVersion });
     await generator(tree, options);
     const config = readProjectConfiguration(tree, options.analogAppName);
@@ -86,17 +89,44 @@ describe('nx-plugin generator', () => {
     expect(devDependencies['vitest']).toBe('^0.32.2');
   };
 
-  const verifyConfig = (config: ProjectConfiguration, name: string) => {
+  const verifyConfig = (
+    config: ProjectConfiguration,
+    name: string,
+    standalone = false
+  ) => {
     expect(config.projectType).toBe('application');
-    expect(config.root).toBe('apps/' + name);
+    expect(config.root).toBe(standalone ? name : 'apps/' + name);
+    const outputs = standalone
+      ? [
+          '{options.outputPath}',
+          `dist/${name}/.nitro`,
+          `dist/${name}/ssr`,
+          `dist/${name}/analog`,
+        ]
+      : [
+          '{options.outputPath}',
+          `dist/apps/${name}/.nitro`,
+          `dist/apps/${name}/ssr`,
+          `dist/apps/${name}/analog`,
+        ];
+    expect(config.targets.build.outputs).toStrictEqual(outputs);
+    expect(config.targets.test.outputs).toStrictEqual(
+      standalone ? [`${name}/coverage`] : [`apps/${name}/coverage`]
+    );
   };
 
-  const verifyHomePageExists = (tree: Tree, appName: string) => {
+  const verifyHomePageExists = (
+    tree: Tree,
+    appName: string,
+    standalone = false
+  ) => {
     const hasHomePageFile = tree.exists(
-      `apps/${appName}/src/app/pages/(home).page.ts`
+      `${standalone ? '' : 'apps/'}${appName}/src/app/pages/(home).page.ts`
     );
     const hasWelcomeComponentFile = tree.exists(
-      `apps/${appName}/src/app/pages/analog-welcome.component.ts`
+      `${
+        standalone ? '' : 'apps/'
+      }${appName}/src/app/pages/analog-welcome.component.ts`
     );
     expect(hasHomePageFile).toBeTruthy();
     expect(hasWelcomeComponentFile).toBeTruthy();
@@ -185,6 +215,20 @@ describe('nx-plugin generator', () => {
       verifyConfig(config, analogAppName);
 
       verifyHomePageExists(tree, analogAppName);
+
+      verifyEslint(tree, config, devDependencies);
+    });
+
+    it('creates a default standalone analogjs app in the source directory', async () => {
+      const analogAppName = 'analog';
+      const { config, tree } = await setup({ analogAppName }, '16.1.0', true);
+      const { dependencies, devDependencies } = readJson(tree, 'package.json');
+
+      verifyCoreDependenciesAngularV16_X(dependencies, devDependencies);
+
+      verifyConfig(config, analogAppName, true);
+
+      verifyHomePageExists(tree, analogAppName, true);
 
       verifyEslint(tree, config, devDependencies);
     });

--- a/packages/nx-plugin/src/generators/app/lib/add-analog-project-config.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-analog-project-config.ts
@@ -10,6 +10,8 @@ export function addAnalogProjectConfig(
   appsDir: string,
   nxPackageNamespace: string
 ) {
+  const isStandalone = appsDir === '.';
+  const workspaceAppsDir = isStandalone ? '' : `${appsDir}/`;
   const projectConfiguration: ProjectConfiguration = {
     root: projectRoot,
     projectType: 'application',
@@ -19,14 +21,14 @@ export function addAnalogProjectConfig(
         executor: `${nxPackageNamespace}/vite:build`,
         outputs: [
           '{options.outputPath}',
-          `dist/${appsDir}/${projectName}/.nitro`,
-          `dist/${appsDir}/${projectName}/ssr`,
-          `dist/${appsDir}/${projectName}/analog`,
+          `dist/${workspaceAppsDir}${projectName}/.nitro`,
+          `dist/${workspaceAppsDir}${projectName}/ssr`,
+          `dist/${workspaceAppsDir}${projectName}/analog`,
         ],
         options: {
-          main: `${appsDir}/${projectName}/src/main.ts`,
-          configFile: `${appsDir}/${projectName}/vite.config.ts`,
-          outputPath: `dist/${appsDir}/${projectName}/client`,
+          main: `${workspaceAppsDir}${projectName}/src/main.ts`,
+          configFile: `${workspaceAppsDir}${projectName}/vite.config.ts`,
+          outputPath: `dist/${workspaceAppsDir}${projectName}/client`,
         },
         defaultConfiguration: 'production',
         configurations: {
@@ -64,7 +66,7 @@ export function addAnalogProjectConfig(
       },
       test: {
         executor: `${nxPackageNamespace}/vite:test`,
-        outputs: [`${appsDir}/${projectName}/coverage`],
+        outputs: [`${workspaceAppsDir}${projectName}/coverage`],
       },
     },
     tags: parsedTags,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [x] nx-plugin
- [ ] trpc

## What is the current behavior?

The `outputs` array for a standalone project contains a period for each path. This now triggers a validation error with Nx.

Example: `dist/./analog-app/ssr`

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The `outputs` array for a standalone project does not contain a period for each path

Example: `dist/analog-app/ssr`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/U7isUDZ6VPWJW/giphy.gif"/>
