### PR TITLE
feat(astro-angular): implement output forwarding on client-side hydrated components

### DIFF
--- a/apps/astro-app-e2e-playwright/tests/app.spec.ts
+++ b/apps/astro-app-e2e-playwright/tests/app.spec.ts
@@ -46,5 +46,27 @@ describe('AstroApp', () => {
         componentLocator.locator('>> text=Angular (server side binding)')
       ).toContain(/Angular \(server side binding\)/i);
     });
+
+    test('Then client side rendered CardComponent should emit an event on click', async () => {
+      const console = waitForConsole();
+      const componentLocator = page.locator(
+        'astro-island[component-export="CardComponent"]'
+        // '[data-analog-id=card-1]'
+      );
+      const elementLocator = componentLocator.locator('li');
+      await elementLocator.click();
+
+      await expect(await console).toBe('event received from card-1: clicked');
+    }, 1000000);
   });
 });
+
+async function waitForConsole(): Promise<string> {
+  return new Promise(function (resolve) {
+    page.on('console', (msg) => {
+      if (msg.type() === 'log') {
+        resolve(msg.text());
+      }
+    });
+  });
+}

--- a/apps/astro-app-e2e-playwright/tests/app.spec.ts
+++ b/apps/astro-app-e2e-playwright/tests/app.spec.ts
@@ -57,7 +57,7 @@ describe('AstroApp', () => {
       await elementLocator.click();
 
       await expect(await console).toBe('event received from card-1: clicked');
-    }, 1000000);
+    });
   });
 });
 

--- a/apps/astro-app-e2e-playwright/tests/app.spec.ts
+++ b/apps/astro-app-e2e-playwright/tests/app.spec.ts
@@ -50,13 +50,14 @@ describe('AstroApp', () => {
     test('Then client side rendered CardComponent should emit an event on click', async () => {
       const console = waitForConsole();
       const componentLocator = page.locator(
-        'astro-island[component-export="CardComponent"]'
-        // '[data-analog-id=card-1]'
+        '[data-analog-id=card-component-1]'
       );
       const elementLocator = componentLocator.locator('li');
       await elementLocator.click();
 
-      await expect(await console).toBe('event received from card-1: clicked');
+      await expect(await console).toBe(
+        'event received from card-component-1: clicked'
+      );
     });
   });
 });

--- a/apps/astro-app/src/components/card.component.ts
+++ b/apps/astro-app/src/components/card.component.ts
@@ -1,8 +1,10 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  EventEmitter,
   inject,
   Input,
+  Output,
   ViewEncapsulation,
 } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
