### PR TITLE
feat: add support for Nx w/Project Crystal setup

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/build-ssr.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-ssr.ts
@@ -10,9 +10,12 @@ export async function buildSSRApp(config: UserConfig, options?: Options) {
     build: {
       ssr: true,
       rollupOptions: {
-        input: options?.entryServer || resolve(rootDir, './src/main.server.ts'),
+        input:
+          options?.entryServer ||
+          resolve(workspaceRoot, rootDir, 'src/main.server.ts'),
       },
-      outDir: options?.ssrBuildDir || resolve('dist', rootDir, 'ssr'),
+      outDir:
+        options?.ssrBuildDir || resolve(workspaceRoot, 'dist', rootDir, 'ssr'),
     },
   });
 

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -72,9 +72,6 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
               `ssr/main.server${filePrefix ? '.js' : ''}`
             )
         );
-        const indexEntry = normalizePath(
-          resolve(clientOutputPath, 'index.html')
-        );
         const rendererEntry =
           filePrefix +
           normalizePath(
@@ -130,10 +127,15 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
         if (!ssrBuild && !isTest) {
           // store the client output path for the SSR build config
           clientOutputPath = resolve(
+            workspaceRoot,
             rootDir,
             config.build?.outDir || 'dist/client'
           );
         }
+
+        const indexEntry = normalizePath(
+          resolve(clientOutputPath, 'index.html')
+        );
 
         nitroConfig.alias = {
           '#analog/ssr': ssrEntry,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #960 

## What is the new behavior?

Enables support for Analog to be used with Nx and Project Crystal, as the paths are resolved correctly when providing a custom `workspaceRoot` to the analog plugin.

To use Project Crystal
- Add the Nx Vite plugin configuration to the `nx.json` - https://nx.dev/nx-api/vite#nxvite-configuration
- Remove the existing serve, build, test targets from the project.json
- Configure the analog plugin with a custom `workspaceRoot` imported from `@nx/devkit`

```ts
/// <reference types="vitest" />

import { defineConfig } from 'vite';
import analog from '@analogjs/platform';
import { workspaceRoot } from '@nx/devkit';

// https://vitejs.dev/config/
export default defineConfig(({ mode }) => ({
  // other config
  plugins: [
    analog({
      workspaceRoot
    }),
  ],
}));

```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/26gsdS1KCyxwTl6IU/giphy.gif"/>
