### PR TITLE
fix: add file protocol to solve windows pre rendering issues

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -3,6 +3,7 @@ import { App, toNodeListener } from 'h3';
 import type { Plugin, UserConfig } from 'vite';
 import { normalizePath, ViteDevServer } from 'vite';
 import * as path from 'path';
+import { platform } from 'node:os';
 
 import { buildServer } from './build-server';
 import { buildSSRApp } from './build-ssr';
@@ -15,6 +16,7 @@ import { devServerPlugin } from './plugins/dev-server-plugin';
 import { loadEsmModule } from './utils/load-esm';
 import { getMatchingContentFilesWithFrontMatter } from './utils/get-content-files';
 
+const isWindows = platform() === 'win32';
 let clientOutputPath = '';
 
 export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
@@ -104,9 +106,12 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
         }
 
         nitroConfig.alias = {
-          '#analog/ssr': normalizePath(
-            path.resolve(workspaceRoot, 'dist', rootDir, 'ssr/main.server')
-          ),
+          // This is not the final fix but start point to discuss a fix for windows
+          '#analog/ssr':
+            (isWindows ? 'file://' : '') +
+            normalizePath(
+              path.resolve(workspaceRoot, 'dist', rootDir, 'ssr/main.server')
+            ),
           '#analog/index': normalizePath(
             path.resolve(clientOutputPath, 'index.html')
           ),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

In windows pre rendering fails due next error

```
[nitro] [request error] [unhandled] Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:' 
```

Closes https://github.com/analogjs/analog/issues/688

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
