### PR TITLE
fix(vite-plugin-angular): extract `templateUrl`s using AST

### DIFF
--- a/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
@@ -139,6 +139,23 @@ describe('component-resolvers', () => {
         expect(thePathsAreEqual(resolvedTemplateUrls, [actualUrl])).toBe(true);
       });
 
+      it('should handle templateUrls with single quotes and route params', () => {
+        const code = `
+        @Component({
+          templateUrl: './[param].component.html'
+        })
+        export class MyComponent {}
+      `;
+
+        const actualUrl =
+          './[param].component.html|/path/to/src/[param].component.html';
+        const templateUrlsResolver = new TemplateUrlsResolver();
+        const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
+
+        expect(hasTemplateUrl(code)).toBeTruthy();
+        expect(thePathsAreEqual(resolvedTemplateUrls, [actualUrl])).toBe(true);
+      });
+
       it('should handle templateUrls with double quotes', () => {
         const code = `
         @Component({
@@ -149,6 +166,23 @@ describe('component-resolvers', () => {
 
         const actualUrl =
           './app.component.html|/path/to/src/app.component.html';
+        const templateUrlsResolver = new TemplateUrlsResolver();
+        const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
+
+        expect(hasTemplateUrl(code)).toBeTruthy();
+        expect(thePathsAreEqual(resolvedTemplateUrls, [actualUrl])).toBe(true);
+      });
+
+      it('should handle templateUrls with double quotes and route params', () => {
+        const code = `
+        @Component({
+          templateUrl: "./[param].component.html"
+        })
+        export class MyComponent {}
+      `;
+
+        const actualUrl =
+          './[param].component.html|/path/to/src/[param].component.html';
         const templateUrlsResolver = new TemplateUrlsResolver();
         const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
 

--- a/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
@@ -136,7 +136,7 @@ describe('component-resolvers', () => {
         const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
 
         expect(hasTemplateUrl(code)).toBeTruthy();
-        expect(thePathsAreEqual(resolvedTemplateUrls, [actualUrl]));
+        expect(thePathsAreEqual(resolvedTemplateUrls, [actualUrl])).toBe(true);
       });
 
       it('should handle templateUrls with double quotes', () => {
@@ -153,7 +153,7 @@ describe('component-resolvers', () => {
         const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
 
         expect(hasTemplateUrl(code)).toBeTruthy();
-        expect(thePathsAreEqual(resolvedTemplateUrls, [actualUrl]));
+        expect(thePathsAreEqual(resolvedTemplateUrls, [actualUrl])).toBe(true);
       });
 
       it('should handle multiple templateUrls in a single file', () => {
@@ -166,7 +166,7 @@ describe('component-resolvers', () => {
         @Component({
           templateUrl: "./app1.component.html"
         })
-        export class MyComponentTwo {}        
+        export class MyComponentTwo {}
       `;
 
         const actualUrl1 =
@@ -179,7 +179,21 @@ describe('component-resolvers', () => {
         expect(hasTemplateUrl(code)).toBeTruthy();
         expect(
           thePathsAreEqual(resolvedTemplateUrls, [actualUrl1, actualUrl2])
-        );
+        ).toBe(true);
+      });
+
+      it('should ignore commented out templateUrls', () => {
+        const code = `
+        @Component({
+          //templateUrl: './app.component.html'
+        })
+        export class MyComponent {}
+      `;
+
+        const templateUrlsResolver = new TemplateUrlsResolver();
+        const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
+
+        expect(resolvedTemplateUrls).toHaveLength(0);
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?
Closes #797 

## What is the new behavior?
Uses AST instead of string matching/replacement to parse `templateUrl`s

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media1.giphy.com/media/TFxKPzueXr3DbBJ3e4/giphy.gif"/>