### PR TITLE
fix(astro-angular): use first selector for component tag on server render

### DIFF
--- a/packages/astro-angular/src/server.ts
+++ b/packages/astro-angular/src/server.ts
@@ -81,7 +81,8 @@ async function renderToStaticMarkup(
   _children: unknown
 ) {
   const mirror = reflectComponentType(Component);
-  const appId = mirror?.selector || Component.name.toString().toLowerCase();
+  const appId =
+    mirror?.selector.split(',')[0] || Component.name.toString().toLowerCase();
   const document = `<${appId}></${appId}>`;
   const bootstrap = () =>
     bootstrapApplication(Component, {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [x] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

If a component has more than one selector when used with an Astro component, an error is thrown that it cannot find the root selector.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

If a component has more than one selector when used with an Astro component, the first selector is used to server render the component.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/GIZNdnvv8OqowDQiSL/giphy.gif"/>