### PR TITLE
feat(vite-plugin-angular): allow analog imports with no name

### DIFF
--- a/apps/ng-app/src/app/app.component.analog
+++ b/apps/ng-app/src/app/app.component.analog
@@ -5,10 +5,10 @@
   import { RouterOutlet, RouterLink } from '@angular/router' with { analog: 'imports'};
   import { delay } from 'rxjs';
 
-  import Hello from './hello.analog' with { analog: 'imports'};
-  import AnotherOne from './another-one.analog' with { analog: 'imports' };
-  import Highlight from './highlight.analog' with { analog: 'imports' };
-  import External from './external/external.analog' with { analog: 'imports' };
+  import './hello.analog' with { analog: 'imports'};
+  import './another-one.analog' with { analog: 'imports' };
+  import './highlight.analog' with { analog: 'imports' };
+  import './external/external.analog' with { analog: 'imports' };
   import { Goodbye } from './my-components' with { analog: 'imports' };
   import { HelloOriginal } from './hello' with { analog: 'imports'};
   import { MyService } from './my.service' with { analog: 'providers'};

--- a/apps/ng-app/src/app/pages/about.page.analog
+++ b/apps/ng-app/src/app/pages/about.page.analog
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { RouteMeta } from '@analogjs/router';
-  import Hello from '../hello.analog' with { analog: 'imports'};
+  import '../hello.analog' with { analog: 'imports'};
 
   export const routeMeta: RouteMeta = {
     title: 'My page',

--- a/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/analog.spec.ts.snap
+++ b/packages/vite-plugin-angular/src/lib/authoring/__snapshots__/analog.spec.ts.snap
@@ -6,6 +6,7 @@ import { signal, input, ViewChild, afterNextRender, ElementRef, viewChild, viewC
 import External from "./external.analog";
 import { ExternalService } from "./external";
 import { ExternalEnum } from "./external.model";
+import nonameanalog from "./noname.analog";
 
 @Component({
     standalone: true,
@@ -21,7 +22,7 @@ import { ExternalEnum } from "./external.model";
     queries: {
         divElement: new ViewChild('divElement')
     },
-    imports: [External],
+    imports: [External, nonameanalog],
     providers: [ExternalService],
     outputs: ['output', 'outputWithType']
 })

--- a/packages/vite-plugin-angular/src/lib/authoring/analog.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.spec.ts
@@ -6,6 +6,7 @@ import { signal, input, ViewChild, afterNextRender, ElementRef, viewChild, viewC
 import External from './external.analog' with { analog: 'imports' };
 import { ExternalService } from './external' with { analog: 'providers' };
 import { ExternalEnum } from './external.model' with { analog: 'exposes' };
+import './noname.analog' with { analog: 'imports' };
 
 defineMetadata({
   exposes: [Math],

--- a/packages/vite-plugin-angular/src/lib/authoring/analog.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.ts
@@ -172,7 +172,11 @@ function processAnalogScript(
     if (Node.isImportDeclaration(node)) {
       let structure = node.getStructure();
 
-      if (!structure.namedImports?.length && !structure.defaultImport) {
+      if (
+        !structure.namedImports?.length &&
+        !structure.defaultImport &&
+        structure.moduleSpecifier.endsWith('.analog')
+      ) {
         const generatedName = structure.moduleSpecifier.replace(
           /[^a-zA-Z]/g,
           ''

--- a/packages/vite-plugin-angular/src/lib/authoring/analog.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.ts
@@ -5,6 +5,7 @@ import {
   FunctionDeclaration,
   FunctionExpression,
   ImportAttributeStructure,
+  ImportDeclaration,
   ImportSpecifierStructure,
   Node,
   ObjectLiteralExpression,
@@ -169,7 +170,17 @@ function processAnalogScript(
 
   for (const node of sourceSyntaxList.getChildren()) {
     if (Node.isImportDeclaration(node)) {
-      const structure = node.getStructure();
+      let structure = node.getStructure();
+
+      if (!structure.namedImports?.length && !structure.defaultImport) {
+        const generatedName = structure.moduleSpecifier.replace(
+          /[^a-zA-Z]/g,
+          ''
+        );
+        (node as ImportDeclaration).setDefaultImport(generatedName);
+        structure = node.getStructure();
+      }
+
       const attributes = structure.attributes;
       const passThroughAttributes: OptionalKind<ImportAttributeStructure>[] =
         [];


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Analog components need to be imported like this:

```ts
import Hello from './hello.analog' with { analog: 'imports' };
```

and can then be used like this:

```html
<Hello />
```

I think this creates the false perception that the name of the default import is relevant, when it isn't actually used at all to determine the components selector. If we change the default import name:

```ts
import HelloComponent from './hello.analog' with { analog: 'imports' };
```

```html
<HelloComponent />
```

This will not work. I think this is surprising behaviour, and second to that since we don't actually need the default import name it is unnecessary boilerplate.

## What is the new behavior?

This PR allows importing analog components like this:

```ts
import './hello.analog' with { analog: 'imports' };
```

Which I think makes for nicer DX and removes the confusion around the default import name having anything to do with the selector.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/3o85xL8B5OwJsoeAzC/giphy.gif"/>