### PR TITLE
feat(vite-plugin-nitro): add support for typescript paths import resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "prettier": "^2.8.3",
     "prismjs": "^1.29.0",
     "prompts": "^2.4.2",
+    "rollup-plugin-typescript-paths": "^1.4.0",
     "rollup-plugin-visualizer": "^5.9.0",
     "start-server-and-test": "^1.15.4",
     "tailwindcss": "^3.0.2",

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/vite.config.ts__template__
@@ -48,6 +48,7 @@ export default defineConfig(({ mode }) => {
         prerender: {
           routes: ['/'],
         },
+        tsConfigPath: 'tsconfig.base.json',
       }),
       tsConfigPaths({
         root: '<%= offsetFromRoot %>',

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/vite.config.ts__template__
@@ -25,10 +25,13 @@ export default defineConfig(({ mode }) => {
               prerender: false,
             }
           }
-        }
+        },
+        tsConfigPath: 'tsconfig.base.json',
       }),
       <% } else { %>
-      analog(),
+      analog({
+        tsConfigPath: 'tsconfig.base.json',
+      }),
       <% } %>
       tsConfigPaths({
         root: '<%= offsetFromRoot %>',

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v17/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v17/vite.config.ts__template__
@@ -25,10 +25,13 @@ export default defineConfig(({ mode }) => {
               prerender: false,
             }
           }
-        }
+        },
+        tsConfigPath: 'tsconfig.base.json',
       }),
       <% } else { %>
-      analog(),
+      analog({
+        tsConfigPath: 'tsconfig.base.json',
+      }),
       <% } %>
       nxViteTsPaths(),
       splitVendorChunkPlugin(),

--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -32,4 +32,5 @@ export interface Options {
   jit?: boolean;
   index?: string;
   workspaceRoot?: string;
+  tsConfigPath?: string;
 }

--- a/packages/vite-plugin-nitro/package.json
+++ b/packages/vite-plugin-nitro/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "nitropack": "^2.6.0",
+    "rollup-plugin-typescript-paths": "^1.4.0",
     "xmlbuilder2": "^3.0.2"
   },
   "ng-update": {

--- a/packages/vite-plugin-nitro/src/lib/options.ts
+++ b/packages/vite-plugin-nitro/src/lib/options.ts
@@ -11,6 +11,7 @@ export interface Options {
   entryServer?: string;
   index?: string;
   workspaceRoot?: string;
+  tsConfigPath?: string;
 }
 
 export interface PrerenderOptions {

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -3,6 +3,7 @@ import { App, toNodeListener } from 'h3';
 import type { Plugin, UserConfig } from 'vite';
 import { normalizePath, ViteDevServer } from 'vite';
 import * as path from 'path';
+import { typescriptPaths } from 'rollup-plugin-typescript-paths';
 
 import { buildServer } from './build-server';
 import { buildSSRApp } from './build-ssr';
@@ -79,7 +80,13 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                 return;
               }
             },
-            plugins: [pageEndpointsPlugin()],
+            plugins: [
+              pageEndpointsPlugin(),
+              typescriptPaths({
+                tsConfigPath: options?.tsConfigPath ?? 'tsconfig.json',
+                preserveExtensions: true,
+              }) as unknown as any,
+            ],
           },
           handlers: [
             {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      rollup-plugin-typescript-paths:
+        specifier: ^1.4.0
+        version: 1.4.0(typescript@5.2.2)
       rollup-plugin-visualizer:
         specifier: ^5.9.0
         version: 5.9.0
@@ -22105,6 +22108,14 @@ packages:
   /robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
     dev: false
+
+  /rollup-plugin-typescript-paths@1.4.0(typescript@5.2.2):
+    resolution: {integrity: sha512-6EgeLRjTVmymftEyCuYu91XzY5XMB5lR0YrJkeT0D7OG2RGSdbNL+C/hfPIdc/sjMa9Sl5NLsxIr6C/+/5EUpA==}
+    peerDependencies:
+      typescript: '>=3.4'
+    dependencies:
+      typescript: 5.2.2
+    dev: true
 
   /rollup-plugin-visualizer@5.9.0:
     resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [X] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [X] platform
- [ ] content
- [X] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently typescript imports using the `compilerOptions.paths` aliases set in `tsconfig.json` are not automatically handled for Nitro. This causes the nitro server to fail to run when executing the imports. This is especially evident in a Nx monorepo leveraging multiple in-built libraries.

Closes # [Discord Thread](https://discordapp.com/channels/994618831987290112/1183254913086656718)

## What is the new behavior?

This PR adds [rollup-plugin-typescript-paths](https://www.npmjs.com/package/rollup-plugin-typescript-paths) as a dependency of `vite-plugin-nitro`. This plugin is included as one of the `plugins` within the `rollupConfig` of the `NitroConfig`.

The plugin is configured to default to loading / reading from a `tsconfig.json` file in the root of the repo. However, to support other setups an option was added to both the `Options` for `vite-plugin-nitro` and the `@analog/platform` plugin to allow a user to override the tsconfig file / path.

Related to the 2nd point, the `nx-plugin` was update to specify `tsconfig.base.json` as the tsconfig file to load. This was added as a default for all current `vite.config.ts` templates in the plugin.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/3o6nVb2jKZGnsvfhNC/giphy.gif"/>