### PR TITLE
feat(vite-plugin-angular): support auto import via barrel files

### DIFF
--- a/apps/ng-app/src/app/another-one.analog
+++ b/apps/ng-app/src/app/another-one.analog
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { ChangeDetectorRef, inject } from '@angular/core';
+  import Barrel from './barrel' with { type: 'template' };
 
   const cdr = inject(ChangeDetectorRef);
 
@@ -24,6 +25,8 @@
   @if (lateVariable) {
   <h2>Late Variable here: {{ lateVariable }}</h2>
   }
+
+  <Barrel />
 </template>
 
 <style>

--- a/apps/ng-app/src/app/app.component.analog
+++ b/apps/ng-app/src/app/app.component.analog
@@ -1,19 +1,18 @@
 <script lang="ts">
   import { inject, signal, effect, computed } from '@angular/core';
   import { HttpClient } from '@angular/common/http';
-  import { JsonPipe } from '@angular/common';
-  import { RouterOutlet, RouterLink } from '@angular/router';
+  import { JsonPipe } from '@angular/common' with { type: 'template' };
+  import { RouterOutlet, RouterLink } from '@angular/router' with { type: 'template' }
   import { delay } from 'rxjs';
 
-  import Hello from './hello.analog';
-  import AnotherOne from './another-one.analog';
-  import Highlight from './highlight.analog';
-  import External from './external/external.analog';
-  import { HelloOriginal } from './hello';
+  import Hello from './hello.analog' with { type: 'template' };
+  import AnotherOne from './another-one.analog' with { type: 'template' };
+  import Highlight from './highlight.analog' with { type: 'template' };
+  import External from './external/external.analog' with { type: 'template' };
+  import { HelloOriginal } from './hello' with { type: 'template' };
 
   defineMetadata({
     selector: 'app-root',
-    imports: [JsonPipe, HelloOriginal, RouterOutlet, RouterLink],
     exposes: [Math],
   });
 

--- a/apps/ng-app/src/app/barrel/barrel.analog
+++ b/apps/ng-app/src/app/barrel/barrel.analog
@@ -1,0 +1,3 @@
+<template>
+  <h1>Barrel</h1>
+</template>

--- a/apps/ng-app/src/app/barrel/index.ts
+++ b/apps/ng-app/src/app/barrel/index.ts
@@ -1,0 +1,2 @@
+import Barrel from './barrel.analog';
+export default Barrel;

--- a/apps/ng-app/src/app/hello.analog
+++ b/apps/ng-app/src/app/hello.analog
@@ -16,7 +16,7 @@
     queries: {
       divElement: new ViewChild('divElement'),
     },
-    exposes: [myFunc],
+    exposes: [myFunc]
   });
 
   let divElement: ElementRef<HTMLDivElement>;

--- a/apps/ng-app/src/app/pages/about.page.analog
+++ b/apps/ng-app/src/app/pages/about.page.analog
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { RouteMeta } from '@analogjs/router';
-  import Hello from '../hello.analog';
-
+  import Hello from '../hello.analog' with { type: 'template' };
   export const routeMeta: RouteMeta = {
     title: 'My page',
     canActivate: [() => true],

--- a/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
@@ -1,5 +1,4 @@
 import { Plugin, PluginContainer, ViteDevServer } from 'vite';
-import { readFileSync } from 'fs';
 
 export function jitPlugin({
   inlineStylesExtension,

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1,7 +1,6 @@
 import { CompilerHost, NgtscProgram } from '@angular/compiler-cli';
 import { transformAsync } from '@babel/core';
 import * as path from 'path';
-
 import * as ts from 'typescript';
 import {
   ModuleNode,
@@ -14,7 +13,6 @@ import {
 import { buildOptimizerPlugin } from './angular-build-optimizer-plugin';
 import { jitPlugin } from './angular-jit-plugin';
 import { angularVitestPlugin } from './angular-vitest-plugin';
-
 import { createCompilerPlugin } from './compiler-plugin';
 import { StyleUrlsResolver, TemplateUrlsResolver } from './component-resolvers';
 import { augmentHostWithResources } from './host';

--- a/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/analog.spec.ts.snap
+++ b/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/analog.spec.ts.snap
@@ -6,7 +6,7 @@ import { signal, input, ViewChild, afterNextRender, ElementRef, viewChild, viewC
 
 @Component({
     standalone: true,
-    selector: 'virtual,Virtual,VIRTUAL',
+    selector: 'virtual,Virtual',
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: \`<div #divElement>Component</div>
   <p>{{ counter() }}</p>
@@ -124,7 +124,7 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   standalone: true,
-  selector: 'virtual,Virtual,VIRTUAL',
+  selector: 'virtual,Virtual',
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: \`virtual-analog:virtual.analog\`
 })

--- a/packages/vite-plugin-angular/src/lib/compiler-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler-plugin.ts
@@ -7,7 +7,6 @@
  */
 
 import type { DepOptimizationConfig } from 'vite';
-
 import { CompilerPluginOptions, JavaScriptTransformer } from './utils/devkit';
 
 type EsbuildOptions = NonNullable<DepOptimizationConfig['esbuildOptions']>;

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -19,7 +19,6 @@ export function augmentHostWithResources(
       | {
           include: string[];
         };
-
     isProd?: boolean;
   } = {}
 ) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

- Importing `.analog` entities via barrel files aren't auto-imported

Closes #

## What is the new behavior?

- Importing `.analog` entities via barrel files should be auto-imported with the following caveat: only `export { default as NamedExport }` syntax is supported at the moment

```ts
export { default as NamedExport } from './local.analog';
```

```ts
import { NamedExport } from '@path/to/barrel';
```

- Do not require `@nx/devkit` anymore and use local utilities to compute names. This ensures Angular CLI projects (via `custom-esbuild` builder) work without having to installing `nx` and `@nx/devkit`.
- Remove `constantName` as a default selector.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
