### PR TITLE
fix(vite-plugin-angular): remove experimental support for .ng files

### DIFF
--- a/apps/ng-app/project.json
+++ b/apps/ng-app/project.json
@@ -6,7 +6,7 @@
   "sourceRoot": "apps/ng-app/src",
   "tags": [],
   "targets": {
-    "build": {
+    "builds": {
       "executor": "@nx/vite:build",
       "outputs": [
         "{options.outputPath}",

--- a/apps/ng-app/vite.config.ts
+++ b/apps/ng-app/vite.config.ts
@@ -15,7 +15,6 @@ export default defineConfig(({ mode }) => ({
   plugins: [
     analog({
       ssr: false,
-      vite: { experimental: { dangerouslySupportNgFormat: true } },
     }),
   ],
   test: {

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -41,12 +41,7 @@ export interface PluginOptions {
      */
     tsTransformers?: ts.CustomTransformers;
   };
-  experimental?: {
-    /**
-     * Enable experimental support for .ng file format! Use as your own risk!
-     */
-    dangerouslySupportNgFormat?: boolean;
-  };
+  experimental?: {};
   supportedBrowsers?: string[];
   transformFilter?: (code: string, id: string) => boolean;
 }
@@ -89,7 +84,7 @@ export function angular(options?: PluginOptions): Plugin[] {
     },
     supportedBrowsers: options?.supportedBrowsers ?? ['safari 15'],
     jit: options?.jit,
-    supportNgFormat: options?.experimental?.dangerouslySupportNgFormat,
+    supportNgFormat: false,
   };
 
   // The file emitter created during `onStart` that will be used during the build in `onLoad` callbacks for TS files


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Experimental support for `.ng` files was enabled through Analog

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Support for `.ng` files is removed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This was experimental in supporting an alternate way of authoring Angular components and directives. Despite various disclaimers, the `.ng` file associated causes too much confusion that this is an Angular team project that intends to replace the usage of class components in Angular.

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/hQKJar3Tz0jIxPhxf3/giphy.gif"/>