### PR TITLE
Document Analog SFC Usage

### DIFF
--- a/apps/docs-app/docs/experimental/sfc/index.md
+++ b/apps/docs-app/docs/experimental/sfc/index.md
@@ -6,28 +6,74 @@ sidebar_position: 1
 
 > **Note:**
 >
-> This file format and API is extremely experimental and is a community project, not an official Angular proposal API. Use it at your own risk.
+> This file format and API is experimental, is a community-driven initiative, and is not an officially proposed change to Angular. Use it at your own risk.
 
 The `.analog` file extension denotes a new file format for Angular Single File Components (SFCs) that aims to simplify the authoring experience of Angular components.
 
 Together, it combines:
 
-- Colocated template, script, and style
+- Colocated template, script, and style tags
 - No decorators
 - Performance-first defaults (`OnPush` change detection, no accesss to `ngDoCheck`, etc.)
+
+# Usage
+
+To use the Analog SFC format, you need to use the Analog Vite plugin or the [Analog Astro plugin](/docs/packages/astro-angular/overview) with an additional flag to enable its usage:
+
+```typescript
+import { defineConfig } from 'vite';
+import analog from '@analogjs/vite-plugin-angular';
+
+export default defineConfig({
+  // ...
+  plugins: [
+    analog({
+      experimental: {
+        // Required to use the Analog SFC format
+        supportAnalogFormat: true,
+      },
+    }),
+  ],
+});
+```
+
+## IDE Support
+
+To support syntax highlighting and other IDE functionality with `.analog` files, you need to install an extension to support the format for:
+
+- [WebStorm 2024.1+ or IDEA Ultimate 2024.1+](https://github.com/analogjs/idea-plugin)
+
+> [Support for VSCode is coming! Please see this issue for more details](https://github.com/volarjs/angular-language-tools/).
+
+## Additional Configuration
+
+If you are using `.analog` files outside a project's root you will need to specify all paths of `.analog` files using globs, like so:
+
+```typescript
+export default defineConfig(({ mode }) => ({
+  // ...
+  plugins: [
+    analog({
+      experimental: {
+        supportAnalogFormat: {
+          include: ['/libs/shared/ui/**/*', '/libs/angularstart/ui/**/*'],
+        },
+      },
+    }),
+  ],
+}));
+```
+
+# Authoring an SFC
 
 Here's a demonstration of the Analog format building a simple todo list:
 
 ```html
+<!-- app-root.analog -->
 <script lang="ts">
   import { signal } from '@angular/core';
 
   let id = 0;
-
-  // Optional for most components
-  defineMetadata({
-    selector: 'app-root',
-  });
 
   interface TodoItem {
     id: number;
@@ -112,53 +158,7 @@ Here's a demonstration of the Analog format building a simple todo list:
 </style>
 ```
 
-# Usage
-
-To use the Analog SFC format, you'll need to use the Analog Vite plugin or the [Analog Astro plugin](/docs/packages/astro-angular/overview) with an additional flag to enable its usage:
-
-```typescript
-import { defineConfig } from 'vite';
-import analog from '@analogjs/vite-plugin-angular';
-
-export default defineConfig({
-  // ...
-  plugins: [
-    analog({
-      experimental: {
-        // Required to use the Analog SFC format
-        supportAnalogFormat: true,
-      },
-    }),
-  ],
-});
-```
-
-## IDE Support
-
-To support syntax highlighting and other IDE functionality with `.analog` files, you'll need to install an extension to support the format for:
-
-- [WebStorm 2024.1+ or IDEA Ultimate 2024.1+](https://github.com/analogjs/idea-plugin)
-
-> [Support for VSCode is coming! Please see this issue for more details](https://github.com/volarjs/angular-language-tools/).
-
-## Additional Configuration
-
-If you are using `.analog` files outside a project's root you will need to specify all paths of `.analog` files using globs, like so:
-
-```typescript
-export default defineConfig(({ mode }) => ({
-  // ...
-  plugins: [
-    analog({
-      experimental: {
-        supportAnalogFormat: {
-          include: ['/libs/shared/ui/**/*', '/libs/angularstart/ui/**/*'],
-        },
-      },
-    }),
-  ],
-}));
-```
+See the [defineMetadata](#metadata) section for adding additional component metadata.
 
 # Metadata
 
@@ -260,7 +260,7 @@ When importing a `.analog` component, you have two options:
 </script>
 ```
 
-Using the import attribute method will add the component to your metadata's `imports` and can be used for other imports you want to add to the metadata, like so:
+Using the import attribute method adds the component to your metadata's `imports` and can be used for other imports you want to add to the metadata, like so:
 
 ```html
 <script lang="ts">
@@ -350,7 +350,7 @@ And can be used in the template like so:
 
 The new [`model` signal API](https://angular.io/api/core/model) is not yet supported.
 
-# Dedicated Template and Style Files
+# Using an External Template and Styles
 
 If you like the developer experience of Analog's `<script>` to build your logic, but don't want your template and styling in the same file, you can break those out to their own files using:
 
@@ -374,7 +374,7 @@ In `defineMetadata`, like so:
 </script>
 ```
 
-# Directives
+# Authoring Directives
 
 Any `.analog` file without a `<template>` tag or usage of `templateUrl` in the `defineMetadata` function are treated as Angular Directives.
 
@@ -404,7 +404,7 @@ Here's an example of a directive that focuses an input and has two lifecycle met
 </script>
 ```
 
-# Markdown
+# Authoring SFCs using Markdown
 
 If you'd like to write Markdown as your template rather than Angular-enhanced HTML, you can add `lang="md"` to your `<template>` tag in an `.analog` file:
 

--- a/apps/docs-app/docs/experimental/sfc/index.md
+++ b/apps/docs-app/docs/experimental/sfc/index.md
@@ -66,94 +66,38 @@ export default defineConfig(({ mode }) => ({
 
 # Authoring an SFC
 
-Here's a demonstration of the Analog format building a simple todo list:
+Here's a demonstration of the Analog format building a simple counter:
 
 ```html
-<!-- app-root.analog -->
 <script lang="ts">
+  // counter.analog
   import { signal } from '@angular/core';
 
-  let id = 0;
+  const count = signal(0);
 
-  interface TodoItem {
-    id: number;
-    name: string;
-    done: boolean;
-  }
-
-  const list = signal<TodoItem[]>([]);
-
-  function onSubmit(e: SubmitEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    const formData = new FormData(e.target);
-    const name = formData.get('name') as string;
-    list.update((prevList) => [
-      ...prevList,
-      {
-        name,
-        done: false,
-        id: ++id,
-      },
-    ]);
-  }
-
-  function onDone(id: number) {
-    list.update((prevList) =>
-      prevList.map((item) => {
-        if (item.id === id) {
-          return {
-            ...item,
-            done: !item.done,
-          };
-        }
-        return item;
-      })
-    );
+  function add() {
+    count.set(count() + 1);
   }
 </script>
 
 <template>
   <div class="container">
-    <h1>Todo list</h1>
-    <ul class="todoList">
-      @for (item of list(); track item.id) {
-      <li class="todoItem">
-        <span>{{ item.name }}</span>
-        <input
-          type="checkbox"
-          [checked]="item.done"
-          (change)="onDone(item.id)"
-        />
-      </li>
-      }
-    </ul>
-    <form (submit)="onSubmit($event)">
-      <h2>Add a task</h2>
-      <label>
-        <div>Task name</div>
-        <input name="name" />
-      </label>
-      <button>Add task</button>
-    </form>
+    <button (click)="add()">{{count()}}</button>
   </div>
 </template>
 
 <style>
   .container {
-    max-width: 600px;
-    margin: 0 auto;
-    padding: 1rem;
-    text-align: center;
-  }
-
-  .todoList:empty::after {
-    content: 'No tasks';
-  }
-
-  .todoItem {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+  }
+
+  button {
+    font-size: 2rem;
+    padding: 1rem 2rem;
+    border-radius: 0.5rem;
+    background-color: #f0f0f0;
+    border: 1px solid #ccc;
   }
 </style>
 ```

--- a/apps/docs-app/docs/experimental/sfc/index.md
+++ b/apps/docs-app/docs/experimental/sfc/index.md
@@ -355,7 +355,7 @@ This can be used in combination with the other SFC tags: `<script>` and `<style>
 
 ```html
 <script lang="ts">
-  import Hello from './hello.analog';
+  import Hello from './hello.analog' with { analog: 'imports' };
 </script>
 
 <template lang="md">

--- a/apps/docs-app/docs/experimental/sfc/index.md
+++ b/apps/docs-app/docs/experimental/sfc/index.md
@@ -143,9 +143,7 @@ import { appConfig } from './app/app.config';
 bootstrapApplication(App, appConfig).catch((err) => console.error(err));
 ```
 
-Further, when importing an `.analog` file into another `.analog` file, you do not need to add them to your `imports` like you do with non-analog components and directives.
-
-Instead, you can use components directly from their imported name:
+To use the components you will need to add them to your `imports` (alternatively, you can use **import attributes** as explained in the following section):
 
 ```html
 <!-- layout.analog -->
@@ -156,8 +154,7 @@ Instead, you can use components directly from their imported name:
   import LayoutFooter from '../ui-layout/layout-footer.analog';
   import LayoutHeader from '../ui-layout/layout-header.analog';
 
-  // You still need to add non-Analog items to `imports`:
-  defineMetadata({ imports: [RouterOutlet] });
+  defineMetadata({ imports: [RouterOutlet, LayoutFooter, LayoutHeader] });
 
   const authStore = inject(AuthStore);
 </script>
@@ -188,23 +185,13 @@ Instead, you can use components directly from their imported name:
 >
 > An official solution for this problem, from Angular, has been hinted by the Angular team and may come in a future version of Angular.
 
-## Alternate Component Import
+## Import Attributes
 
-When importing a `.analog` component, you have two options:
-
-1. Include the `.analog` extension in your import
+To avoid the necessity of manually adding components to the `imports` metadata, you can also use [import attributes](https://github.com/tc39/proposal-import-attributes)
 
 ```html
 <script lang="ts">
-  import YourComponent from './your-component.analog';
-</script>
-```
-
-2. Using [import attributes](https://github.com/tc39/proposal-import-attributes) to denote an Analog file
-
-```html
-<script lang="ts">
-  import { YourComponent } from "your-component" with { analog: 'imports' }
+  import YourComponent from './your-component.analog' with { analog: 'imports' };
 </script>
 ```
 

--- a/apps/docs-app/docs/experimental/sfc/index.md
+++ b/apps/docs-app/docs/experimental/sfc/index.md
@@ -32,7 +32,7 @@ export default defineConfig({
         // Required to use the Analog SFC format
         experimental: {
           supportAnalogFormat: true,
-        }
+        },
       },
     }),
   ],
@@ -61,7 +61,7 @@ export default defineConfig(({ mode }) => ({
           supportAnalogFormat: {
             include: ['/libs/shared/ui/**/*', '/libs/some-lib/ui/**/*'],
           },
-        }
+        },
       },
     }),
   ],

--- a/apps/docs-app/docs/experimental/sfc/index.md
+++ b/apps/docs-app/docs/experimental/sfc/index.md
@@ -28,9 +28,11 @@ export default defineConfig({
   // ...
   plugins: [
     analog({
-      experimental: {
+      vite: {
         // Required to use the Analog SFC format
-        supportAnalogFormat: true,
+        experimental: {
+          supportAnalogFormat: true,
+        }
       },
     }),
   ],
@@ -54,10 +56,12 @@ export default defineConfig(({ mode }) => ({
   // ...
   plugins: [
     analog({
-      experimental: {
-        supportAnalogFormat: {
-          include: ['/libs/shared/ui/**/*', '/libs/angularstart/ui/**/*'],
-        },
+      vite: {
+        experimental: {
+          supportAnalogFormat: {
+            include: ['/libs/shared/ui/**/*', '/libs/some-lib/ui/**/*'],
+          },
+        }
       },
     }),
   ],

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -24,10 +24,15 @@ Here's a demonstration of the Analog format building a simple todo list:
 
   let id = 0;
 
+  // Optional for most components
+  defineMetadata({
+    selector: 'app-root',
+  });
+
   interface TodoItem {
-    number;
-    string;
-    boolean;
+    id: number;
+    name: string;
+    done: boolean;
   }
 
   const list = signal<TodoItem[]>([]);
@@ -36,9 +41,7 @@ Here's a demonstration of the Analog format building a simple todo list:
     e.preventDefault();
     e.stopPropagation();
     const formData = new FormData(e.target);
-    const name = formData.get('name');
-    as;
-    string;
+    const name = formData.get('name') as string;
     list.update((prevList) => [
       ...prevList,
       {
@@ -68,7 +71,7 @@ Here's a demonstration of the Analog format building a simple todo list:
   <div class="container">
     <h1>Todo list</h1>
     <ul class="todoList">
-      @for (item of list(); track $index) {
+      @for (item of list(); track item.id) {
       <li class="todoItem">
         <span>{{ item.name }}</span>
         <input
@@ -304,7 +307,7 @@ Here's an example of a directive that focuses an input and has two lifecycle met
 
 ```html
 <script lang="ts">
-  import { inject, ElementRef, afterNextRender } from '@angular/core';
+  import { inject, ElementRef, afterNextRender, effect } from '@angular/core';
 
   defineMetadata({
     selector: 'input[directive]',

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -186,14 +186,24 @@ This encourages best practices when using Angular signals since many of the othe
 
 # Inputs and Outputs
 
-To use inputs and outputs use the signals APIs for them
+To add inputs and outputs to an Analog component, you use the new Angular signals API.
+
+Let's explore what that looks like in practical terms.
 
 ## Inputs
 
 Inputs can be added to a component or directive in the Analog format using [the new `input` signal API](https://angular.io/guide/signal-inputs):
 
 ```typescript
-const name = input();
+const namedInput = input();
+```
+
+This will add an input with the name of `namedInput` that can be used in the template like so:
+
+```html
+<template>
+  <SomeComponent [namedInput]="someValue"/>
+</template>
 ```
 
 ## Outputs
@@ -202,7 +212,7 @@ Outputs are added in the Analog format like so:
 
 ```html
 <script lang="ts">
-  const selectFeed = new EventEmitter();
+  const selectItem = new EventEmitter();
 </script>
 ```
 
@@ -210,8 +220,16 @@ The above will be transformed to:
 
 ```typescript
 class Component {
-  @Output() selectFeed = new EventEmitter();
+  @Output() selectItem = new EventEmitter();
 }
+```
+
+And can be used in the template like so:
+
+```html
+<template>
+  <SomeComponent (selectItem)="doSomething($event)"/>
+</template>
 ```
 
 > In the future, this will be replaced with [the `output` signals API](https://blog.angular.io/meet-angulars-new-output-api-253a41ffa13c).
@@ -254,18 +272,19 @@ Here's an example of a directive that focuses an input and has two lifecycle met
 
 # Markdown
 
+If you'd like to write Markdown as your template rather than Angular-enhanced HTML, you can add `lang="md"` to your `<template>` tag in an `.analog` file:
+
 ```html
 <template lang="md">
   # Hello World
 </template>
 ```
 
-<!-- Can this be mixed and matched with `<script>`? -->
-
-<!-- Can this be mixed and matched with `<style>`? -->
+This can be used in combination with the other SFC tags: `<script>` and `<style>`.
 
 # Limitations
 
-- Cannot use decorator APIs (`@Input`, `@Component`, `@ViewChild`)
-- You must have `lang="ts"` present in the `<script>`
+There are a few limitations to the Analog format:
 
+- You cannot use decorator APIs (`@Input`, `@Component`, `@ViewChild`)
+- You must have `lang="ts"` present in the `<script>`

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -347,6 +347,24 @@ If you'd like to write Markdown as your template rather than Angular-enhanced HT
 
 This can be used in combination with the other SFC tags: `<script>` and `<style>`.
 
+## Using Components in Markdown
+
+`lang="md"` templates in Analog also support Analog and Angular components in their templates:
+
+```html
+<script lang="ts">
+  import Hello from './hello.analog';
+</script>
+
+<template lang="md">
+  # Greeting
+
+  <Hello />
+
+  > You might want to say "Hello" back!
+</template>
+```
+
 # Limitations
 
 There are a few limitations to the Analog format:

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -1,0 +1,176 @@
+---
+sidebar_position: 1
+---
+
+# Analog SFCs
+
+> **Note:**
+>
+> This file format and API is extremely experimental and is a community project, not an official Angular proposal API. Use it at your own risk.
+
+# Metadata
+
+While class decorators are used to add metadata to a component or directive in the traditional Angular authoring methods, they're replaced in the Analog format with the `defineMetadata` global function:
+
+```typescript
+defineMetadata({
+  host: { class: 'block articles-toggle' },
+});
+```
+
+## Disallowed Metadata Properties
+
+The following properties are not allowed on the metadata fields:
+
+- `template`: Use the SFC `<template>` or `defineMetadata.templateUrl` instead
+- `standalone`: Always set to `true`
+- `changeDetection`: Always set to `OnPush`
+- `styles`: Use the SFC `<style>` tag
+- `outputs`: Implicitly added with `new EventEmitter()` usage
+- `inputs`: Use the `input` signal API instead
+
+# Using Components
+
+When using the Analog format, you do not need to explicitly export anything; the component is the default export of the `.analog` file:
+
+```typescript
+import { bootstrapApplication } from '@angular/platform-browser';
+import App from './app/app.analog';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(App, appConfig).catch((err) => console.error(err));
+```
+
+Further, when importing an `.analog` file into another `.analog` file, you do not need to add them to your `imports` like you do with non-analog components and directives.
+
+Instead, you can utilize components directly from their imported name:
+
+```html
+<!-- layout.analog -->
+<script lang="ts">
+  import { inject } from '@angular/core';
+  import { RouterOutlet } from '@angular/router';
+  import { AuthStore } from '../shared-data-access-auth/auth.store';
+  import LayoutFooter from '../ui-layout/layout-footer.analog';
+  import LayoutHeader from '../ui-layout/layout-header.analog';
+
+  // You still need to add non-Analog items to `imports`:
+  defineMetadata({ imports: [RouterOutlet] });
+
+  const authStore = inject(AuthStore);
+</script>
+
+<template>
+  <LayoutHeader [isAuthenticated]="authStore.isAuthenticated()" [username]="authStore.username()" />
+  <router-outlet />
+  <LayoutFooter />
+</template>
+```
+
+# Lifecycle Methods
+
+Currently, only two lifecycle methods from Angular are available to `.analog` SFCs:
+
+- `onInit`
+- `onDestroy`
+
+You use these lifecycle methods like so:
+
+```html
+<!-- app.analog -->
+<script lang="ts">
+  onInit(() => {
+    console.log("I am mounting");
+  })
+
+  onDestroy(() => {
+    console.log("I am unmounting");
+  })
+</script>
+```
+
+# Inputs and Outputs
+
+To use inputs and outputs use the signals APIs for them
+
+## Inputs
+
+Inputs can be added to a component or directive in the Analog format using [the new `input` signal API](https://angular.io/guide/signal-inputs):
+
+```typescript
+const name = input();
+```
+
+## Outputs
+
+Outputs are added in the Analog format like so:
+
+```html
+<script lang="ts">
+const selectFeed = new EventEmitter();
+</script>
+```
+
+The above will be transformed to:
+
+```typescript
+class Component {
+  @Output() selectFeed = new EventEmitter();
+}
+```
+
+> In the future, this will be replaced with [the `output` signals API](https://blog.angular.io/meet-angulars-new-output-api-253a41ffa13c).
+
+## Models
+
+The new [`model` signal API](https://angular.io/api/core/model) is not yet supported.
+
+# Dedicated Template and Style Files
+
+# Directives
+
+Any `.analog` file without a `<template>` tag or usage of `templateUrl` in the `defineMetadata` function are treated as Angular Directives.
+
+Here's an example of a directive that focuses an input and has two lifecycle methods:
+
+```html
+<script lang="ts">
+  import { inject, ElementRef, afterNextRender } from '@angular/core';
+
+  defineMetadata({
+    selector: 'input[directive]',
+  })
+
+  const elRef = inject(ElementRef);
+
+  afterNextRender(() => {
+    elRef.nativeElement.focus();
+  });
+
+  onInit(() => {
+    console.log('init code');
+  });
+
+  effect(() => {
+    console.log('just some effect');
+  });
+</script>
+```
+
+# Markdown
+
+```html
+<template lang="md">
+  # Hello World
+</template>
+```
+
+<!-- Can this be mixed and matched with `<script>`? -->
+
+<!-- Can this be mixed and matched with `<style>`? -->
+
+# Limitations
+
+- Cannot use decorator APIs (`@Input`, `@Component`, `@ViewChild`)
+- You must have `lang="ts"` present in the `<script>`
+

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -197,7 +197,7 @@ bootstrapApplication(App, appConfig).catch((err) => console.error(err));
 
 Further, when importing an `.analog` file into another `.analog` file, you do not need to add them to your `imports` like you do with non-analog components and directives.
 
-Instead, you can utilize components directly from their imported name:
+Instead, you can use components directly from their imported name:
 
 ```html
 <!-- layout.analog -->
@@ -222,6 +222,38 @@ Instead, you can utilize components directly from their imported name:
   <router-outlet />
   <LayoutFooter />
 </template>
+```
+
+## Alternate Component Import
+
+When importing a `.analog` component, you have two options:
+
+1) Include the `.analog` extension in your import
+
+```html
+<script lang="ts">
+  import YourComponent from "./your-component.analog";
+</script>
+```
+
+2) Using [import attributes](https://github.com/tc39/proposal-import-attributes) to denote an Analog file
+
+```html
+<script lang="ts">
+  import { YourComponent } from "your-component" with { analog: 'imports' }
+</script>
+```
+
+Using the import attribute method will add the component to your metadata's `imports` and can be used for other imports you want to add to the metadata, like so:
+
+```html
+<script lang="ts">
+  // This will add to the `providers` array in your metadata
+  import { MyService } from './my.service' with { analog: 'providers'};
+  // This will add the `ExternalEnum` field to your component's constructor so that you can use it in your template
+  import { ExternalEnum } from './external.model' with { analog: 'exposes' };
+  // ...
+</script>
 ```
 
 # Lifecycle Methods

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -8,6 +8,99 @@ sidebar_position: 1
 >
 > This file format and API is extremely experimental and is a community project, not an official Angular proposal API. Use it at your own risk.
 
+The `.analog` file extension denotes a new file format for Angular Single File Components (SFCs) that aims to simplify the authoring experience of Angular components.
+
+Together, it combines:
+
+- Colocated template, script, and style
+- No decorators
+- Performance-first defaults (`OnPush` change detection, no accesss to `ngDoCheck`, etc.)
+
+Here's a demonstration of the Analog format building a simple todo list:
+
+```html
+
+<script lang="ts">
+  import { signal } from '@angular/core';
+
+  let id = 0;
+
+  interface TodoItem {
+    number;
+    string;
+    boolean;
+  }
+
+  const list = signal < TodoItem[] > ([]);
+
+  function onSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    const formData = new FormData(e.target);
+    const name = formData.get('name')
+    as
+    string;
+    list.update(prevList => [...prevList, {
+      name,
+      done: false,
+      id: ++id
+    }]);
+  }
+
+  function onDone(id: number) {
+    list.update(prevList => prevList.map(item => {
+      if (item.id === id) {
+        return {
+          ...item,
+          done: !item.done
+        };
+      }
+      return item;
+    }));
+  }
+</script>
+
+<template>
+  <div class="container">
+    <h1>Todo list</h1>
+    <ul class="todoList">
+      @for (item of list(); track $index) {
+        <li class="todoItem">
+          <span>{{ item.name }}</span>
+          <input type="checkbox" [checked]="item.done" (change)="onDone(item.id)" />
+        </li>
+      }
+    </ul>
+    <form (submit)="onSubmit($event)">
+      <h2>Add a task</h2>
+      <label>
+        <div>Task name</div>
+        <input name="name" />
+      </label>
+      <button>Add task</button>
+    </form>
+  </div>
+</template>
+
+<style>
+  .container {
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 1rem;
+    text-align: center;
+  }
+
+  .todoList:empty::after {
+    content: 'No tasks';
+  }
+
+  .todoItem {
+    display: flex;
+    justify-content: space-between;
+  }
+</style>
+```
+
 # Metadata
 
 While class decorators are used to add metadata to a component or directive in the traditional Angular authoring methods, they're replaced in the Analog format with the `defineMetadata` global function:
@@ -89,6 +182,8 @@ You use these lifecycle methods like so:
 </script>
 ```
 
+This encourages best practices when using Angular signals since many of the other lifecycle methods can introduce performance issues or are easily replaced with other APIs.
+
 # Inputs and Outputs
 
 To use inputs and outputs use the signals APIs for them
@@ -107,7 +202,7 @@ Outputs are added in the Analog format like so:
 
 ```html
 <script lang="ts">
-const selectFeed = new EventEmitter();
+  const selectFeed = new EventEmitter();
 </script>
 ```
 

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -19,7 +19,6 @@ Together, it combines:
 Here's a demonstration of the Analog format building a simple todo list:
 
 ```html
-
 <script lang="ts">
   import { signal } from '@angular/core';
 
@@ -31,32 +30,37 @@ Here's a demonstration of the Analog format building a simple todo list:
     boolean;
   }
 
-  const list = signal < TodoItem[] > ([]);
+  const list = signal<TodoItem[]>([]);
 
   function onSubmit(e: SubmitEvent) {
     e.preventDefault();
     e.stopPropagation();
     const formData = new FormData(e.target);
-    const name = formData.get('name')
-    as
+    const name = formData.get('name');
+    as;
     string;
-    list.update(prevList => [...prevList, {
-      name,
-      done: false,
-      id: ++id
-    }]);
+    list.update((prevList) => [
+      ...prevList,
+      {
+        name,
+        done: false,
+        id: ++id,
+      },
+    ]);
   }
 
   function onDone(id: number) {
-    list.update(prevList => prevList.map(item => {
-      if (item.id === id) {
-        return {
-          ...item,
-          done: !item.done
-        };
-      }
-      return item;
-    }));
+    list.update((prevList) =>
+      prevList.map((item) => {
+        if (item.id === id) {
+          return {
+            ...item,
+            done: !item.done,
+          };
+        }
+        return item;
+      })
+    );
   }
 </script>
 
@@ -65,10 +69,14 @@ Here's a demonstration of the Analog format building a simple todo list:
     <h1>Todo list</h1>
     <ul class="todoList">
       @for (item of list(); track $index) {
-        <li class="todoItem">
-          <span>{{ item.name }}</span>
-          <input type="checkbox" [checked]="item.done" (change)="onDone(item.id)" />
-        </li>
+      <li class="todoItem">
+        <span>{{ item.name }}</span>
+        <input
+          type="checkbox"
+          [checked]="item.done"
+          (change)="onDone(item.id)"
+        />
+      </li>
       }
     </ul>
     <form (submit)="onSubmit($event)">
@@ -106,17 +114,19 @@ Here's a demonstration of the Analog format building a simple todo list:
 To use the Analog SFC format, you'll need to use the Analog Vite plugin or the [Analog Astro plugin](/docs/packages/astro-angular/overview) with an additional flag to enable its usage:
 
 ```typescript
-import {defineConfig} from 'vite';
+import { defineConfig } from 'vite';
 import analog from '@analogjs/vite-plugin-angular';
 
 export default defineConfig({
   // ...
-  plugins: [analog({
-    experimental: {
-    	// Required to use the Analog SFC format
-      supportAnalogFormat: true
-  	}
-  })],
+  plugins: [
+    analog({
+      experimental: {
+        // Required to use the Analog SFC format
+        supportAnalogFormat: true,
+      },
+    }),
+  ],
 });
 ```
 
@@ -175,7 +185,10 @@ Instead, you can utilize components directly from their imported name:
 </script>
 
 <template>
-  <LayoutHeader [isAuthenticated]="authStore.isAuthenticated()" [username]="authStore.username()" />
+  <LayoutHeader
+    [isAuthenticated]="authStore.isAuthenticated()"
+    [username]="authStore.username()"
+  />
   <router-outlet />
   <LayoutFooter />
 </template>
@@ -194,12 +207,12 @@ You use these lifecycle methods like so:
 <!-- app.analog -->
 <script lang="ts">
   onInit(() => {
-    console.log("I am mounting");
-  })
+    console.log('I am mounting');
+  });
 
   onDestroy(() => {
-    console.log("I am unmounting");
-  })
+    console.log('I am unmounting');
+  });
 </script>
 ```
 
@@ -223,7 +236,7 @@ This will add an input with the name of `namedInput` that can be used in the tem
 
 ```html
 <template>
-  <SomeComponent [namedInput]="someValue"/>
+  <SomeComponent [namedInput]="someValue" />
 </template>
 ```
 
@@ -249,7 +262,7 @@ And can be used in the template like so:
 
 ```html
 <template>
-  <SomeComponent (selectItem)="doSomething($event)"/>
+  <SomeComponent (selectItem)="doSomething($event)" />
 </template>
 ```
 
@@ -272,11 +285,11 @@ In `defineMetadata`, like so:
 ```html
 <script lang="ts">
   defineMetadata({
-    selector: "app-root",
-    templateUrl: "./test.html",
-    styleUrl: "./test.css"
-  })
-  
+    selector: 'app-root',
+    templateUrl: './test.html',
+    styleUrl: './test.css',
+  });
+
   onInit(() => {
     alert('Hello World');
   });
@@ -295,7 +308,7 @@ Here's an example of a directive that focuses an input and has two lifecycle met
 
   defineMetadata({
     selector: 'input[directive]',
-  })
+  });
 
   const elRef = inject(ElementRef);
 
@@ -318,9 +331,7 @@ Here's an example of a directive that focuses an input and has two lifecycle met
 If you'd like to write Markdown as your template rather than Angular-enhanced HTML, you can add `lang="md"` to your `<template>` tag in an `.analog` file:
 
 ```html
-<template lang="md">
-  # Hello World
-</template>
+<template lang="md"> # Hello World </template>
 ```
 
 This can be used in combination with the other SFC tags: `<script>` and `<style>`.

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -224,19 +224,35 @@ Instead, you can use components directly from their imported name:
 </template>
 ```
 
+> A component's `selector` is not determined by the imported name, but rather determined by the name of the file. If you change your imported name to:
+>
+> ```html
+> <script lang="ts">
+>   import LayoutHeaderHeading from '../ui-layout/layout-header.analog';
+> </script>
+>
+> <template>
+>   <LayoutHeaderHeading />
+> </template>
+> ```
+>
+> It would not work as expected. To solve this, you'll need the name of the default import to match the file name of the `.analog` file.
+>
+> An official solution for this problem, from Angular, has been hinted by the Angular team and may come in a future version of Angular.
+
 ## Alternate Component Import
 
 When importing a `.analog` component, you have two options:
 
-1) Include the `.analog` extension in your import
+1. Include the `.analog` extension in your import
 
 ```html
 <script lang="ts">
-  import YourComponent from "./your-component.analog";
+  import YourComponent from './your-component.analog';
 </script>
 ```
 
-2) Using [import attributes](https://github.com/tc39/proposal-import-attributes) to denote an Analog file
+2. Using [import attributes](https://github.com/tc39/proposal-import-attributes) to denote an Analog file
 
 ```html
 <script lang="ts">

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -133,6 +133,14 @@ export default defineConfig({
 });
 ```
 
+## IDE Support
+
+To support syntax highlighting and other IDE functionality with `.analog` files, you'll need to install an extension to support the format for:
+
+- [WebStorm 2024.1+ or IDEA Ultimate 2024.1+](https://github.com/analogjs/idea-plugin)
+
+> [Support for VSCode is coming! Please see this issue for more details](https://github.com/volarjs/angular-language-tools/).
+
 # Metadata
 
 While class decorators are used to add metadata to a component or directive in the traditional Angular authoring methods, they're replaced in the Analog format with the `defineMetadata` global function:

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -101,6 +101,25 @@ Here's a demonstration of the Analog format building a simple todo list:
 </style>
 ```
 
+# Usage
+
+To use the Analog SFC format, you'll need to use the Analog Vite plugin or the [Analog Astro plugin](/docs/packages/astro-angular/overview) with an additional flag to enable its usage:
+
+```typescript
+import {defineConfig} from 'vite';
+import analog from '@analogjs/vite-plugin-angular';
+
+export default defineConfig({
+  // ...
+  plugins: [analog({
+    experimental: {
+    	// Required to use the Analog SFC format
+      supportAnalogFormat: true
+  	}
+  })],
+});
+```
+
 # Metadata
 
 While class decorators are used to add metadata to a component or directive in the traditional Angular authoring methods, they're replaced in the Analog format with the `defineMetadata` global function:

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -240,6 +240,28 @@ The new [`model` signal API](https://angular.io/api/core/model) is not yet suppo
 
 # Dedicated Template and Style Files
 
+If you like the developer experience of Analog's `<script>` to build your logic, but don't want your template and styling in the same file, you can break those out to their own files using:
+
+- `templateUrl`
+- `styleUrl`
+- `styleUrls`
+
+In `defineMetadata`, like so:
+
+```html
+<script lang="ts">
+  defineMetadata({
+    selector: "app-root",
+    templateUrl: "./test.html",
+    styleUrl: "./test.css"
+  })
+  
+  onInit(() => {
+    alert('Hello World');
+  });
+</script>
+```
+
 # Directives
 
 Any `.analog` file without a `<template>` tag or usage of `templateUrl` in the `defineMetadata` function are treated as Angular Directives.

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -141,6 +141,25 @@ To support syntax highlighting and other IDE functionality with `.analog` files,
 
 > [Support for VSCode is coming! Please see this issue for more details](https://github.com/volarjs/angular-language-tools/).
 
+## Additional Configuration
+
+If you are using `.analog` files outside a project's root you will need to specify all paths of `.analog` files using globs, like so:
+
+```typescript
+export default defineConfig(({ mode }) => ({
+  // ...
+  plugins: [
+    analog({
+      experimental: {
+        supportAnalogFormat: {
+          include: ['/libs/shared/ui/**/*', '/libs/angularstart/ui/**/*'],
+        },
+      },
+    }),
+  ],
+}));
+```
+
 # Metadata
 
 While class decorators are used to add metadata to a component or directive in the traditional Angular authoring methods, they're replaced in the Analog format with the `defineMetadata` global function:

--- a/apps/docs-app/docs/experiments/sfc/index.md
+++ b/apps/docs-app/docs/experiments/sfc/index.md
@@ -111,6 +111,8 @@ defineMetadata({
 });
 ```
 
+This supports all of the decorator properties of `@Component` or `@Directive` with a few exceptions.
+
 ## Disallowed Metadata Properties
 
 The following properties are not allowed on the metadata fields:

--- a/apps/docs-app/sidebars.js
+++ b/apps/docs-app/sidebars.js
@@ -180,7 +180,7 @@ const sidebars = {
           type: 'doc',
           id: 'experiments/sfc/index',
           label: 'Analog SFCs',
-        }
+        },
       ],
     },
     {

--- a/apps/docs-app/sidebars.js
+++ b/apps/docs-app/sidebars.js
@@ -173,6 +173,17 @@ const sidebars = {
       ],
     },
     {
+      type: 'category',
+      label: 'Experiments',
+      items: [
+        {
+          type: 'doc',
+          id: 'experiments/sfc/index',
+          label: 'Analog SFCs',
+        }
+      ],
+    },
+    {
       type: 'doc',
       id: 'contributors',
       label: 'Contributors',

--- a/apps/docs-app/sidebars.js
+++ b/apps/docs-app/sidebars.js
@@ -174,11 +174,11 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Experiments',
+      label: 'Experimental',
       items: [
         {
           type: 'doc',
-          id: 'experiments/sfc/index',
+          id: 'experimental/sfc/index',
           label: 'Analog SFCs',
         },
       ],


### PR DESCRIPTION
I noticed that there were no docs for using the `.analog` extension.

This PR adds in initial documentation for the Analog SFC format. It denotes the extension as being experimental, but otherwise outlines how to use the extension

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/a5viI92PAF89q/giphy.gif"/>