### PR TITLE
feat(vite-plugin-angular): add support for styleUrl in component decorator

### DIFF
--- a/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
@@ -34,7 +34,7 @@ const thePathsAreEqual = (actual: string[], expected: string[]) => {
   return true;
 };
 
-describe('component-resolvers styleUrls', () => {
+describe('component-resolvers', () => {
   const id = '/path/to/src/app.component.ts';
 
   describe('matcher', () => {
@@ -42,6 +42,23 @@ describe('component-resolvers styleUrls', () => {
       const code = `
         @Component({
           styleUrls: ['./app.component.css']
+        })
+        export class MyComponent {}
+      `;
+
+      const actualPaths = [
+        './app.component.css|/path/to/src/app.component.css',
+      ];
+      const templateUrlsResolver = new TemplateUrlsResolver();
+      const resolvedPaths = templateUrlsResolver.resolve(code, id);
+
+      expect(thePathsAreEqual(resolvedPaths, actualPaths));
+    });
+
+    it('should handle single line styleUrl', () => {
+      const code = `
+        @Component({
+          styleUrl: './app.component.css'
         })
         export class MyComponent {}
       `;

--- a/packages/vite-plugin-angular/src/lib/component-resolvers.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.ts
@@ -1,6 +1,6 @@
 import { dirname, resolve } from 'path';
 
-const styleUrlsRE = /styleUrls\s*:\s*\[([^\[]*?)\]/;
+const styleUrlsRE = /styleUrls\s*:\s*\[([^\[]*?)\]|styleUrl:\s*["'](.*?)["']/;
 const templateUrlRE = /templateUrl:\s*["'](.*?)["']/g;
 
 export function hasStyleUrls(code: string) {
@@ -50,6 +50,7 @@ export class StyleUrlsResolver {
     // "styleUrls: [\n    './app.component.scss',\n    '../global.scss'\n  ]"
     const styleUrlPaths = matchedStyleUrls
       .replace(/(styleUrls|\:|\s|\[|\]|"|')/g, '')
+      .replace(/(styleUrl|:\s*["'](.*?)["'])/g, '')
       // The above replace will result in the following:
       // "./app.component.scss,../global.scss"
       .split(',');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

The `styleUrl` property in the component decorator isn't supported during file watching and testing.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #783 

## What is the new behavior?

The `styleUrl` property in the component decorator isn't supported during file watching and testing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/ghAbYUswkmXHq/giphy.gif"/>
