### PR TITLE
fix(vite-plugin-nitro): retain event context when fetching API routes

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/runtime/api-middleware.ts
+++ b/packages/vite-plugin-nitro/src/lib/runtime/api-middleware.ts
@@ -12,7 +12,10 @@ export default eventHandler(async (event) => {
       // and can render the XML correctly as a static asset
       !event.node.req.url?.endsWith('.xml')
     ) {
-      return $fetch(reqUrl, { headers: event.node.req.headers });
+      return $fetch(reqUrl, {
+        headers: event.node.req.headers,
+        context: event.context,
+      });
     }
 
     return proxyRequest(event, reqUrl, {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

API routes created with `defineEventHandler` don't have access to platform-specific fields that get added to the `h3` event context when using various build presets (my specific use-case of concern is the `cloudflare-pages` preset)

Closes #1006

## What is the new behavior?

The `event.context` object is now forwarded along to api route handlers created with `defineEventHandler`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
