### PR TITLE
feat(vite-plugin-nitro): add `workspaceRoot` option to override `process.cwd`

### DIFF
--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -30,4 +30,5 @@ export interface Options {
   nitro?: NitroConfig;
   apiPrefix?: string;
   jit?: boolean;
+  workspaceRoot?: string;
 }

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -30,7 +30,11 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
     (platformOptions.ssr ? ssrBuildPlugin() : false) as Plugin,
     ...routerPlugin(),
     ...contentPlugin(),
-    ...angular({ jit: platformOptions.jit, ...(opts?.vite ?? {}) }),
+    ...angular({
+      jit: platformOptions.jit,
+      workspaceRoot: platformOptions.workspaceRoot,
+      ...(opts?.vite ?? {}),
+    }),
     ssrXhrBuildPlugin(),
     clearClientPageEndpointsPlugin(),
   ];

--- a/packages/vite-plugin-nitro/src/lib/options.ts
+++ b/packages/vite-plugin-nitro/src/lib/options.ts
@@ -10,6 +10,7 @@ export interface Options {
   prerender?: PrerenderOptions;
   entryServer?: string;
   index?: string;
+  workspaceRoot?: string;
 }
 
 export interface PrerenderOptions {

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
@@ -205,6 +205,29 @@ describe('nitro', () => {
       );
     });
 
+    it('should use the workspace root option when it is set', async () => {
+      // Arrange
+      vi.mock('process');
+      process.cwd = vi.fn().mockReturnValue('/some-other-root-directory');
+      const { buildServerImportSpy } = await mockBuildFunctions();
+
+      const plugin = nitro({ workspaceRoot: '/custom-root-directory' }, {});
+
+      // Act
+      await runConfigAndCloseBundle(plugin);
+
+      // Assert
+      expect(buildServerImportSpy).toHaveBeenCalledWith(
+        { workspaceRoot: '/custom-root-directory' },
+        expect.objectContaining({
+          output: {
+            dir: '/custom-root-directory/dist/analog',
+            publicDir: '/custom-root-directory/dist/analog/public',
+          },
+        })
+      );
+    });
+
     it('should use the .vercel output paths when preset is vercel', async () => {
       // Arrange
       vi.mock('process');

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -17,7 +17,7 @@ import { loadEsmModule } from './utils/load-esm';
 let clientOutputPath = '';
 
 export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
-  const workspaceRoot = process.cwd();
+  const workspaceRoot = options?.workspaceRoot ?? process.cwd();
   const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
   const apiPrefix = `/${nitroOptions?.runtimeConfig?.['apiPrefix'] ?? 'api'}`;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## Which package are you modifying?

- [x] vite-plugin-nitro
- [x] platform

## What is the current behavior?

You can set the `workspaceRoot` for the vite plugin Angular, but not for the vite nitro plugin.

## What is the new behavior?
Adding a new `workspaceRoot` option to platform and vite nitro plugin. The platform option will automatically set it for both the angular and nitro plugins.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

