### PR TITLE
docs: use correct syntax highlighting tag type

### DIFF
--- a/apps/docs-app/docs/experimental/sfc/index.md
+++ b/apps/docs-app/docs/experimental/sfc/index.md
@@ -157,8 +157,7 @@ You can also have **Property Binding** and **Event Binding** in the `<template>`
 
   const bg = signal('black');
 
-  function handleClick() {
-  }
+  function handleClick() {}
 </script>
 
 <template [style.backgroundColor]="bg()" (click)="handleClick()"></template>

--- a/apps/docs-app/docs/experimental/sfc/index.md
+++ b/apps/docs-app/docs/experimental/sfc/index.md
@@ -145,13 +145,13 @@ defineMetadata({
 
 Another way to add host metadata is to use the `<template>` tag
 
-```analog
+```html
 <template class="block articles-toggle"></template>
 ```
 
 You can also have **Property Binding** and **Event Binding** in the `<template>` tag:
 
-```analog
+```html
 <script lang="ts">
   import { signal } from '@angular/core';
 


### PR DESCRIPTION
Using `analog` as a tag type does not highlight the example code on https://analogjs.org/docs/experimental/sfc#host-metadata

Using `html` is fixing that issue.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Using `analog` as a tag type does not highlight the example code on https://analogjs.org/docs/experimental/sfc#host-metadata

## What is the new behavior?

Using `html` is fixing that issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

