### PR TITLE
fix(vite-plugin-angular): support Windows path for templateUrl and styleUrl

### DIFF
--- a/packages/vite-plugin-angular/src/lib/component-resolvers.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.ts
@@ -1,4 +1,5 @@
 import { dirname, resolve } from 'path';
+import { normalizePath } from 'vite';
 
 const styleUrlsRE = /styleUrls\s*:\s*\[([^\[]*?)\]|styleUrl:\s*["'](.*?)["']/;
 const templateUrlRE = /templateUrl:\s*["'](.*?)["']/g;
@@ -56,7 +57,9 @@ export class StyleUrlsResolver {
       .split(',');
 
     const styleUrls = styleUrlPaths.map((styleUrlPath) => {
-      return `${styleUrlPath}|${resolve(dirname(id), styleUrlPath)}`;
+      return `${styleUrlPath}|${normalizePath(
+        resolve(dirname(id), styleUrlPath)
+      )}`;
     });
 
     this.styleUrlsCache.set(matchedStyleUrls, { styleUrls, matchedStyleUrls });
@@ -94,7 +97,9 @@ export class TemplateUrlsResolver {
           /templateUrl|\s|'|"|\:|,/g,
           ''
         );
-        const templateUrlPath = resolve(dirname(id), resolvedTemplatePath);
+        const templateUrlPath = normalizePath(
+          resolve(dirname(id), resolvedTemplatePath).replace(/\\/g, '/')
+        );
         templateUrlPaths.push(`${resolvedTemplatePath}|${templateUrlPath}`);
       });
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Closes https://github.com/analogjs/analog/issues/798

On Windows, path is: "C:UserProjectNameFrontsrcappapp.component.html?raw"

## What is the new behavior?

Path is: "C:/User/ProjectName/Front/src/app/app.component.html?raw"

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/l3q2zbskZp2j8wniE/giphy-downsized-medium.gif"/>