### PR TITLE
Added missing dependency and configuration to vitest documentation

### DIFF
--- a/apps/docs-app/docs/features/testing/vitest.md
+++ b/apps/docs-app/docs/features/testing/vitest.md
@@ -13,7 +13,7 @@ To add Vitest, install the necessary packages:
   <TabItem value="npm">
 
 ```shell
-npm install @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths --save-dev
+npm install @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths @nx/vite --save-dev
 ```
 
   </TabItem>
@@ -21,7 +21,7 @@ npm install @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig
   <TabItem label="Yarn" value="yarn">
 
 ```shell
-yarn add @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths --dev
+yarn add @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths @nx/vite --dev
 ```
 
   </TabItem>
@@ -29,7 +29,7 @@ yarn add @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-pa
   <TabItem value="pnpm">
 
 ```shell
-pnpm install -w @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths
+pnpm install -w @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths @nx/vite
 ```
 
   </TabItem>
@@ -107,6 +107,18 @@ Next, update the `test` target in the `angular.json` to use the `@analogjs/platf
 
 > You can also add a new target and name it `vitest` to run alongside your `test` target.
 
+Next, you may need to modify your `tsconfig.spec.json` to mandate using `vitest` rather than `jasmine` (or `jest`) as the type of your test runner, and add the `test.ts` file you created above:
+```json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": ["node", "vitest/globals"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}
+```
 Lastly, add the `src/test.ts` to `files` array in the `tsconfig.spec.json` in the root of your project, and update the `types`.
 
 ```json

--- a/apps/docs-app/docs/features/testing/vitest.md
+++ b/apps/docs-app/docs/features/testing/vitest.md
@@ -107,7 +107,8 @@ Next, update the `test` target in the `angular.json` to use the `@analogjs/platf
 
 > You can also add a new target and name it `vitest` to run alongside your `test` target.
 
-Next, you may need to modify your `tsconfig.spec.json` to mandate using `vitest` rather than `jasmine` (or `jest`) as the type of your test runner, and add the `test.ts` file you created above:
+Next, modify your `tsconfig.spec.json` to stipulate `vitest` rather than `jasmine` (or `jest`) as your test runner, and add the `test.ts` file you created above:
+
 ```json
 {
   "extends": "./tsconfig.json",
@@ -119,6 +120,7 @@ Next, you may need to modify your `tsconfig.spec.json` to mandate using `vitest`
   "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }
 ```
+
 Lastly, add the `src/test.ts` to `files` array in the `tsconfig.spec.json` in the root of your project, and update the `types`.
 
 ```json


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ X] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ X] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Installation of vitest does not work because of the missing dependency and configuration change. 

Closes #

## What is the new behavior?

Installation of vitest works with extant (sample) Angular tests written for Jasmine.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ X] No

## Other information

None.
