### PR TITLE
fix(vite-plugin-angular): remove numbers at beginning in toPropertyName

### DIFF
--- a/packages/vite-plugin-angular/src/lib/authoring/analog.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.ts
@@ -631,7 +631,7 @@ function getIOStructure(
  * Hyphenated to UpperCamelCase
  */
 function toClassName(str: string) {
-  return toCapitalCase(toPropertyName(str));
+  return toCapitalCase(toPropertyName(toNonNumeric(str)));
 }
 /**
  * Hyphenated to lowerCamelCase
@@ -659,4 +659,10 @@ function toFileName(str: string) {
  */
 function toCapitalCase(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
+}
+/**
+ * Removes numbers from a string
+ */
+function toNonNumeric(str: string) {
+  return str.replace(/[0-9]/g, '');
 }

--- a/packages/vite-plugin-angular/src/lib/authoring/analog.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.ts
@@ -631,7 +631,7 @@ function getIOStructure(
  * Hyphenated to UpperCamelCase
  */
 function toClassName(str: string) {
-  return toCapitalCase(toPropertyName(toNonNumeric(str)));
+  return toCapitalCase(toPropertyName(str));
 }
 /**
  * Hyphenated to lowerCamelCase
@@ -642,7 +642,8 @@ function toPropertyName(str: string) {
       chr ? chr.toUpperCase() : ''
     )
     .replace(/[^a-zA-Z\d]/g, '')
-    .replace(/^([A-Z])/, (m) => m.toLowerCase());
+    .replace(/^([A-Z])/, (m) => m.toLowerCase())
+    .replace(/^\d+/, '');
 }
 
 /**
@@ -659,10 +660,4 @@ function toFileName(str: string) {
  */
 function toCapitalCase(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
-}
-/**
- * Removes numbers from a string
- */
-function toNonNumeric(str: string) {
-  return str.replace(/[0-9]/g, '');
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

If an analog/agx file contains a number, e.g:

```
01-lesson-one.agx
02-lesson-two.agx
03-lesson-three.agx
```

The number will be used in the generated class name and will cause `ts-morph` to fail

## What is the new behavior?

Numbers are stripped when generating class names

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/NKjsoJHLZKbSeTd7uk/giphy-downsized-medium.gif"/>
