### PR TITLE
refactor(vite-plugin-angular): do not use names from nx/devkit

### DIFF
--- a/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/analog.spec.ts.snap
+++ b/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/analog.spec.ts.snap
@@ -6,7 +6,7 @@ import { signal, input, ViewChild, afterNextRender, ElementRef, viewChild, viewC
 
 @Component({
     standalone: true,
-    selector: 'virtual,Virtual,VIRTUAL',
+    selector: 'virtual,Virtual',
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: \`<div #divElement>Component</div>
   <p>{{ counter() }}</p>
@@ -124,7 +124,7 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   standalone: true,
-  selector: 'virtual,Virtual,VIRTUAL',
+  selector: 'virtual,Virtual',
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: \`virtual-analog:virtual.analog\`
 })

--- a/packages/vite-plugin-angular/src/lib/authoring/analog.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.ts
@@ -38,14 +38,10 @@ export function compileAnalogFile(
     throw new Error(`[Analog] Missing component name ${filePath}`);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { names } = require('@nx/devkit');
-
-  const {
-    fileName: componentFileName,
-    className,
-    constantName,
-  } = names(componentName);
+  const [componentFileName, className] = [
+    toFileName(componentName),
+    toClassName(componentName),
+  ];
 
   const isMarkdown = fileContent.includes('lang="md"');
 
@@ -94,7 +90,7 @@ import { ${ngType}${
 
 @${ngType}({
   standalone: true,
-  selector: '${componentFileName},${className},${constantName}',
+  selector: '${componentFileName},${className}',
   ${componentMetadata}
 })
 export default class ${entityName} {
@@ -537,4 +533,38 @@ function getIOStructure(
   }
 
   return null;
+}
+
+/**
+ * Hyphenated to UpperCamelCase
+ */
+function toClassName(str: string) {
+  return toCapitalCase(toPropertyName(str));
+}
+/**
+ * Hyphenated to lowerCamelCase
+ */
+function toPropertyName(str: string) {
+  return str
+    .replace(/([^a-zA-Z0-9])+(.)?/g, (_, __, chr) =>
+      chr ? chr.toUpperCase() : ''
+    )
+    .replace(/[^a-zA-Z\d]/g, '')
+    .replace(/^([A-Z])/, (m) => m.toLowerCase());
+}
+
+/**
+ * Upper camelCase to lowercase, hyphenated
+ */
+function toFileName(str: string) {
+  return str
+    .replace(/([a-z\d])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .replace(/(?!^[_])[ _]/g, '-');
+}
+/**
+ * Capitalizes the first letter of a string
+ */
+function toCapitalCase(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }


### PR DESCRIPTION
BREAKING CHANGE: This PR removes `constantName` from the default selectors

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

`names` is imported from `nx/devkit` to derive different variations of the `componentName`. This forces Angular CLI users to install `nx` and `nx/devkit` to use `.analog` format.

Closes #

## What is the new behavior?

- No longer use `nx/devkit`
- The utilities of `names` are copied over
- `constantName` is removed from the default selectors

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
