### PR TITLE
fix(trpc): remove imports to @trpc/client/src and @trpc/server/src

### DIFF
--- a/packages/trpc/src/lib/client/client.ts
+++ b/packages/trpc/src/lib/client/client.ts
@@ -1,6 +1,11 @@
 import { InjectionToken, Provider, signal, TransferState } from '@angular/core';
 import 'isomorphic-fetch';
-import { httpBatchLink, HttpBatchLinkOptions } from '@trpc/client';
+import {
+  httpBatchLink,
+  HttpBatchLinkOptions,
+  CreateTRPCClientOptions,
+  HTTPHeaders,
+} from '@trpc/client';
 import { AnyRouter } from '@trpc/server';
 import { transferStateLink } from './links/transfer-state-link';
 import {
@@ -9,8 +14,6 @@ import {
   tRPC_CACHE_STATE,
 } from './cache-state';
 import { createTRPCRxJSProxyClient } from './trpc-rxjs-proxy';
-import { CreateTRPCClientOptions } from '@trpc/client/src/createTRPCUntypedClient';
-import { HTTPHeaders } from '@trpc/client/src/links/types';
 import { FetchEsque } from '@trpc/client/dist/internals/types';
 
 export type TrpcOptions<T extends AnyRouter> = {

--- a/packages/trpc/src/lib/client/shared-internal.ts
+++ b/packages/trpc/src/lib/client/shared-internal.ts
@@ -6,11 +6,12 @@ import {
   DefaultDataTransformer,
 } from '@trpc/server';
 import {
+  Operation,
+  TRPCLink,
   OperationContext,
   OperationLink,
   OperationResultObservable,
-} from '@trpc/client/src/links/types';
-import { Operation, TRPCLink } from '@trpc/client';
+} from '@trpc/client';
 import { observable } from '@trpc/server/observable';
 
 // Removed subscription

--- a/packages/trpc/src/lib/client/trpc-rxjs-proxy.ts
+++ b/packages/trpc/src/lib/client/trpc-rxjs-proxy.ts
@@ -17,21 +17,24 @@ import {
   createRecursiveProxy,
   inferTransformedProcedureOutput,
 } from '@trpc/server/shared';
-import { inferObservableValue, share } from '@trpc/server/observable';
 import {
+  inferObservableValue,
+  share,
+  Observable as TrpcObservable,
+} from '@trpc/server/observable';
+import { Observable as RxJSObservable } from 'rxjs';
+import {
+  TRPCClientError,
   OperationContext,
   OperationLink,
   TRPCClientRuntime,
-} from '@trpc/client/src/links/types';
-import { Observable as RxJSObservable } from 'rxjs';
-import { TRPCClientError } from '@trpc/client';
+} from '@trpc/client';
 import {
   createChain,
   CreateTRPCClientOptions,
   TRPCRequestOptions,
   TRPCType,
 } from './shared-internal';
-import { Observable as TrpcObservable } from '@trpc/server/src/observable/types';
 
 // Changed to rxjs observable
 type Resolver<TProcedure extends AnyProcedure> = (


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [X] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently trying to build an analog application integrated with tRPC in the Nx monorepo setup fails due to type checks being run on the `@trpc/client` and `@trpc/server` npm packages. This is highlighting some transitive items that may be improved in trpc, but is highlighting that our trpc import references are not correct on our side. Namely, there are imports importing directly from the source files included in the trpc packages as opposed to importing from the library mapping or `dist` folder. This is leading to `skipLibChecks` not being respected.

Closes #722

## What is the new behavior?

The application can now be built without issue. No regressions as imports were updated to stop referencing the `src/` directories for the trpc dependencies, instead importing directly from the libraries or the `dist/` folder is needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/UZuAr03kNcTL71bTWj/giphy.gif"/>
