### PR TITLE
fix(platform): add missing `index` option for the platform plugin

### DIFF
--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -30,5 +30,6 @@ export interface Options {
   nitro?: NitroConfig;
   apiPrefix?: string;
   jit?: boolean;
+  index?: string;
   workspaceRoot?: string;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Which package are you modifying?

- [x] platform

## What is the current behavior?

The nitro plugin inherits the platform options, but the interface doesn't reflect this as the `index` option was missing.

## What is the new behavior?

You can see the index option in the options of the platform plugin

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

