### PR TITLE
fix(vite-plugin-angular): bind css transform to correct plugin scope

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -190,15 +190,19 @@ export function angular(options?: PluginOptions): Plugin[] {
       },
       configureServer(server) {
         viteServer = server;
-        server.watcher.on('add', setupCompilation);
-        server.watcher.on('unlink', setupCompilation);
+        const context = this;
+        server.watcher.on('add', () => setupCompilation(userConfig, context));
+        server.watcher.on('unlink', () =>
+          setupCompilation(userConfig, context)
+        );
       },
       async buildStart({ plugins }) {
         if (Array.isArray(plugins)) {
           cssPlugin = plugins.find((plugin) => plugin.name === 'vite:css');
         }
 
-        setupCompilation(userConfig);
+        const context = this;
+        setupCompilation(userConfig, context);
 
         // Only store cache if in watch mode
         if (watchMode) {
@@ -472,7 +476,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       .map((file: string) => `${file}.ts`);
   }
 
-  function setupCompilation(config: UserConfig) {
+  function setupCompilation(config: UserConfig, context?: unknown) {
     const analogFiles = findAnalogFiles(config);
     const { options: tsCompilerOptions, rootNames: rn } =
       compilerCli.readConfiguration(pluginOptions.tsconfig, {
@@ -506,7 +510,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
     styleTransform = watchMode
       ? viteServer!.pluginContainer.transform
-      : (cssPlugin!.transform as PluginContainer['transform']);
+      : (cssPlugin!.transform as PluginContainer['transform']).bind(context);
 
     if (!jit) {
       augmentHostWithResources(host, styleTransform, {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

We extract the `vite:css` plugin during build to transform inline CSS. The function call do to the transform wasn't including the correct scope, causing an issue in Vite 5.1+.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #969

## What is the new behavior?

The plugin transform is called with the correct plugin scope.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
