### PR TITLE
fix(vite-plugin-angular): escape common characters in code snippets for analog template

### DIFF
--- a/apps/ng-app/src/app/pages/about.page.analog
+++ b/apps/ng-app/src/app/pages/about.page.analog
@@ -18,5 +18,14 @@
   npm create analog
   ```
 
+  ```ts
+  @Component({
+    selector: 'app-root',
+  })
+  class AppComponent {
+    doSomething() {}
+  }
+  ```
+
   <Hello />
 </template>

--- a/packages/vite-plugin-angular/src/lib/authoring/marked-setup.service.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/marked-setup.service.ts
@@ -25,6 +25,17 @@ export class MarkedSetupService {
   constructor() {
     const renderer = new marked.Renderer();
     renderer.code = (code: string, lang: string) => {
+      // Escape commonly used HTML characters
+      // in Angular templates that cause template parse errors
+      // such as @, {, and ,}.
+      code = code.replace(/@/g, '&#64;');
+
+      if (code.includes('>{<') || code.includes('>}<')) {
+        code = code
+          .replace(/>\{</g, '>&#x2774;<')
+          .replace(/>\}</g, '>&#x2775;<');
+      }
+
       // Let's do a language based detection like on GitHub
       // So we can still have non-interpreted mermaid code
       if (lang === 'mermaid') {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

When using common characters such as `@`, `{`, and `}` with `lang="md"` in code blocks, a template compilation error occurs. These are reserved symbols in an Angular template that should be escaped using HTML entities.


```html
<template lang="md">
  # About me works!

  ## Subheader

  '''sh
  npm create analog
  '''

  '''ts
  @Component({
    selector: 'app-root',
  })
  class AppComponent {
    doSomething() {}
  }
  '''

  <Hello />
</template>
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When using common characters such as `@`, `{`, and `}` with `lang="md"` in code blocks, these characters are replaced with HTML entities. This reduces the compilation errors when using code blocks.

<img width="880" alt="image" src="https://github.com/analogjs/analog/assets/42211/3ffb11a6-e725-4af9-9f2f-5bfb6e59b28a">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
