### PR TITLE
fix(vite-plugin-angular): add support for testing Analog SFCs

### DIFF
--- a/apps/ng-app/project.json
+++ b/apps/ng-app/project.json
@@ -55,6 +55,9 @@
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/vite:test"
     }
   }
 }

--- a/apps/ng-app/src/app/hello.analog.spec.ts
+++ b/apps/ng-app/src/app/hello.analog.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+import Hello from './hello.analog';
+
+describe('Hello', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Hello],
+    }).compileComponents();
+  });
+
+  it('should create the component', () => {
+    const fixture = TestBed.createComponent(Hello);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+});

--- a/apps/ng-app/src/test-setup.ts
+++ b/apps/ng-app/src/test-setup.ts
@@ -1,0 +1,12 @@
+import '@analogjs/vite-plugin-angular/setup-vitest';
+
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+import { getTestBed } from '@angular/core/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/apps/ng-app/tsconfig.spec.json
+++ b/apps/ng-app/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node", "vitest/globals"],
+    "target": "es2016"
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/apps/ng-app/vite.config.ts
+++ b/apps/ng-app/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig(({ mode }) => ({
     },
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['src/test.ts'],
+    setupFiles: ['src/test-setup.ts'],
     include: ['**/*.spec.ts'],
     reporters: ['default'],
   },

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -103,7 +103,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       },
     },
     supportedBrowsers: options?.supportedBrowsers ?? ['safari 15'],
-    jit: options?.jit,
+    jit: options?.experimental?.supportAnalogFormat ? false : options?.jit,
     supportAnalogFormat: options?.experimental?.supportAnalogFormat ?? false,
     markdownTemplateTransforms:
       options?.experimental?.markdownTemplateTransforms ??
@@ -374,7 +374,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           const useInputSourcemap = (!isProd ? undefined : false) as undefined;
 
           if (
-            (id.includes('.analog') || id.includes('.agx')) &&
+            (id.endsWith('.analog') || id.endsWith('.agx')) &&
             pluginOptions.supportAnalogFormat &&
             fileEmitter
           ) {

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -42,7 +42,7 @@ export function augmentHostWithResources(
       onError,
       ...parameters
     ) => {
-      if (fileName.includes('.analog') || fileName.includes('.agx.ts')) {
+      if (fileName.endsWith('.analog.ts') || fileName.endsWith('.agx.ts')) {
         const contents = readFileSync(
           fileName.replace('.analog.ts', '.analog').replace('.agx.ts', '.agx'),
           'utf-8'


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Analog SFCs cannot be used with the TestBed. In test mode, the compiler host is not patched to enable SFC support.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Analog SFCs can be used with the TestBed. This forces disabling of JIT mode, so the compiler host is patched correctly to emit SFCs to JavaScript.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
