### PR TITLE
fix(nx-plugin): fix server tests and tsConfigPaths not being recognized

### DIFF
--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/tsconfig.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/tsconfig.json__template__
@@ -2,7 +2,7 @@
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "files": [],
   "include": [],
-  "exclude": ["./src/server/**/*"],
+  "exclude": [],
   "references": [
     {
       "path": "./tsconfig.app.json"

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/tsconfig.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/tsconfig.json__template__
@@ -2,7 +2,7 @@
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "files": [],
   "include": [],
-  "exclude": ["./src/server/**/*"],
+  "exclude": [],
   "references": [
     {
       "path": "./tsconfig.app.json"

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v17/tsconfig.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v17/tsconfig.json__template__
@@ -2,7 +2,7 @@
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "files": [],
   "include": [],
-  "exclude": ["./src/server/**/*"],
+  "exclude": [],
   "references": [
     {
       "path": "./tsconfig.app.json"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [X] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently tests created in the `src/server` directory within an analog application scaffolded inside a Nx monorepo are not recognized. Similarly, tsconfig paths are not respected, causing import issues.

Closes #801

## What is the new behavior?

After conversation with @brandonroberts , making the `exclude` array in the `tsconfig.json` of the application an empty array fixes this as currently it is excluding all test files under `src/server`. An alternative is to override the `excludes` by setting an empty array in `tsconfig.spec.json`, but this only fixes the tests not being recognized, not the tsconfig paths issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media1.giphy.com/media/r7riLSvkCAgSI/giphy.gif"/>