### PR TITLE
feat(vite-plugin-angular): support components and control flow in markdown

### DIFF
--- a/apps/ng-app/src/app/pages/about.page.analog
+++ b/apps/ng-app/src/app/pages/about.page.analog
@@ -6,6 +6,8 @@
     title: 'My page',
     canActivate: [() => true],
   };
+
+  const helloInput = "test";
 </script>
 
 <template lang="md">
@@ -27,5 +29,5 @@
   }
   ```
 
-  <Hello />
+  <Hello [text]="helloInput" />
 </template>

--- a/apps/ng-app/src/content/post.agx
+++ b/apps/ng-app/src/content/post.agx
@@ -3,7 +3,11 @@ title: Hello World
 ---
 
 <script lang="ts">
-  const name = 'Analog';
+import Hello from '../app/hello.analog' with { analog: 'imports' };
+
+const name = 'Analog';
+const greetings = ['Hello', 'Hi'];
+const show = false;
 </script>
 
 <template lang="md">
@@ -20,5 +24,13 @@ title: Hello World
   ```ts
   import { CoolStuff } from "@analogjs/platform"
   ```
+
+  @for(greeting of greetings; track $index){
+    <Hello [text]="greeting" />
+  }
+
+  @if(show){
+    <p>I am hidden</p>
+  }
 
 </template>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

If attempting to use an Angular component that uses non-standard HTML syntax (e.g. expression bindings):

```html
<Hello [text]="greeting" />
```

The marked renderer will escape the HTML entities and it will be displayed as text rather than rendering the component. Control flow syntax kind of works as is but marked also encapsulates this syntax inside of paragraph tags, e.g:

## What is the new behavior?

Detection has been added for paragraphs that are any HTML/Angular component (e.g. it starts with `<` and ends with `/>`). In this case, the escaping of HTML entities will be reversed.

We also need to detect control flow syntax statements (e.g. starts with `@for`, ends with `}`) for two reasons:

1) It prevents the unnecessary `<p>` tag encapsulation
2) Without detecting these blocks, Angular components within a control flow syntax statement would not have the HTML entity encoding reversed

**Note:** Since this relies on `renderer.paragraph` control flow statements do need to be in a single paragraph, e.g this is fine:

```
@if(whatever){
  <Hello />
}
```

This will break:

```
@if(whatever){

  <Hello />
}
```

Because marked treats it as two separate paragraphs. Perhaps this can just be something noted in the docs?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/xT5LMTEQsx6daGbsyc/giphy.gif"/>
