### PR TITLE
fix: add default reporters to vitest configuration

### DIFF
--- a/apps/docs-app/docs/features/testing/vitest.md
+++ b/apps/docs-app/docs/features/testing/vitest.md
@@ -92,6 +92,7 @@ export default defineConfig(({ mode }) => ({
     setupFiles: ['src/test-setup.ts'],
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
   },
   define: {
     'import.meta.vitest': mode !== 'production',
@@ -210,6 +211,7 @@ export default defineConfig(({ mode }) => ({
     setupFiles: ['src/test-setup.ts'],
     // environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
     // Vitest browser config
     browser: {
       enabled: true,

--- a/packages/create-analog/template-angular-v16/vite.config.ts
+++ b/packages/create-analog/template-angular-v16/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig(({ mode }) => ({
     environment: 'jsdom',
     setupFiles: ['src/test.ts'],
     include: ['**/*.spec.ts'],
+    reporters: ['default'],
   },
   define: {
     'import.meta.vitest': mode !== 'production',

--- a/packages/create-analog/template-angular-v17/vite.config.ts
+++ b/packages/create-analog/template-angular-v17/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig(({ mode }) => ({
     environment: 'jsdom',
     setupFiles: ['src/test.ts'],
     include: ['**/*.spec.ts'],
+    reporters: ['default'],
   },
   define: {
     'import.meta.vitest': mode !== 'production',

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/vite.config.ts__template__
@@ -40,6 +40,7 @@ export default defineConfig(({ mode }) => {
       environment: 'jsdom',
       setupFiles: ['src/test-setup.ts'],
       include: ['**/*.spec.ts'],
+      reporters: ['default'],
       cache: {
         dir: `<%= offsetFromRoot %>node_modules/.vitest`,
       },

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v17/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v17/vite.config.ts__template__
@@ -38,6 +38,7 @@ export default defineConfig(({ mode }) => {
       environment: 'jsdom',
       setupFiles: ['src/test-setup.ts'],
       include: ['**/*.spec.ts'],
+      reporters: ['default'],
       cache: {
         dir: `<%= offsetFromRoot %>node_modules/.vitest`,
       },

--- a/packages/nx-plugin/src/generators/setup-vitest/files/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/setup-vitest/files/vite.config.ts__template__
@@ -12,6 +12,7 @@ export default defineConfig(({ mode }) => {
       environment: 'jsdom',
       setupFiles: ['src/test-setup.ts'],
       include: ['**/*.spec.ts'],
+      reporters: ['default'],
     },
     define: {
       'import.meta.vitest': mode !== 'production',

--- a/packages/nx-plugin/src/generators/setup-vitest/files/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/setup-vitest/files/vite.config.ts__template__
@@ -1,12 +1,12 @@
 /// <reference types="vitest" />
 
-import analog from '@analogjs/platform';
+import angular from '@analogjs/vite-plugin-angular';
 import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   return {
-    plugins: [analog()],
+    plugins: [angular()],
     test: {
       globals: true,
       environment: 'jsdom',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [x] create-analog
- [ ] router
- [x] platform
- [ ] content
- [x] nx-plugin
- [ ] trpc

## What is the current behavior?

If the `reporters` array is undefined, no reporters are added, causing the `ng test` command to run with no output.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The `reporters` array is set to `['default']`, so terminal output is produced.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
