### PR TITLE
refactor(vite-plugin-angular): use standard imports for ng-app examples

### DIFF
--- a/apps/ng-app/src/app/app.component.analog
+++ b/apps/ng-app/src/app/app.component.analog
@@ -5,9 +5,11 @@
   import { RouterOutlet, RouterLink } from '@angular/router' with { analog: 'imports'};
   import { delay } from 'rxjs';
 
-  import './hello.analog' with { analog: 'imports'};
-  import './another-one.analog' with { analog: 'imports' };
-  import './highlight.analog' with { analog: 'imports' };
+  import Hello from './hello.analog' with { analog: 'imports'};
+  import AnotherOne from './another-one.analog' with { analog: 'imports' };
+  import Highlight from './highlight.analog' with { analog: 'imports' };
+
+  // components can optionally be imported with no default import name
   import './external/external.analog' with { analog: 'imports' };
   import { Goodbye } from './my-components' with { analog: 'imports' };
   import { HelloOriginal } from './hello' with { analog: 'imports'};

--- a/apps/ng-app/src/app/pages/about.page.analog
+++ b/apps/ng-app/src/app/pages/about.page.analog
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { RouteMeta } from '@analogjs/router';
-  import '../hello.analog' with { analog: 'imports'};
+  import Hello from '../hello.analog' with { analog: 'imports' };
 
   export const routeMeta: RouteMeta = {
     title: 'My page',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

The example `ng-app` uses the non-standard format for importing `.analog` components:

```ts
import './hello.analog' with { analog: 'imports' };
```

## What is the new behavior?

Uses standard imports for examples:

```ts
import Hello from './hello.analog' with { analog: 'imports' };
```

(one example is left using no default import name)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/xFpT7lMV5Mkqq0E6YM/giphy.gif"/>
