### PR TITLE
feat(vite-plugin-angular): add ability to export from .ng files

### DIFF
--- a/apps/ng-app/src/app/export-stuff.ng
+++ b/apps/ng-app/src/app/export-stuff.ng
@@ -1,0 +1,20 @@
+<script lang="ts">
+  export interface MyInterface {
+    title: string;
+  }
+
+  export type MyType = string;
+
+  export enum Direction {
+    Up,
+    Down,
+    Left,
+    Right,
+  }
+
+  export function myFunc() {
+    return 'hi';
+  }
+</script>
+
+<template> Sharing is caring </template>

--- a/apps/ng-app/src/app/hello.ng
+++ b/apps/ng-app/src/app/hello.ng
@@ -10,10 +10,13 @@
     afterNextRender,
   } from '@angular/core';
 
+  import { myFunc } from './export-stuff.ng';
+
   defineMetadata({
     queries: {
       divElement: new ViewChild('divElement'),
     },
+    exposes: [myFunc],
   });
 
   let divElement: ElementRef<HTMLDivElement>;
@@ -47,6 +50,7 @@
   <p>Text from input: {{ text() }}</p>
   <button (click)="clicked.emit($event)">Emit The Click</button>
   <div #divElement>my div</div>
+  <p>From imported function: {{ myFunc() }}</p>
 </template>
 
 <style>

--- a/apps/ng-app/src/app/pages/about.page.ng
+++ b/apps/ng-app/src/app/pages/about.page.ng
@@ -4,6 +4,7 @@
 
   export const routeMeta: RouteMeta = {
     title: 'My page',
+    canActivate: [() => true],
   };
 </script>
 

--- a/apps/ng-app/src/app/pages/about.page.ng
+++ b/apps/ng-app/src/app/pages/about.page.ng
@@ -1,5 +1,11 @@
 <script lang="ts">
   import Hello from '../hello.ng';
+
+  defineMetadata({
+    route: {
+      title: 'My page',
+    },
+  });
 </script>
 
 <template>

--- a/apps/ng-app/src/app/pages/about.page.ng
+++ b/apps/ng-app/src/app/pages/about.page.ng
@@ -1,11 +1,10 @@
 <script lang="ts">
+  import { RouteMeta } from '@analogjs/router';
   import Hello from '../hello.ng';
 
-  defineMetadata({
-    route: {
-      title: 'My page',
-    },
-  });
+  export const routeMeta: RouteMeta = {
+    title: 'My page',
+  };
 </script>
 
 <template>

--- a/apps/ng-app/src/vite-env.d.ts
+++ b/apps/ng-app/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+import { RouteMeta } from '@analogjs/router';
+
 interface ImportMetaEnv {
   readonly VITE_ANALOG_PUBLIC_BASE_URL: string;
 }
@@ -28,8 +30,11 @@ declare global {
         | 'styles'
         | 'outputs'
         | 'inputs'
-      >
+      > & {
+        route: RouteMeta;
+      }
     ) => void;
+
     /**
      * Invoke the callback when the component is initialized.
      */

--- a/apps/ng-app/src/vite-env.d.ts
+++ b/apps/ng-app/src/vite-env.d.ts
@@ -1,7 +1,5 @@
 /// <reference types="vite/client" />
 
-import { RouteMeta } from '@analogjs/router';
-
 interface ImportMetaEnv {
   readonly VITE_ANALOG_PUBLIC_BASE_URL: string;
 }
