### PR TITLE
fix(vite-plugin-nitro): fix prerender from content directory

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/utils/get-content-files.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-content-files.ts
@@ -15,7 +15,7 @@ export function getMatchingContentFilesWithFrontMatter(
   const fm = require('front-matter');
   const root = normalizePath(path.resolve(workspaceRoot, rootDir));
 
-  const resolvedDir = normalizePath(path.resolve(root, glob));
+  const resolvedDir = normalizePath(path.relative(root, path.join(root, glob)));
   const contentFiles: string[] = fg.sync([`${root}/${resolvedDir}/*`], {
     dot: true,
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/analogjs/analog/issues/894

Closes #

## What is the new behavior?
The user can specify the contentDir with and without adding '/' as first character

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
While setting up the content directory the user has access to "transform" property, that's a callback. The callback is being called with the object returned by `getMatchingContentFilesWithFrontMatter` as its argument. Property "path" used to be always starting with '/' as first character but it's not anymore. Right now it's a relative path from root to content directory. I think that's the expected behavior.

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
