### PR TITLE
fix(vite-plugin-nitro): update plugin name, pass options to dev server

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/options.ts
+++ b/packages/vite-plugin-nitro/src/lib/options.ts
@@ -9,6 +9,7 @@ export interface Options {
   static?: boolean;
   prerender?: PrerenderOptions;
   entryServer?: string;
+  index?: string;
 }
 
 export interface PrerenderOptions {

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
@@ -17,7 +17,7 @@ describe('nitro', () => {
   });
 
   it('should work', () => {
-    expect(nitro({})[1].name).toEqual('@analogjs/vite-nitro-plugin');
+    expect(nitro({})[1].name).toEqual('@analogjs/vite-plugin-nitro');
   });
 
   it(`should not call the route middleware in test mode `, async () => {

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -29,10 +29,13 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
 
   return [
     (options?.ssr
-      ? devServerPlugin({ entryServer: options?.entryServer })
+      ? devServerPlugin({
+          entryServer: options?.entryServer,
+          index: options?.index,
+        })
       : false) as Plugin,
     {
-      name: '@analogjs/vite-nitro-plugin',
+      name: '@analogjs/vite-plugin-nitro',
       async config(_config, { command }) {
         isServe = command === 'serve';
         isBuild = command === 'build';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- The internal name for the plugin is correct
- The `index` option is passed to the dev server

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
