### PR TITLE
feat(vite-plugin-angular): use template block for auto imports

### DIFF
--- a/apps/ng-app/src/app/app.component.analog
+++ b/apps/ng-app/src/app/app.component.analog
@@ -51,11 +51,13 @@
 </script>
 
 <template>
-  import Hello from './hello.analog';
-  import AnotherOne from './another-one.analog';
-  import Highlight from './highlight.analog';
-  import External from './external/external.analog';
-  import { Goodbye } from './my-components';
+  <imports>
+    import Hello from './hello.analog';
+    import AnotherOne from './another-one.analog';
+    import Highlight from './highlight.analog';
+    import External from './external/external.analog';
+    import { Goodbye } from './my-components';
+  </imports>
 
   <External />
 

--- a/apps/ng-app/src/app/app.component.analog
+++ b/apps/ng-app/src/app/app.component.analog
@@ -84,7 +84,7 @@
 
   <br />
 
-  <goodbye />
+  <Goodbye />
 
   <router-outlet />
 </template>

--- a/apps/ng-app/src/app/app.component.analog
+++ b/apps/ng-app/src/app/app.component.analog
@@ -5,10 +5,6 @@
   import { RouterOutlet, RouterLink } from '@angular/router';
   import { delay } from 'rxjs';
 
-  import Hello from './hello.analog';
-  import AnotherOne from './another-one.analog';
-  import Highlight from './highlight.analog';
-  import External from './external/external.analog';
   import { HelloOriginal } from './hello';
 
   defineMetadata({
@@ -55,6 +51,12 @@
 </script>
 
 <template>
+  import Hello from './hello.analog';
+  import AnotherOne from './another-one.analog';
+  import Highlight from './highlight.analog';
+  import External from './external/external.analog';
+  import { Goodbye } from './my-components';
+
   <External />
 
   @if (counter() > 5) {
@@ -81,6 +83,8 @@
   <a routerLink="/">Home</a> | <a routerLink="/about">About</a>
 
   <br />
+
+  <goodbye />
 
   <router-outlet />
 </template>

--- a/apps/ng-app/src/app/goodbye.analog
+++ b/apps/ng-app/src/app/goodbye.analog
@@ -1,0 +1,3 @@
+<template>
+  <h2>Goodbye</h2>
+</template>

--- a/apps/ng-app/src/app/my-components.ts
+++ b/apps/ng-app/src/app/my-components.ts
@@ -1,0 +1,3 @@
+import Goodbye from './goodbye.analog';
+
+export { Goodbye };

--- a/apps/ng-app/src/app/pages/about.page.analog
+++ b/apps/ng-app/src/app/pages/about.page.analog
@@ -8,7 +8,9 @@
 </script>
 
 <template lang="md">
-  import Hello from '../hello.analog';
+  <imports>
+    import Hello from '../hello.analog';
+  </imports>
 
   # About me works!
 

--- a/apps/ng-app/src/app/pages/about.page.analog
+++ b/apps/ng-app/src/app/pages/about.page.analog
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { RouteMeta } from '@analogjs/router';
-  import Hello from '../hello.analog';
 
   export const routeMeta: RouteMeta = {
     title: 'My page',
@@ -9,6 +8,8 @@
 </script>
 
 <template lang="md">
+  import Hello from '../hello.analog';
+
   # About me works!
 
   ## Subheader

--- a/packages/vite-plugin-angular/src/lib/authoring/analog.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.ts
@@ -18,6 +18,7 @@ import {
 } from 'ts-morph';
 import {
   HOOKS_MAP,
+  IMPORT_STATEMENT_REGEX,
   INVALID_METADATA_PROPERTIES,
   ON_DESTROY,
   ON_INIT,
@@ -33,11 +34,9 @@ function extractAutoImports(
 ): [string, string[], string] {
   const autoImports = [];
   let importStatements = '';
-  const importRegex =
-    /import\s+({.*?})?\s*([\w\d]+)?\s+from\s+['"](.+?)['"]\s*;?/g;
 
   let match;
-  while ((match = importRegex.exec(templateContent)) !== null) {
+  while ((match = IMPORT_STATEMENT_REGEX.exec(templateContent)) !== null) {
     const defaultImport = match[2];
     const namedImports = match[1]
       ? match[1]
@@ -56,7 +55,7 @@ function extractAutoImports(
     importStatements += match[0] + '\n';
   }
 
-  templateContent = templateContent.replace(importRegex, '');
+  templateContent = templateContent.replace(IMPORT_STATEMENT_REGEX, '');
 
   return [templateContent.trim(), autoImports, importStatements.trim()];
 }
@@ -85,13 +84,17 @@ export function compileAnalogFile(
   // eslint-disable-next-line prefer-const
   let [scriptContent, templateContent, styleContent] = [
     SCRIPT_TAG_REGEX.exec(fileContent)?.pop()?.trim() || '',
-    isMarkdown ? '' : TEMPLATE_TAG_REGEX.exec(fileContent)?.pop()?.trim() || '',
+    TEMPLATE_TAG_REGEX.exec(fileContent)?.pop()?.trim() || '',
     STYLE_TAG_REGEX.exec(fileContent)?.pop()?.trim() || '',
   ];
 
   const [extractedTemplateContent, autoImports, templateImportStatements] =
     extractAutoImports(templateContent);
   templateContent = extractedTemplateContent;
+
+  if (isMarkdown) {
+    templateContent = '';
+  }
 
   scriptContent = templateImportStatements + scriptContent;
 

--- a/packages/vite-plugin-angular/src/lib/authoring/constants.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/constants.ts
@@ -11,6 +11,7 @@ export const SCRIPT_TAG_REGEX = /<script lang="ts">([\s\S]*?)<\/script>/i;
 export const TEMPLATE_TAG_REGEX =
   /(<template>|<template lang="md">)([\s\S]*?)<\/template>/i;
 export const STYLE_TAG_REGEX = /<style>([\s\S]*?)<\/style>/i;
+export const IMPORT_TAG_REGEX = /<imports>([\s\S]*?)<\/imports>/i;
 export const IMPORT_STATEMENT_REGEX =
   /import\s+({.*?})?\s*([\w\d]+)?\s+from\s+['"](.+?)['"]\s*;?/g;
 

--- a/packages/vite-plugin-angular/src/lib/authoring/constants.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/constants.ts
@@ -11,6 +11,8 @@ export const SCRIPT_TAG_REGEX = /<script lang="ts">([\s\S]*?)<\/script>/i;
 export const TEMPLATE_TAG_REGEX =
   /(<template>|<template lang="md">)([\s\S]*?)<\/template>/i;
 export const STYLE_TAG_REGEX = /<style>([\s\S]*?)<\/style>/i;
+export const IMPORT_STATEMENT_REGEX =
+  /import\s+({.*?})?\s*([\w\d]+)?\s+from\s+['"](.+?)['"]\s*;?/g;
 
 export const ON_INIT = 'onInit';
 export const ON_DESTROY = 'onDestroy';

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -3,10 +3,7 @@ import { normalizePath } from '@ngtools/webpack/src/ivy/paths';
 import { readFileSync } from 'node:fs';
 import * as ts from 'typescript';
 import { compileAnalogFile } from './authoring/analog';
-import {
-  IMPORT_STATEMENT_REGEX,
-  TEMPLATE_TAG_REGEX,
-} from './authoring/constants';
+import { IMPORT_TAG_REGEX, TEMPLATE_TAG_REGEX } from './authoring/constants';
 
 export function augmentHostWithResources(
   host: ts.CompilerHost,
@@ -76,7 +73,7 @@ export function augmentHostWithResources(
         let templateContent =
           TEMPLATE_TAG_REGEX.exec(fileContent)?.pop()?.trim() || '';
 
-        templateContent = templateContent.replace(IMPORT_STATEMENT_REGEX, '');
+        templateContent = templateContent.replace(IMPORT_TAG_REGEX, '');
 
         return templateContent;
       }

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -3,7 +3,10 @@ import { normalizePath } from '@ngtools/webpack/src/ivy/paths';
 import { readFileSync } from 'node:fs';
 import * as ts from 'typescript';
 import { compileAnalogFile } from './authoring/analog';
-import { TEMPLATE_TAG_REGEX } from './authoring/constants';
+import {
+  IMPORT_STATEMENT_REGEX,
+  TEMPLATE_TAG_REGEX,
+} from './authoring/constants';
 
 export function augmentHostWithResources(
   host: ts.CompilerHost,
@@ -70,8 +73,10 @@ export function augmentHostWithResources(
           'No Analog Markdown Content Found';
 
         // eslint-disable-next-line prefer-const
-        const templateContent =
+        let templateContent =
           TEMPLATE_TAG_REGEX.exec(fileContent)?.pop()?.trim() || '';
+
+        templateContent = templateContent.replace(IMPORT_STATEMENT_REGEX, '');
 
         return templateContent;
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

The current approach for automatically adding `.analog` components to the `imports` for a component only works if the import is directly a `.analog` file, e.g:

```ts
import MyThing from './my-thing.analog'
```

The following import will not work:

```ts
import { MyOtherThing } from './my-components'
```

Unless `MyOtherThing` is manually added to `imports` in `defineMetadata`

Closes #

## What is the new behavior?

This PR introduces a new format for handling auto imports and removes the existing functionality. With this approach, imports for the template would be supplied within an imports tag in the template, e.g:

```html
<template>
  <imports>
    import External from './external/external.analog';
    import { Goodbye } from './my-components';
    import { MyComponentModule } from '@org/shared/components';
  </imports>

  <p>Hello</p>
  <External />
  <Goodbye />
  <some-component />
</template>
```

Any import declarations in the template will be added to the component, and all of the named/default imports will also be added to the `imports` array in the components metadata.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This change would be breaking as any imports for the template would need to be moved to the template tag - however, we could also easily leave in the automatic imports of `.analog` files either permanently or perhaps deprecate it.

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/6uGk0oyqsHylHIiGxh/giphy.gif"/>