### PR TITLE
feat: add initial support for agx content files

### DIFF
--- a/apps/ng-app/src/app/pages/posts.page.analog
+++ b/apps/ng-app/src/app/pages/posts.page.analog
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import {
+    inject,
+    ViewChild,
+    ElementRef,
+    afterNextRender,
+    ViewContainerRef,
+    ChangeDetectorRef,
+    signal
+  } from '@angular/core';
+  import { injectContentFiles } from '@analogjs/content';
+
+  defineMetadata({
+    queries: {
+      divPost: new ViewChild('post', { static: true, read: ViewContainerRef }),
+    }
+  });
+
+  let divPost: ElementRef<HTMLDivElement>;
+  const cdr = inject(ChangeDetectorRef);
+  let title = signal('');
+
+  afterNextRender(() => {
+    console.log('the post', divPost);
+
+    const postId = 'post';
+    import(`../../content/${postId}.agx`).then(m => {
+      divPost.createComponent(m.default);
+      title.set(m.metadata.title);
+      cdr.detectChanges();
+    });
+  });
+
+  const posts = injectContentFiles();
+
+  onInit(() => {
+    console.log('posts', posts);
+  });
+</script>
+
+<template>
+  Posts
+
+  @for (post of posts; track post) {
+    <p>{{ post.attributes.title }}</p>
+  }
+
+  <hr />
+
+  <h2>Post</h2>
+
+  <h3>{{ title() }}</h3>
+  
+  <div #post></div>
+</template>
+

--- a/apps/ng-app/src/content/post.agx
+++ b/apps/ng-app/src/content/post.agx
@@ -1,0 +1,11 @@
+---
+title: Hello World
+---
+
+<script lang="ts">
+  const name = 'Analog';
+</script>
+
+<template>
+  My First Post on {{ name }}
+</template>

--- a/packages/content/src/lib/get-content-files.ts
+++ b/packages/content/src/lib/get-content-files.ts
@@ -6,11 +6,14 @@
  * @returns
  */
 export const getContentFilesList = () =>
-  import.meta.glob<Record<string, any>>('/src/content/**/*.md', {
-    eager: true,
-    import: 'default',
-    query: { 'analog-content-list': true },
-  });
+  import.meta.glob<Record<string, any>>(
+    ['/src/content/**/*.md', '/src/content/**/*.agx'],
+    {
+      eager: true,
+      import: 'default',
+      query: { 'analog-content-list': true },
+    }
+  );
 
 /**
  * Returns the lazy loaded content files for lookups.
@@ -18,6 +21,6 @@ export const getContentFilesList = () =>
  * @returns
  */
 export const getContentFiles = () =>
-  import.meta.glob(['/src/content/**/*.md'], {
+  import.meta.glob(['/src/content/**/*.md', '/src/content/**/*.agx'], {
     as: 'raw',
   });

--- a/packages/platform/src/lib/content-plugin.ts
+++ b/packages/platform/src/lib/content-plugin.ts
@@ -14,7 +14,7 @@ export function contentPlugin(): Plugin[] {
       name: 'analogjs-content-frontmatter',
       async transform(code, id) {
         // Transform only the frontmatter into a JSON object for lists
-        if (!id.includes('.md?analog-content-list')) {
+        if (!id.includes('analog-content-list=true')) {
           return;
         }
 

--- a/packages/vite-plugin-angular/src/lib/authoring/frontmatter.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/frontmatter.ts
@@ -1,0 +1,12 @@
+export async function getFrontmatterMetadata(content: string) {
+  const fm: any = await import('front-matter');
+  // The `default` property will be available in CommonJS environment, for instance,
+  // when running unit tests. It's safe to retrieve `default` first, since we still
+  // fallback to the original implementation.
+  const frontmatterFn: (code: string) => { attributes: object } =
+    fm.default || fm;
+
+  const { attributes } = frontmatterFn(content);
+
+  return `\n\nexport const metadata = ${JSON.stringify(attributes)}`;
+}

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -31,9 +31,9 @@ export function augmentHostWithResources(
       onError,
       ...parameters
     ) => {
-      if (fileName.includes('.analog')) {
+      if (fileName.includes('.analog') || fileName.includes('.agx.ts')) {
         const contents = readFileSync(
-          fileName.replace('.analog.ts', '.analog'),
+          fileName.replace('.analog.ts', '.analog').replace('.agx.ts', '.agx'),
           'utf-8'
         );
         const source = compileAnalogFile(fileName, contents, options.isProd);
@@ -122,7 +122,7 @@ export function augmentHostWithResources(
         context.resourceFile ??
         `${context.containingFile.replace(/(\.analog)?\.ts$/, (...args) => {
           // NOTE: if the original file name contains `.analog`, we turn that into `-analog.css`
-          if (args.includes('.analog')) {
+          if (args.includes('.analog') || args.includes('.agx')) {
             return `-analog.${options?.inlineStylesExtension}`;
           }
           return `.${options?.inlineStylesExtension}`;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [x] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Markdown files can be used for content authoring, without support for Angular components

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The idea started in #448 by @joshuamorony 

This introduces support for `.agx` content files, which are similar to MDX files in that you can have markdown content with frontmatter, along with support for Analog and Angular component authoring syntax.

A similar project is [mdsvex](https://mdsvex.pngwn.io/) which enables this for Svelte components.

A `.agx` content file is transformed into a component file with 2 exports
- A default export for the compiled TypeScript code
- A `metadata` export for the associated frontmatter object

Example (post.agx)

```markdown
---
title: Hello World
---

<script lang="ts">
  const name = 'Analog';
</script>

<template>
  My First Post on {{ name }}
</template>
```

<img width="1284" alt="image" src="https://github.com/analogjs/analog/assets/42211/35b6ea9e-7027-4955-bcfd-ccb6744addad">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/lQ1AkXFktuJsnoqO3A/giphy.gif"/>
