### PR TITLE
fix(vite-plugin-angular): improve compatibility with sourcemaps

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -317,6 +317,9 @@ export function angular(options?: PluginOptions): Plugin[] {
           if (jit) {
             return {
               code: data.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, ''),
+              map: {
+                mappings: '',
+              },
             };
           }
 
@@ -327,6 +330,9 @@ export function angular(options?: PluginOptions): Plugin[] {
           if (!forceAsyncTransformation && !isProd) {
             return {
               code: data.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, ''),
+              map: {
+                mappings: '',
+              },
             };
           }
 
@@ -380,20 +386,16 @@ export function angular(options?: PluginOptions): Plugin[] {
   function setupCompilation() {
     const { options: tsCompilerOptions, rootNames: rn } =
       compilerCli.readConfiguration(pluginOptions.tsconfig, {
-        enableIvy: true,
-        noEmitOnError: false,
         suppressOutputPathCheck: true,
         outDir: undefined,
-        inlineSources: !isProd,
         inlineSourceMap: !isProd,
-        sourceMap: false,
-        mapRoot: undefined,
-        sourceRoot: undefined,
+        inlineSources: !isProd,
         declaration: false,
         declarationMap: false,
         allowEmptyCodegenFiles: false,
         annotationsAs: 'decorators',
         enableResourceInlining: false,
+        supportTestBed: false,
       });
 
     rootNames = rn;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #410 
Closes #86 

## What is the new behavior?

Provides empty `mappings` to suppress warning messages when using inline source maps. Still needs more investigation in terms of original source correctly mapping to the generated source and sourcemap

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
