### PR TITLE
fix(vite-plugin-nitro): enable prerendering of root index.html

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/build-server.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-server.ts
@@ -1,4 +1,5 @@
 import { NitroConfig } from 'nitropack';
+import * as fs from 'fs';
 
 import { Options } from './options';
 import { addPostRenderingHooks } from './hooks/post-rendering-hook';
@@ -23,6 +24,16 @@ export async function buildServer(
 
   await prepare(nitro);
   await copyPublicAssets(nitro);
+
+  if (
+    nitroConfig?.prerender?.routes &&
+    nitroConfig?.prerender?.routes.find((route) => route === '/')
+  ) {
+    // Remove the root index.html so it can be replaced with the prerendered version
+    if (fs.existsSync(`${nitroConfig?.output?.publicDir}/index.html`)) {
+      fs.unlinkSync(`${nitroConfig?.output?.publicDir}/index.html`);
+    }
+  }
 
   console.log(`Prerendering static pages...`);
   await prerender(nitro);

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -168,7 +168,6 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
             ...nitroConfig,
           });
           const server = createDevServer(nitro);
-          await prepare(nitro);
           await build(nitro);
           viteServer.middlewares.use(apiPrefix, toNodeListener(server.app));
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

The root `index.html` is not prerendering unless `nitro: { serveStatic: false }` is set in the analog plugin. This prevents retrieving static assets during pre-rendering if needed.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #585

## What is the new behavior?

The root `index.html` is pre-rendered with the `serveStatic` option still being enabled if its included in the prerender routes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/lnd23r2VhqsJhSRyLT/giphy-downsized-medium.gif"/>
