### PR TITLE
feat(create-analog): skip git init flag

### DIFF
--- a/packages/create-analog/index.js
+++ b/packages/create-analog/index.js
@@ -50,6 +50,7 @@ async function init() {
   let targetDir = formatTargetDir(argv._[0]);
   let template = argv.template || argv.t;
   let skipTailwind = argv.skipTailwind || false;
+  let skipGit = argv.skipGit || false;
 
   const defaultTargetDir = 'analog-project';
   const getProjectName = () =>
@@ -206,14 +207,17 @@ async function init() {
 
   write('package.json', JSON.stringify(pkg, null, 2));
 
-  console.log(`\nInitializing git repository:`);
-  execSync(`git init ${targetDir} && cd ${targetDir} && git add .`);
+  skipGit = isGitInitialized(cwd) || skipGit;
+  if (!skipGit) {
+    console.log(`\nInitializing git repository:`);
+    execSync(`git init ${targetDir} && cd ${targetDir} && git add .`);
 
-  // Fail Silent
-  // Can fail when user does not have global git credentials
-  try {
-    execSync(`cd ${targetDir} && git commit -m "initial commit"`);
-  } catch {}
+    // Fail Silent
+    // Can fail when user does not have global git credentials
+    try {
+      execSync(`cd ${targetDir} && git commit -m "initial commit"`);
+    } catch {}
+  }
 
   console.log(`\nDone. Now run:\n`);
   if (root !== cwd) {
@@ -352,6 +356,16 @@ function addDevDependencies(pkg) {
       pkg.devDependencies[name] = version;
     }
   );
+}
+
+function isGitInitialized(dir) {
+  const gitDir = path.join(dir, '.git');
+  if (fs.existsSync(gitDir)) return true;
+
+  const parentDir = path.dirname(dir);
+  if (parentDir === dir) return false;
+
+  return isGitInitialized(parentDir);
 }
 
 init().catch((e) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [x] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

create-analog always initializes the git repo, even if the project is scaffolded inside the monorepo, where git is already initialized.

## What is the new behavior?

create-analog will initialize a new repo only if cwd and parent directories don't have an initialized git repo. Git init could also be skipped through the --skipGit flag.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