@@ -30,9 +28,7 @@ declare global {
         | 'styles'
         | 'outputs'
         | 'inputs'
-      > & {
-        route: RouteMeta;
-      }
+      >
     ) => void;
 
     /**

--- a/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/ng.spec.ts.snap
+++ b/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/ng.spec.ts.snap
@@ -86,6 +86,9 @@ export enum Direction {
     Left,
     Right,
 }
+export function myFunc() {
+    console.log('hello');
+}
 "
 `;
 

--- a/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/ng.spec.ts.snap
+++ b/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/ng.spec.ts.snap
@@ -72,11 +72,20 @@ export default class VirtualAnalogComponent {
     protected output = new EventEmitter();
     protected outputWithType = new EventEmitter<string>();
 }
-
 export const routeMeta = {
     title: 'My page',
     canActivate: [() => true],
-};
+}
+export interface MyInterface {
+    title: string
+}
+export type MyType = string;
+export enum Direction {
+    Up,
+    Down,
+    Left,
+    Right,
+}
 "
 `;
 

--- a/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/ng.spec.ts.snap
+++ b/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/ng.spec.ts.snap
@@ -72,6 +72,11 @@ export default class VirtualAnalogComponent {
     protected output = new EventEmitter();
     protected outputWithType = new EventEmitter<string>();
 }
+
+export const routeMeta = {
+    title: 'My page',
+    canActivate: [() => true],
+};
 "
 `;
 

--- a/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
@@ -29,6 +29,10 @@ export enum Direction {
   Right,
 }
 
+export function myFunc(){
+  console.log('hello');
+}
+
 let divElement: ElementRef<HTMLDivElement>;
 let test: string;
 

--- a/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
@@ -108,7 +108,6 @@ effect(() => {
 describe('authoring ng file', () => {
   it('should process component as ng file', () => {
     const source = compileNgFile('virtual.ng.ts', COMPONENT_CONTENT);
-    console.log(source);
     expect(source).toContain('Component');
     expect(source).toMatchSnapshot();
   });

--- a/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
@@ -9,11 +9,25 @@ defineMetadata({
   queries: {
     divElement: new ViewChild('divElement')
   }
-  route: {
-    title: 'My page',
-    canActivate: [() => true],
-  }
 });
+
+export const routeMeta = {
+  title: 'My page',
+  canActivate: [() => true],
+}
+
+export interface MyInterface {
+  title: string
+}
+
+export type MyType = string;
+
+export enum Direction {
+  Up,
+  Down,
+  Left,
+  Right,
+}
 
 let divElement: ElementRef<HTMLDivElement>;
 let test: string;
@@ -94,6 +108,7 @@ effect(() => {
 describe('authoring ng file', () => {
   it('should process component as ng file', () => {
     const source = compileNgFile('virtual.ng.ts', COMPONENT_CONTENT);
+    console.log(source);
     expect(source).toContain('Component');
     expect(source).toMatchSnapshot();
   });

--- a/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/ng.spec.ts
@@ -9,6 +9,10 @@ defineMetadata({
   queries: {
     divElement: new ViewChild('divElement')
   }
+  route: {
+    title: 'My page',
+    canActivate: [() => true],
+  }
 });
 
 let divElement: ElementRef<HTMLDivElement>;

--- a/packages/vite-plugin-angular/src/lib/authoring/ng.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/ng.ts
@@ -296,7 +296,12 @@ function processNgScript(
         if (functionName === 'defineMetadata') {
           const metadata =
             expression.getArguments()[0] as ObjectLiteralExpression;
-          processMetadata(metadata, targetMetadataArguments, targetClass);
+          processMetadata(
+            metadata,
+            targetMetadataArguments,
+            targetClass,
+            targetSourceFile
+          );
         } else if (functionName === ON_INIT || functionName === ON_DESTROY) {
           const initFunction = expression.getArguments()[0];
           if (Node.isArrowFunction(initFunction)) {
@@ -368,7 +373,8 @@ ${gettersSetters
 function processMetadata(
   metadataObject: ObjectLiteralExpression,
   targetMetadataArguments: ObjectLiteralExpression,
-  targetClass: ClassDeclaration
+  targetClass: ClassDeclaration,
+  targetSourceFile: any
 ) {
   metadataObject.getPropertiesWithComments().forEach((property) => {
     if (Node.isPropertyAssignment(property)) {
@@ -398,6 +404,17 @@ function processMetadata(
             }));
 
           targetClass.addProperties(exposes);
+        } else if (propertyName === 'route') {
+          targetSourceFile.addVariableStatement({
+            isExported: true,
+            declarationKind: VariableDeclarationKind.Const,
+            declarations: [
+              {
+                name: 'routeMeta',
+                initializer: propertyInitializer.getText(),
+              },
+            ],
+          });
         } else {
           targetMetadataArguments.addPropertyAssignment({
             name: propertyName,

--- a/packages/vite-plugin-angular/src/lib/authoring/ng.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/ng.ts
@@ -294,12 +294,16 @@ function processNgScript(
     if (Node.isFunctionDeclaration(node)) {
       const functionName = node.getName();
       if (functionName) {
-        targetConstructor.addStatements([
-          // bring the function over
-          nodeFullText,
-          // assign class property
-          `this.${functionName} = ${functionName}.bind(this);`,
-        ]);
+        if (node.hasExportKeyword()) {
+          targetSourceFile.addStatements(nodeFullText);
+        } else {
+          targetConstructor.addStatements([
+            // bring the function over
+            nodeFullText,
+            // assign class property
+            `this.${functionName} = ${functionName}.bind(this);`,
+          ]);
+        }
       }
     }
 

--- a/packages/vite-plugin-angular/src/lib/authoring/ng.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/ng.ts
@@ -13,6 +13,7 @@ import {
   Project,
   PropertyDeclarationStructure,
   Scope,
+  SourceFile,
   StructureKind,
   SyntaxKind,
   VariableDeclarationKind,
@@ -374,7 +375,7 @@ function processMetadata(
   metadataObject: ObjectLiteralExpression,
   targetMetadataArguments: ObjectLiteralExpression,
   targetClass: ClassDeclaration,
-  targetSourceFile: any
+  targetSourceFile: SourceFile
 ) {
   metadataObject.getPropertiesWithComments().forEach((property) => {
     if (Node.isPropertyAssignment(property)) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

.ng format does not support defining a routeMeta

## What is the new behavior?

This allows adding a `route` configuration to `defineMetadata` e.g:

```ts
  defineMetadata({
    route: {
      title: 'My page',
    },
  });
```

Happy to modify how this is supplied - this seemed the most natural to me (I have also extended the window type to include the `RouteMeta` type for `route`).

I assumed we didn't want to `export` the routeMeta in .ng files. Another option I considered was having a separate `defineRouteMetadata`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
