### PR TITLE
fix(vite-plugin-nitro): produce consistent builds for CSR mode

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/build-server.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-server.ts
@@ -23,6 +23,7 @@ export async function buildServer(
   await copyPublicAssets(nitro);
 
   if (
+    options?.ssr &&
     nitroConfig?.prerender?.routes &&
     nitroConfig?.prerender?.routes.find((route) => route === '/')
   ) {

--- a/packages/vite-plugin-nitro/src/lib/runtime/renderer-client.mjs
+++ b/packages/vite-plugin-nitro/src/lib/runtime/renderer-client.mjs
@@ -1,0 +1,8 @@
+import { eventHandler } from 'h3';
+
+// @ts-ignore
+import template from '#analog/index';
+
+export default eventHandler(async () => {
+  return template;
+});

--- a/packages/vite-plugin-nitro/src/lib/runtime/renderer-client.ts
+++ b/packages/vite-plugin-nitro/src/lib/runtime/renderer-client.ts
@@ -1,0 +1,8 @@
+import { eventHandler } from 'h3';
+
+// @ts-ignore
+import template from '#analog/index';
+
+export default eventHandler(async () => {
+  return template;
+});

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
@@ -58,8 +58,11 @@ describe('nitro', () => {
           ...mockNitroConfig,
           alias: expect.anything(),
           prerender: { routes: ['/'] },
+          renderer: expect.anything(),
           rollupConfig: expect.anything(),
           handlers: expect.anything(),
+          publicAssets: expect.anything(),
+          serverAssets: expect.anything(),
         }
       );
     });
@@ -88,7 +91,10 @@ describe('nitro', () => {
           prerender: { routes: ['/'] },
           alias: expect.anything(),
           rollupConfig: expect.anything(),
+          renderer: expect.anything(),
           handlers: expect.anything(),
+          publicAssets: expect.anything(),
+          serverAssets: expect.anything(),
         }
       );
     });
@@ -125,12 +131,15 @@ describe('nitro', () => {
           ...mockNitroConfig,
           alias: expect.anything(),
           rollupConfig: expect.anything(),
+          renderer: expect.anything(),
           handlers: expect.anything(),
           preset: undefined,
           prerender: {
             ...mockNitroConfig.prerender,
             routes: [],
           },
+          publicAssets: expect.anything(),
+          serverAssets: expect.anything(),
         }
       );
       expect(buildSitemapImportSpy).not.toHaveBeenCalled();
@@ -172,7 +181,10 @@ describe('nitro', () => {
           },
           alias: expect.anything(),
           rollupConfig: expect.anything(),
+          renderer: expect.anything(),
           handlers: expect.anything(),
+          publicAssets: expect.anything(),
+          serverAssets: expect.anything(),
         }
       );
 
@@ -237,8 +249,11 @@ describe('nitro', () => {
                 routes: ['/blog', '/about', '/blog/first', '/blog/02-second'],
               },
               alias: expect.anything(),
+              publicAssets: expect.anything(),
               rollupConfig: expect.anything(),
+              renderer: expect.anything(),
               handlers: expect.anything(),
+              serverAssets: expect.anything(),
             }
           );
 

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -123,7 +123,6 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
             },
             ...pageHandlers,
           ],
-          renderer: rendererEntry,
         };
 
         if (isVercelPreset(buildPreset)) {
@@ -157,6 +156,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
               dir: clientOutputPath,
             },
           ];
+          nitroConfig.renderer = rendererEntry;
 
           if (isEmptyPrerenderRoutes(options)) {
             nitroConfig.prerender = {};

--- a/packages/vite-plugin-nitro/tsconfig.lib.json
+++ b/packages/vite-plugin-nitro/tsconfig.lib.json
@@ -8,8 +8,9 @@
   },
   "include": ["src/**/*.ts"],
   "exclude": [
-    "jest.config.ts",
+    "vite.config.ts",
     "src/**/*.spec.ts",
+    "src/**/*.spec.data.ts",
     "src/**/*.test.ts",
     "src/lib/runtime/*.ts"
   ]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

When setting `ssr: false` in the analog plugin config, the client build output isn't produced in the `dist/analog/public` folder.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- When setting `ssr: false` in the analog plugin config, the client build output is still produced in the `dist/analog/public` folder by default. 
- Prerendered routes are rendered as CSR-only HTML files.
- Running the built server serves the app with a fallback to CSR-only mode.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://tenor.com/boDaL.gif" />
