### PR TITLE
fix(vite-plugin-angular): escape breaking characters for codespan

### DIFF
--- a/apps/ng-app/src/content/post.agx
+++ b/apps/ng-app/src/content/post.agx
@@ -14,4 +14,11 @@ title: Hello World
   ```ts
   const test = "hi";
   ```
+
+  Make cool apps with `@analogjs/platform`:
+
+  ```ts
+  import { CoolStuff } from "@analogjs/platform"
+  ```
+
 </template>

--- a/packages/vite-plugin-angular/src/lib/authoring/marked-setup.service.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/marked-setup.service.ts
@@ -24,18 +24,14 @@ export class MarkedSetupService {
 
   constructor() {
     const renderer = new marked.Renderer();
+
+    renderer.codespan = (code: string) => {
+      code = this.escapeBreakingCharacters(code);
+      return `<code>${code}</code>`;
+    };
+
     renderer.code = (code: string, lang: string) => {
-      // Escape commonly used HTML characters
-      // in Angular templates that cause template parse errors
-      // such as @, {, and ,}.
-      code = code.replace(/@/g, '&#64;');
-
-      if (code.includes('>{<') || code.includes('>}<')) {
-        code = code
-          .replace(/>\{</g, '>&#x2774;<')
-          .replace(/>\}</g, '>&#x2775;<');
-      }
-
+      code = this.escapeBreakingCharacters(code);
       // Let's do a language based detection like on GitHub
       // So we can still have non-interpreted mermaid code
       if (lang === 'mermaid') {
@@ -106,6 +102,19 @@ export class MarkedSetupService {
     );
 
     this.marked = marked;
+  }
+
+  escapeBreakingCharacters(code: string) {
+    // Escape commonly used HTML characters
+    // in Angular templates that cause template parse errors
+    // such as @, {, and ,}.
+    code = code.replace(/@/g, '&#64;');
+
+    if (code.includes('>{<') || code.includes('>}<')) {
+      code = code.replace(/>\{</g, '>&#x2774;<').replace(/>\}</g, '>&#x2775;<');
+    }
+
+    return code;
   }
 
   getMarkedInstance(): typeof marked {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

We escape potentially breaking characters for code blocks in the `MarkedSetupService` but not for single backtick codespans.

This caused a situation where if you have something like this in an agx file:

```
You will need to import from `@angular/fire`
```

It will cause a JIT compilation error because the `@` is never escaped.

## What is the new behavior?

The logic for escaping characters has been abstracted and is used for both `code` and `codespan` when setting up marked now.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/O2ZurZ1wcFqxjrKj9f/giphy.gif"/>
