### PR TITLE
fix(router): server-side-data-fetching when using basehref

### DIFF
--- a/apps/docs-app/docs/features/deployment/overview.md
+++ b/apps/docs-app/docs/features/deployment/overview.md
@@ -51,7 +51,7 @@ export default defineConfig({
 
 ## Deploying with a Custom URL Prefix
 
-If you are deploying to a non-root URL, https://domain.com/`basehref`/ you must do these steps for [server-side-data-fetching](https://analogjs.org/docs/features/data-fetching/server-side-data-fetching), [html markup and assets](https://angular.io/api/common/APP_BASE_HREF), and [dynamic api routes](https://analogjs.org/docs/features/api/overview) to work correctly on the specified `basehref`.
+If you are deploying with a custom URL prefix, such as https://domain.com/`basehref`/ you must do these steps for [server-side-data-fetching](https://analogjs.org/docs/features/data-fetching/server-side-data-fetching), [html markup and assets](https://angular.io/api/common/APP_BASE_HREF), and [dynamic api routes](https://analogjs.org/docs/features/api/overview) to work correctly on the specified `basehref`.
 
 1. Instruct Angular on how recognize and generate URLs. Create a new file `app.config.env.ts`.
 

--- a/apps/docs-app/docs/features/deployment/overview.md
+++ b/apps/docs-app/docs/features/deployment/overview.md
@@ -49,7 +49,7 @@ export default defineConfig({
 });
 ```
 
-## Deploying to a non root url
+## Deploying with a Custom URL Prefix
 
 If you are deploying to a non-root URL, https://domain.com/`basehref`/ you must do these steps for [server-side-data-fetching](https://analogjs.org/docs/features/data-fetching/server-side-data-fetching), [html markup and assets](https://angular.io/api/common/APP_BASE_HREF), and [dynamic api routes](https://analogjs.org/docs/features/api/overview) to work correctly on the specified `basehref`.
 

--- a/apps/docs-app/docs/features/deployment/overview.md
+++ b/apps/docs-app/docs/features/deployment/overview.md
@@ -90,7 +90,7 @@ export const appConfig = mergeApplicationConfig(envConfig, {
 NITRO_APP_BASE_URL="/basehref/"
 ```
 
-given a `vite.config.ts` file similar to this:
+Given a `vite.config.ts` file similar to this:
 
 ```ts
     plugins: [

--- a/apps/docs-app/docs/features/deployment/overview.md
+++ b/apps/docs-app/docs/features/deployment/overview.md
@@ -48,3 +48,54 @@ export default defineConfig({
   ],
 });
 ```
+
+## Deploying to non root url settings
+
+If you are deploying to a non-root URL, https://domain.com/<basehref>/ you must do these steps for [server-side-data-fetching](https://analogjs.org/docs/features/data-fetching/server-side-data-fetching), [html markup and assets](https://angular.io/api/common/APP_BASE_HREF), and [dynamic api routes](https://analogjs.org/docs/features/api/overview) to work correctly on the specified `<basehref>`.
+
+1. Instruct Angular on how recognize and generate URLs. Create a new file `app.config.env.ts`.
+
+```ts
+import { ApplicationConfig } from '@angular/core';
+import { APP_BASE_HREF } from '@angular/common';
+
+export const envConfig: ApplicationConfig = {
+  providers: [{ provide: APP_BASE_HREF, useValue: '/basehref/' }],
+};
+```
+
+2. Update the `app.config.ts` file to use the new file.
+
+```ts
+import { mergeApplicationConfig } from '@angular/core';
+import { envConfig } from './app.config.env';
+
+export const appConfig = mergeApplicationConfig(envConfig, {
+....
+});
+```
+
+3. In CI production build
+
+```bash
+  # sets the base url for server-side data fetching
+  export VITE_ANALOG_PUBLIC_BASE_URL="https://domain.com/basehref"
+  # prefixes all assets and html with /basehref/
+  npx nx run appname:build:production --baseHref='/basehref/'
+```
+
+4. In production containers specify the env flag `NITRO_APP_BASE_URL`.
+
+```bash
+NITRO_APP_BASE_URL="/basehref/"
+```
+
+given a `vite.config.ts` file similar to this:
+
+```ts
+    plugins: [
+      analog({
+        apiPrefix: 'api',
+```
+
+Nitro will prefix all api routes with `/basehref/api`.

--- a/apps/docs-app/docs/features/deployment/overview.md
+++ b/apps/docs-app/docs/features/deployment/overview.md
@@ -98,4 +98,4 @@ Given a `vite.config.ts` file similar to this:
         apiPrefix: 'api',
 ```
 
-Nitro will prefix all api routes with `/basehref/api`.
+Nitro prefixes all API routes with `/basehref/api`.

--- a/apps/docs-app/docs/features/deployment/overview.md
+++ b/apps/docs-app/docs/features/deployment/overview.md
@@ -51,7 +51,7 @@ export default defineConfig({
 
 ## Deploying to non root url settings
 
-If you are deploying to a non-root URL, https://domain.com/<basehref>/ you must do these steps for [server-side-data-fetching](https://analogjs.org/docs/features/data-fetching/server-side-data-fetching), [html markup and assets](https://angular.io/api/common/APP_BASE_HREF), and [dynamic api routes](https://analogjs.org/docs/features/api/overview) to work correctly on the specified `<basehref>`.
+If you are deploying to a non-root URL, https://domain.com/`basehref`/ you must do these steps for [server-side-data-fetching](https://analogjs.org/docs/features/data-fetching/server-side-data-fetching), [html markup and assets](https://angular.io/api/common/APP_BASE_HREF), and [dynamic api routes](https://analogjs.org/docs/features/api/overview) to work correctly on the specified `basehref`.
 
 1. Instruct Angular on how recognize and generate URLs. Create a new file `app.config.env.ts`.
 

--- a/apps/docs-app/docs/features/deployment/overview.md
+++ b/apps/docs-app/docs/features/deployment/overview.md
@@ -49,7 +49,7 @@ export default defineConfig({
 });
 ```
 
-## Deploying to non root url settings
+## Deploying to a non root url
 
 If you are deploying to a non-root URL, https://domain.com/`basehref`/ you must do these steps for [server-side-data-fetching](https://analogjs.org/docs/features/data-fetching/server-side-data-fetching), [html markup and assets](https://angular.io/api/common/APP_BASE_HREF), and [dynamic api routes](https://analogjs.org/docs/features/api/overview) to work correctly on the specified `basehref`.
 

--- a/packages/router/src/lib/route-config.ts
+++ b/packages/router/src/lib/route-config.ts
@@ -39,7 +39,9 @@ export function toRouteConfig(routeMeta: RouteMeta | undefined): RouteConfig {
         const segment =
           parent?.url.map((segment) => segment.path).join('/') || '';
         const url = new URL('', import.meta.env['VITE_ANALOG_PUBLIC_BASE_URL']);
-        url.pathname = `/api/_analog${routeConfig[ANALOG_META_KEY].endpoint}`;
+        url.pathname = `${
+          url.pathname.endsWith('/') ? url.pathname : url.pathname + '/'
+        }api/_analog${routeConfig[ANALOG_META_KEY].endpoint}`;
         url.search = `${new URLSearchParams(queryParams).toString()}`;
         url.hash = hash ?? '';
 


### PR DESCRIPTION
url.pathname ignoring path defined in env flag: VITE_ANALOG_PUBLIC_BASE_URL.

fixes: #954

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)




## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Which package are you modifying?

- [x] router

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #954 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/39hoXKE2isn6nrwKos/giphy.gif"/>
