### PR TITLE
fix(vite-plugin-nitro): forward HTTP headers to the API endpoint

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/runtime/api-middleware.js
+++ b/packages/vite-plugin-nitro/src/lib/runtime/api-middleware.js
@@ -19,7 +19,7 @@ export default eventHandler(async (event) => {
       // and can render the XML correctly as a static asset
       !event.node.req.url?.endsWith('.xml')
     ) {
-      return $fetch(reqUrl);
+      return $fetch(reqUrl, { headers: event.node.req.headers });
     }
 
     return proxyRequest(event, reqUrl, {


### PR DESCRIPTION
## PR Checklist

- [ x ] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ - ] Tests for the changes have been added (for bug fixes / features)
- [ - ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ x ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

The HTTP headers are not tranmitted to the API endpoints.

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No

## Other information

We are using cookies in our application, and there are some cases where cookies are not transmitted to the backend, during SSR rendering (for example, the default resolver doesn't transmit the cookies). The minimal modification we need for now is the one inside this PR.