@@ -12,7 +14,7 @@ import { HttpClient, provideHttpClient } from '@angular/common/http';
   selector: 'astro-card',
   standalone: true,
   template: `
-    <li class="link-card">
+    <li class="link-card" (click)="onClick()">
       <a [href]="href">
         <h2>
           {{ title }}
@@ -93,9 +95,14 @@ export class CardComponent {
   @Input() href = '';
   @Input() title = '';
   @Input() body = '';
+  @Output() output = new EventEmitter<string>();
 
   static renderProviders = [provideHttpClient()];
   static clientProviders = [CardComponent.renderProviders, provideAnimations()];
 
   private _http = inject(HttpClient);
+
+  onClick() {
+    this.output.emit('clicked');
+  }
 }

--- a/apps/astro-app/src/pages/index.astro
+++ b/apps/astro-app/src/pages/index.astro
@@ -35,6 +35,7 @@ const serverSideTitle = 'Angular (server side binding)';
 			/>
 			<CardComponent
         client:visible
+        data-analog-id="card-1"
         href="https://angular.io/"
         title="Angular (Client Side)"
         body="Build with Angular. ❤️"
@@ -111,5 +112,10 @@ const serverSideTitle = 'Angular (server side binding)';
 </style>
 
 <script>
-	console.log('Hello Astro');
+  import { addAnalogOutputListener } from '@analogjs/astro-angular/utils';
+  console.log('Hello Astro');
+
+  addAnalogOutputListener('card-1', 'output', (event) => {
+    console.log('event received from card-1:', event.detail);
+  });
 </script>

--- a/apps/astro-app/src/pages/index.astro
+++ b/apps/astro-app/src/pages/index.astro
@@ -35,7 +35,7 @@ const serverSideTitle = 'Angular (server side binding)';
 			/>
 			<CardComponent
         client:visible
-        data-analog-id="card-1"
+        data-analog-id="card-component-1"
         href="https://angular.io/"
         title="Angular (Client Side)"
         body="Build with Angular. ❤️"
@@ -112,10 +112,10 @@ const serverSideTitle = 'Angular (server side binding)';
 </style>
 
 <script>
-  import { addAnalogOutputListener } from '@analogjs/astro-angular/utils';
+  import { addOutputListener } from '@analogjs/astro-angular/utils';
   console.log('Hello Astro');
 
-  addAnalogOutputListener('card-1', 'output', (event) => {
-    console.log('event received from card-1:', event.detail);
+  addOutputListener('card-component-1', 'output', (event) => {
+    console.log('event received from card-component-1:', event.detail);
   });
 </script>

--- a/packages/astro-angular/README.md
+++ b/packages/astro-angular/README.md
@@ -174,7 +174,7 @@ export class HelloComponent {
 
 Add the Angular component to the Astro component template. This only renders the HTML from the Angular component.
 
-```ts
+```tsx
 ---
 import { HelloComponent } from '../components/hello.component';
 
@@ -188,7 +188,7 @@ const helpText = "Helping binding";
 
 To hydrate the component on the client, use one of the Astro [client directives](https://docs.astro.build/en/reference/directives-reference/#client-directives):
 
-```ts
+```tsx
 ---
 import { HelloComponent } from '../components/hello.component';
 ---
@@ -197,6 +197,37 @@ import { HelloComponent } from '../components/hello.component';
 ```
 
 Find more information about [Client Directives](https://docs.astro.build/en/reference/directives-reference/#client-directives) in the Astro documentation.
+
+### Listening to Component Outputs
+
+Outputs can be emitted by the Angular component are forwarded as HTML events to the Astro island.
+To enable this feature, add a client directive and a `[data-analog-id]` property to the Angular component:
+
+```tsx
+---
+import { HelloComponent } from '../components/hello.component';
+---
+
+<HelloComponent client:visible data-analog-id="hello-1" />
+```
+
+Then, listen to the event in the Astro component using the `addAnalogOutputListener` function:
+
+```tsx
+---
+import { HelloComponent } from '../components/hello.component';
+---
+
+<HelloComponent client:visible data-analog-id="hello-1" />
+
+<script>
+  import { addAnalogOutputListener } from '@analogjs/astro-angular/utils';
+
+  addAnalogOutputListener('hello-1', 'outputName', (event) => {
+    console.log(event.detail);
+  });
+</script>
+```
 
 ## Adding Component Providers
 
@@ -295,4 +326,3 @@ import { HelloComponent } from "../../components/hello.component.ts";
 ## Current Limitations
 
 - Only standalone Angular components in version v14.2+ are supported
-- Component Outputs are not supported

--- a/packages/astro-angular/README.md
+++ b/packages/astro-angular/README.md
@@ -201,29 +201,29 @@ Find more information about [Client Directives](https://docs.astro.build/en/refe
 ### Listening to Component Outputs
 
 Outputs can be emitted by the Angular component are forwarded as HTML events to the Astro island.
-To enable this feature, add a client directive and a `[data-analog-id]` property to the Angular component:
+To enable this feature, add a client directive and a unique `[data-analog-id]` property to each Angular component:
 
 ```tsx
 ---
 import { HelloComponent } from '../components/hello.component';
 ---
 
-<HelloComponent client:visible data-analog-id="hello-1" />
+<HelloComponent client:visible data-analog-id="hello-component-1" />
 ```
 
-Then, listen to the event in the Astro component using the `addAnalogOutputListener` function:
+Then, listen to the event in the Astro component using the `addOutputListener` function:
 
 ```tsx
 ---
 import { HelloComponent } from '../components/hello.component';
 ---
 
-<HelloComponent client:visible data-analog-id="hello-1" />
+<HelloComponent client:visible data-analog-id="hello-component-1" />
 
 <script>
-  import { addAnalogOutputListener } from '@analogjs/astro-angular/utils';
+  import { addOutputListener } from '@analogjs/astro-angular/utils';
 
-  addAnalogOutputListener('hello-1', 'outputName', (event) => {
+  addOutputListener('hello-component-1', 'outputName', (event) => {
     console.log(event.detail);
   });
 </script>

--- a/packages/astro-angular/package.json
+++ b/packages/astro-angular/package.json
@@ -6,6 +6,7 @@
   "author": "Brandon Roberts <robertsbt@gmail.com>",
   "exports": {
     ".": "./src/index.js",
+    "./utils": "./src/utils.js",
     "./client.js": "./src/client.js",
     "./server.js": "./src/server.js",
     "./package.json": "./package.json"

--- a/packages/astro-angular/src/client.ts
+++ b/packages/astro-angular/src/client.ts
@@ -45,16 +45,29 @@ export default (element: HTMLElement) => {
 
         if (mirror?.outputs.length && props?.['data-analog-id']) {
           const destroyRef = appRef.injector.get(DestroyRef);
-          element.setAttribute('data-analog-id', props['data-analog-id'] as string);
+          element.setAttribute(
+            'data-analog-id',
+            props['data-analog-id'] as string
+          );
 
           mirror.outputs.forEach(({ templateName, propName }) => {
             const outputName = templateName || propName;
-            const component = componentRef.instance as Record<string, Observable<unknown>>;
-            component[outputName].pipe(takeUntilDestroyed(destroyRef)).subscribe((detail) => {
-              const event = new CustomEvent(outputName, { bubbles: true, cancelable: true, composed: true, detail });
-              element.dispatchEvent(event);
-            })
-          })
+            const component = componentRef.instance as Record<
+              string,
+              Observable<unknown>
+            >;
+            component[outputName]
+              .pipe(takeUntilDestroyed(destroyRef))
+              .subscribe((detail) => {
+                const event = new CustomEvent(outputName, {
+                  bubbles: true,
+                  cancelable: true,
+                  composed: true,
+                  detail,
+                });
+                element.dispatchEvent(event);
+              });
+          });
         }
 
         appRef.attachView(componentRef.hostView);

--- a/packages/astro-angular/src/utils.ts
+++ b/packages/astro-angular/src/utils.ts
@@ -1,0 +1,21 @@
+export function addAnalogOutputListener(
+  analogId: string,
+  outputName: string,
+  callback: (...args: any[]) => unknown,
+  eventListenerOptions: EventListenerOptions = {}
+) {
+  const observer = new MutationObserver((mutations) => {
+    const foundTarget = mutations.find(
+      (mutation) =>
+        (mutation.target as HTMLElement).dataset?.['analogId'] === analogId
+    )?.target;
+
+    if (foundTarget) {
+      foundTarget.addEventListener(outputName, callback, eventListenerOptions);
+      observer.disconnect();
+    }
+  });
+  observer.observe(document.body, { attributes: true, subtree: true });
+
+  return () => observer.disconnect();
+}

--- a/packages/astro-angular/src/utils.ts
+++ b/packages/astro-angular/src/utils.ts
@@ -1,4 +1,4 @@
-export function addAnalogOutputListener(
+export function addOutputListener(
   analogId: string,
   outputName: string,
   callback: (...args: any[]) => unknown,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature
- [x] Documentation content changes

## Which package are you modifying?

- [x] astro-angular

## What is the current behavior?

Component outputs are currently not supported.

## What is the new behavior?

Outputs from client-side hydrated Components can be listened to as a custom event using an utility function.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
- Is `[data-analog-id]` the best property name for this?
- Are the caveats for making this work acceptable to release this feature? (only client-side, data attribute required, helper function to abstract some workarounds away)

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media3.giphy.com/media/l2Je0NtJ0UyUSKbe0/giphy.gif"/>