### PR TITLE
fix(vite-plugin-angular): remove numbers from beginning of file name selector

### DIFF
--- a/packages/vite-plugin-angular/src/lib/authoring/analog.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.ts
@@ -657,7 +657,8 @@ function toFileName(str: string) {
   return str
     .replace(/([a-z\d])([A-Z])/g, '$1_$2')
     .toLowerCase()
-    .replace(/(?!^[_])[ _]/g, '-');
+    .replace(/(?!^[_])[ _]/g, '-')
+    .replace(/^\d+-?/, '');
 }
 /**
  * Capitalizes the first letter of a string


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Similar to https://github.com/analogjs/analog/pull/919

When attempting to create a component using a `.agx` file:

```
  import(
    `../../../content/modules/lessons/angular-getting-started/01-generating-angular-app.agx`
  ).then((m) => {
    divPost().createComponent(m.default);
    cdr.detectChanges();
  });
```

It will fail if the file name begins with numbers, as this is used to generate a selector for the component of `01-generating-angular-app` and then `createComponent` will try to use that as the tag name but it is invalid.

## What is the new behavior?

This change strips any leading numbers/hyphen from the selector generated from the file name, so `01-generating-angular-app.agx` would result in a selector of `generating-angular-app`

This change applies to all file name based selectors not just `.agx` files

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/NKjsoJHLZKbSeTd7uk/giphy-downsized-medium.gif"/>
