### PR TITLE
feat(vite-plugin-angular): queries work and outputs are now in metada…

### DIFF
--- a/apps/ng-app/src/app/hello.ng
+++ b/apps/ng-app/src/app/hello.ng
@@ -5,7 +5,22 @@
     input,
     EventEmitter,
     effect,
+    ViewChild,
+    ElementRef,
+    afterNextRender,
   } from '@angular/core';
+
+  defineMetadata({
+    queries: {
+      divElement: new ViewChild('divElement'),
+    },
+  });
+
+  let divElement: ElementRef<HTMLDivElement>;
+
+  afterNextRender(() => {
+    console.log('the Div', divElement);
+  });
 
   const { foo: aliasFoo = 'tran', ...rest } = { foo: 'chau' };
   const [a, b, , c = 5, ...restArray] = [1, 2, 3];
@@ -31,6 +46,7 @@
   <p>{{ aliasFoo }}</p>
   <p>Text from input: {{ text() }}</p>
   <button (click)="clicked.emit($event)">Emit The Click</button>
+  <div #divElement>my div</div>
 </template>
 
 <style>

--- a/apps/ng-app/src/vite-env.d.ts
+++ b/apps/ng-app/src/vite-env.d.ts
@@ -21,12 +21,13 @@ declare global {
         Component,
         | 'template'
         | 'templateUrl'
-        | 'host'
         | 'standalone'
         | 'changeDetection'
         | 'styleUrls'
         | 'styleUrl'
         | 'styles'
+        | 'outputs'
+        | 'inputs'
       >
     ) => void;
     /**

--- a/packages/create-analog/template-angular-v17/src/vite-env.d.ts
+++ b/packages/create-analog/template-angular-v17/src/vite-env.d.ts
@@ -14,12 +14,13 @@
 //         Component,
 //         | 'template'
 //         | 'templateUrl'
-//         | 'host'
 //         | 'standalone'
 //         | 'changeDetection'
 //         | 'styleUrls'
 //         | 'styleUrl'
 //         | 'styles'
+//         | 'ouputs'
+//         | 'inputs'
 //       > & { exposes?: unknown[] }
 //     ) => void;
 //     /**

--- a/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/ng.spec.ts.snap
+++ b/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/ng.spec.ts.snap
@@ -2,23 +2,27 @@
 
 exports[`authoring ng file > should process component as ng file 1`] = `
 "import { Component, ChangeDetectionStrategy } from '@angular/core';
-import { signal, input } from "@angular/core";
-import { Output } from "@angular/core";
+import { signal, input, ViewChild, afterNextRender, ElementRef } from "@angular/core";
 
 @Component({
     standalone: true,
     selector: 'virtual,Virtual,VIRTUAL',
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: \`<style>div {    color: red;  }  p {    color: blue;  }</style>
-<div>Component</div>
+<div #divElement>Component</div>
   <p>{{ counter() }}</p>
   <p>{ a }</p>
   <p>{ b }</p>
   <p>{ c }</p>
-  <p>{{ test }}</p>\`
+  <p>{{ test }}</p>\`,
+    queries: {
+        divElement: new ViewChild('divElement')
+    },
+    outputs: ['output', 'outputWithType']
 })
 export default class VirtualAnalogComponent {
     constructor() {
+        let divElement;
         let test;
         setTimeout(() => {
             test = 'test';
@@ -37,9 +41,13 @@ export default class VirtualAnalogComponent {
         const requiredInputWithTransform = this.requiredInputWithTransform
         const output = this.output
         const outputWithType = this.outputWithType
+        afterNextRender(() => {
+            console.log('the div', divElement);
+        })
 
         Object.defineProperties(this, {
-            test: { get() { return test; } },
+            divElement: { get() { return divElement; }, set(v) { divElement = v; } },
+            test: { get() { return test; }, set(v) { test = v; } },
         });
     }
 
@@ -61,9 +69,7 @@ export default class VirtualAnalogComponent {
     protected requiredInputWithTransform = input.required<unknown, number>({
         transform: (value) => numberAttribute(value, 10),
     });
-    @Output()
     protected output = new EventEmitter();
-    @Output()
     protected outputWithType = new EventEmitter<string>();
 }
 "

--- a/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
@@ -2,12 +2,16 @@ import { compileNgFile } from './ng';
 
 const COMPONENT_CONTENT = `
 <script lang="ts">
-import { signal, input } from '@angular/core';
+import { signal, input, ViewChild, afterNextRender, ElementRef } from '@angular/core';
 
 defineMetadata({
-  exposes: [Math]
+  exposes: [Math],
+  queries: {
+    divElement: new ViewChild('divElement')
+  }
 });
 
+let divElement: ElementRef<HTMLDivElement>;
 let test: string;
 
 setTimeout(() => {
@@ -32,10 +36,15 @@ const requiredInputWithTransform = input.required<unknown, number>({
   });
 const output = new EventEmitter();
 const outputWithType = new EventEmitter<string>();
+
+afterNextRender(() => {
+  console.log('the div', divElement);
+})
+
 </script>
 
 <template>
-  <div>Component</div>
+  <div #divElement>Component</div>
   <p>{{ counter() }}</p>
   <p>{ a }</p>
   <p>{ b }</p>


### PR DESCRIPTION
…ta decorator instead

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

- Outputs are compiled to use `@Output` decorator
- No support for View/Content queries

Closes #

## What is the new behavior?

- Outputs are compiled to use `outputs` metadata instead (no decorator)
- View/Content queries are supported via `defineMetadata`
```html
<script lang="ts">
import { ViewChild, afterNextRender, ElementRef } from '@angular/core';

defineMetadata({
  queries: {
    // 👇 declare a query for Angular Compiler
    divElement: new ViewChild('theDiv')
  }
});

//  👇 declare a variable matched with the query name to use in .ng file
let divElement: ElementRef<HTMLDivElement>;

afterNextRender(() => {
  console.log('div available', divElement);
});
</script>

<template>
  <div #theDiv>Component content</div>
</template>
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
