### PR TITLE
feat(vite-plugin-nitro): provide req and res to renderer

### DIFF
--- a/apps/analog-app/src/app/app.config.ts
+++ b/apps/analog-app/src/app/app.config.ts
@@ -7,12 +7,12 @@ import { ApplicationConfig } from '@angular/core';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideFileRouter } from '@analogjs/router';
 import { withNavigationErrorHandler } from '@angular/router';
-import { cookieInterceotor } from './interceptors/cookies.interceptor';
+import { cookieInterceptor } from './interceptors/cookies.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideFileRouter(withNavigationErrorHandler(console.error)),
-    provideHttpClient(withFetch(), withInterceptors([cookieInterceotor])),
+    provideHttpClient(withFetch(), withInterceptors([cookieInterceptor])),
     provideClientHydration(),
   ],
 };

--- a/apps/analog-app/src/app/app.config.ts
+++ b/apps/analog-app/src/app/app.config.ts
@@ -1,13 +1,18 @@
-import { provideHttpClient } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withFetch,
+  withInterceptors,
+} from '@angular/common/http';
 import { ApplicationConfig } from '@angular/core';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideFileRouter } from '@analogjs/router';
 import { withNavigationErrorHandler } from '@angular/router';
+import { cookieInterceotor } from './interceptors/cookies.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideFileRouter(withNavigationErrorHandler(console.error)),
-    provideHttpClient(),
+    provideHttpClient(withFetch(), withInterceptors([cookieInterceotor])),
     provideClientHydration(),
   ],
 };

--- a/apps/analog-app/src/app/interceptors/cookies.interceptor.ts
+++ b/apps/analog-app/src/app/interceptors/cookies.interceptor.ts
@@ -1,0 +1,23 @@
+import { isPlatformServer } from '@angular/common';
+import { HttpHandlerFn, HttpHeaders, HttpRequest } from '@angular/common/http';
+import { PLATFORM_ID, inject } from '@angular/core';
+
+export function cookieInterceotor(
+  req: HttpRequest<unknown>,
+  next: HttpHandlerFn,
+  location = inject(PLATFORM_ID)
+) {
+  if (isPlatformServer(location)) {
+    let headers = new HttpHeaders();
+    const cookies = req.headers.get('cookie');
+    headers = headers.set('cookie', cookies ?? '');
+
+    const cookiedRequest = req.clone({
+      headers,
+    });
+
+    return next(cookiedRequest);
+  } else {
+    return next(req);
+  }
+}

--- a/apps/analog-app/src/app/interceptors/cookies.interceptor.ts
+++ b/apps/analog-app/src/app/interceptors/cookies.interceptor.ts
@@ -2,7 +2,7 @@ import { isPlatformServer } from '@angular/common';
 import { HttpHandlerFn, HttpHeaders, HttpRequest } from '@angular/common/http';
 import { PLATFORM_ID, inject } from '@angular/core';
 
-export function cookieInterceotor(
+export function cookieInterceptor(
   req: HttpRequest<unknown>,
   next: HttpHandlerFn,
   location = inject(PLATFORM_ID)

--- a/apps/analog-app/src/main.server.ts
+++ b/apps/analog-app/src/main.server.ts
@@ -20,8 +20,7 @@ export function bootstrap() {
 export default async function render(
   url: string,
   document: string,
-  req: Request,
-  res: Response
+  { req, res }: { req: Request; res: Response }
 ) {
   const html = await renderApplication(bootstrap, {
     document,

--- a/apps/analog-app/src/main.server.ts
+++ b/apps/analog-app/src/main.server.ts
@@ -1,5 +1,5 @@
 import 'zone.js/node';
-import { enableProdMode } from '@angular/core';
+import { InjectionToken, enableProdMode } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { renderApplication } from '@angular/platform-server';
 
@@ -10,14 +10,26 @@ if (import.meta.env.PROD) {
   enableProdMode();
 }
 
+const REQUEST = new InjectionToken<Request>('REQUEST');
+const RESPONSE = new InjectionToken<Response>('RESPONSE');
+
 export function bootstrap() {
   return bootstrapApplication(AppComponent, config);
 }
 
-export default async function render(url: string, document: string) {
+export default async function render(
+  url: string,
+  document: string,
+  req: Request,
+  res: Response
+) {
   const html = await renderApplication(bootstrap, {
     document,
     url,
+    platformProviders: [
+      { provide: REQUEST, useValue: req },
+      { provide: RESPONSE, useValue: res },
+    ],
   });
 
   return html;

--- a/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
+++ b/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
@@ -43,7 +43,12 @@ export function devServerPlugin(options: ServerOptions): Plugin {
             const entryServer = (
               await viteServer.ssrLoadModule('~analog/entry-server')
             )['default'];
-            const result = await entryServer(req.originalUrl, template);
+            const result = await entryServer(
+              req.originalUrl,
+              template,
+              req,
+              res
+            );
             res.setHeader('Content-Type', 'text/html');
             res.end(result);
           } catch (e) {

--- a/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
+++ b/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
@@ -43,12 +43,10 @@ export function devServerPlugin(options: ServerOptions): Plugin {
             const entryServer = (
               await viteServer.ssrLoadModule('~analog/entry-server')
             )['default'];
-            const result = await entryServer(
-              req.originalUrl,
-              template,
+            const result = await entryServer(req.originalUrl, template, {
               req,
-              res
-            );
+              res,
+            });
             res.setHeader('Content-Type', 'text/html');
             res.end(result);
           } catch (e) {

--- a/packages/vite-plugin-nitro/src/lib/runtime/renderer.js
+++ b/packages/vite-plugin-nitro/src/lib/runtime/renderer.js
@@ -12,11 +12,9 @@ import renderer from '#analog/ssr';
 import template from '#analog/index';
 
 export default eventHandler(async (event) => {
-  const html = await renderer(
-    event.node.req.url,
-    template,
-    event.node.req,
-    event.node.res
-  );
+  const html = await renderer(event.node.req.url, template, {
+    req: event.node.req,
+    res: event.node.res,
+  });
   return html;
 });

--- a/packages/vite-plugin-nitro/src/lib/runtime/renderer.js
+++ b/packages/vite-plugin-nitro/src/lib/runtime/renderer.js
@@ -12,7 +12,11 @@ import renderer from '#analog/ssr';
 import template from '#analog/index';
 
 export default eventHandler(async (event) => {
-  const html = await renderer(event.node.req.url, template);
-
+  const html = await renderer(
+    event.node.req.url,
+    template,
+    event.node.req,
+    event.node.res
+  );
   return html;
 });


### PR DESCRIPTION
PR adds full req and res object from h3 to the analog event handler for  app rendering

closes #802
closes #586 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Current behavior is that the full, raw request and response are not provided to Analog, which limits the ability to use cookies from the incoming request. 

Closes #802 

## What is the new behavior?

Now both the runtime renderer event handler and the nitro dev server have access to the request and response, which can then be provided to the application.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
