### PR TITLE
fix(vite-plugin-angular): import marked setup service dynamically

### DIFF
--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -3,7 +3,6 @@ import { normalizePath } from '@ngtools/webpack/src/ivy/paths';
 import { readFileSync } from 'node:fs';
 import * as ts from 'typescript';
 import { compileAnalogFile } from './authoring/analog';
-import { MarkedSetupService } from './authoring/marked-setup.service';
 import { TEMPLATE_TAG_REGEX } from './authoring/constants';
 
 export function augmentHostWithResources(
@@ -98,6 +97,9 @@ export function augmentHostWithResources(
     }
 
     if (fileName.includes('virtual-analog:')) {
+      const { MarkedSetupService } = await import(
+        './authoring/marked-setup.service'
+      );
       // read template sections, parse markdown
       const markedSetupService = new MarkedSetupService();
       const mdContent = markedSetupService


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

The `marked-setup-service.ts` was being imported eagerly to support `.analog` files. When used with the Astro integration, this causes an error.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The `marked-setup-service.ts` is imported dynamically only for `.analog` files.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/Y4yUAenXjKBR8xypM9/giphy.gif"/>