### PR TITLE
feat(vite-plugin-angular): add include configuration for analog file globs

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -450,9 +450,8 @@ export function angular(options?: PluginOptions): Plugin[] {
     );
 
     const globs = [
-      `${appRoot}/**/*.analog`,
-      `${appRoot}/**/*.agx`,
-      ...extraGlobs.map((glob) => `${workspaceRoot}${glob}`),
+      `${appRoot}/**/*.{analog,agx}`,
+      ...extraGlobs.map((glob) => `${workspaceRoot}${glob}.{analog,agx}`),
     ];
 
     return fg

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -14,7 +14,12 @@ export function augmentHostWithResources(
   ) => ReturnType<any> | null,
   options: {
     inlineStylesExtension?: string;
-    supportAnalogFormat?: boolean;
+    supportAnalogFormat?:
+      | boolean
+      | {
+          include: string[];
+        };
+
     isProd?: boolean;
   } = {}
 ) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Currently the glob used to find analog files only searches from the root of the application, this means in a workspace with multiple projects analog files outside of the application directory won't be found/compiled

Closes #

## What is the new behavior?

Add a configuration to `supportAnalogFormat` to allow supplying additional globs that will be applied from the workspace root. This will allow specifying specific libraries/directories to find analog files in as well as the app directory which is included by default.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/Xfbm2QYPZczFnMyyyA/giphy.gif"/>