### PR TITLE
fix(docs): simplify npm start command

### DIFF
--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/getting-started.md
@@ -54,7 +54,7 @@ Para iniciar el servidor de desarrollo para la aplicación, ejecuta el comando `
   <TabItem value="npm">
 
 ```shell
-npm run start
+npm start
 ```
 
   </TabItem>


### PR DESCRIPTION
`run` is not required in `npm run start` https://docs.npmjs.com/cli/v10/commands/npm-start

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media1.giphy.com/media/Vd9BqHOvmyXOSScrXd/giphy.gif"/>