### PR TITLE
feat(vite-plugin-angular): support let with getters

### DIFF
--- a/apps/ng-app/src/app/another-one.ng
+++ b/apps/ng-app/src/app/another-one.ng
@@ -1,6 +1,17 @@
 <script lang="ts">
+  import { ChangeDetectorRef, inject } from '@angular/core';
+
+  const cdr = inject(ChangeDetectorRef);
+
+  let lateVariable: string;
+
   onInit(() => {
     console.log('anotherOne init');
+    setTimeout(() => {
+      lateVariable = 'anotherOne';
+      cdr.detectChanges();
+      console.log(this);
+    }, 2000);
   });
 
   onDestroy(() => {
@@ -10,10 +21,17 @@
 
 <template>
   <h1>DJ KHALED!!!</h1>
+  @if (lateVariable) {
+  <h2>Late Variable here: {{ lateVariable }}</h2>
+  }
 </template>
 
 <style>
   h1 {
     color: green;
+  }
+
+  h2 {
+    color: tomato;
   }
 </style>

--- a/apps/ng-app/src/app/app.component.ng
+++ b/apps/ng-app/src/app/app.component.ng
@@ -6,10 +6,11 @@
   import { JsonPipe } from '@angular/common';
   import { delay } from 'rxjs';
   import Highlight from './highlight.ng';
+  import { HelloOriginal } from './hello';
 
   defineMetadata({
     selector: 'app-root',
-    imports: [JsonPipe],
+    imports: [JsonPipe, HelloOriginal],
     exposes: [Math],
   });
 
@@ -49,6 +50,7 @@
   @if (counter() > 5) {
   <Hello />
   <AnotherOne />
+  <app-hello-original />
   }
 
   <p>Counter: {{ counter() }}</p>

--- a/apps/ng-app/src/app/hello.ts
+++ b/apps/ng-app/src/app/hello.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import Hello from './hello.ng';
+
+@Component({
+  selector: 'app-hello-original',
+  standalone: true,
+  template: `
+    <p>I'm a boring hello</p>
+    <p>Below me is a cool hello though</p>
+    <Hello />
+  `,
+  imports: [Hello],
+})
+// eslint-disable-next-line @angular-eslint/component-class-suffix
+export class HelloOriginal {}

--- a/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/ng.spec.ts.snap
+++ b/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/ng.spec.ts.snap
@@ -13,17 +13,26 @@ import { signal } from "@angular/core";
   <p>{{ counter() }}</p>
   <p>{ a }</p>
   <p>{ b }</p>
-  <p>{ c }</p>\`,
+  <p>{ c }</p>
+  <p>{{ test }}</p>\`,
     imports: []
 })
 export default class AnalogNgEntity {
     constructor() {
+        let test: string;
+        setTimeout(() => {
+            test = 'test';
+        }, 1000)
         const counter = signal(0);
         this.counter = counter;
         const [a, b, , c = 4] = [1, 2, 3];
         this.a = a;
         this.b = b;
         this.c = c;
+
+        Object.defineProperties(this, {
+            test: { get() { return test; } },
+        });
     }
 
     protected Math = Math;

--- a/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
@@ -8,6 +8,12 @@ defineMetadata({
   exposes: [Math]
 });
 
+let test: string;
+
+setTimeout(() => {
+  test = 'test';
+}, 1000)
+
 const counter = signal(0);
 const [a, b, , c = 4] = [1, 2, 3];
 </script>
@@ -18,6 +24,7 @@ const [a, b, , c = 4] = [1, 2, 3];
   <p>{ a }</p>
   <p>{ b }</p>
   <p>{ c }</p>
+  <p>{{ test }}</p>
 </template>
 
 <style>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`let` variables that have their value assigned later do not work property if used on the template.

Closes #

## What is the new behavior?
`let` variables are supported by using `getters`. Late variables will still work if used on the template.

NOTE: even `let` is supported, it is recommended to use a reactivity model (signal or observable) if a variable is intended to be used on the template.

```html
<script lang="ts">

const cdr = inject(ChangeDetectorRef);

let lateVariable: string;

setTimeout(() => {
  lateVariable = 'I am late';
  cdr.detectChanges();
}, 2000);
</script>

<template>
  @if (lateVariable) {
    <h1>{{ lateVariable }}</h1>
  }
</template>
```
becomes
```ts
export default class AnalogNgEntity {
  constructor() {
    const cdr = inject(ChangeDetectorRef);
    let lateVariable: string;
    setTimeout(() => {
      lateVariable = 'I am late';
      cdr.detectChanges();
    }, 2000);
    
    Object.defineProperties(this, {
      lateVariable: { get() { return lateVariable; } },
    });
  }
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
