### PR TITLE
docs: added missing dependency to development installations

### DIFF
--- a/apps/docs-app/docs/features/testing/vitest.md
+++ b/apps/docs-app/docs/features/testing/vitest.md
@@ -13,7 +13,7 @@ To add Vitest, install the necessary packages:
   <TabItem value="npm">
 
 ```shell
-npm install @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths --save-dev
+npm install @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths @nx/vite --save-dev
 ```
 
   </TabItem>
@@ -21,7 +21,7 @@ npm install @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig
   <TabItem label="Yarn" value="yarn">
 
 ```shell
-yarn add @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths --dev
+yarn add @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths @nx/vite --dev
 ```
 
   </TabItem>
@@ -29,7 +29,7 @@ yarn add @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-pa
   <TabItem value="pnpm">
 
 ```shell
-pnpm install -w @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths
+pnpm install -w @analogjs/vite-plugin-angular @analogjs/platform jsdom vite-tsconfig-paths @nx/vite
 ```
 
   </TabItem>


### PR DESCRIPTION
Added missing @nx/vite dependency to dev. installs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Incomplete documentation for installation of vitest into extant NG 17 project.

Closes #

## What is the new behavior?

Following the docs leads to successful installation of vitest.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No

## Other information

None.