### PR TITLE
fix(vite-plugin-angular): support backticks with templateUrl and styleUrls

### DIFF
--- a/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
@@ -129,6 +129,90 @@ describe('component-resolvers', () => {
 
       expect(thePathsAreEqual(resolvedPaths, actualPaths)).toBe(true);
     });
+
+    it('should handle styleUrl with backticks', () => {
+      const code = `
+      @Component({
+        styleUrl: \`./app.component.css\`
+      })
+      export class MyComponent {}
+    `;
+
+      const actualPaths = [
+        './app.component.css|/path/to/src/app.component.css',
+      ];
+      const styleUrlsResolver = new StyleUrlsResolver();
+      const resolvedPaths = styleUrlsResolver.resolve(code, id);
+
+      expect(thePathsAreEqual(resolvedPaths, actualPaths)).toBe(true);
+    });
+
+    it('should handle multi-line styleUrls with backticks', () => {
+      const code = `
+        @Component({
+          styleUrls: [
+            \`./app.component.css\`,
+            \`../styles.css\`
+          ]
+        })
+        export class MyComponent {}
+      `;
+
+      const actualPaths = [
+        './app.component.css|/path/to/src/app.component.css',
+        '../styles.css|/path/to/styles.css',
+      ];
+
+      const styleUrlsResolver = new StyleUrlsResolver();
+      const resolvedPaths = styleUrlsResolver.resolve(code, id);
+
+      expect(thePathsAreEqual(resolvedPaths, actualPaths)).toBe(true);
+    });
+
+    it('should handle multi-line styleUrls with backticks and single quotes', () => {
+      const code = `
+        @Component({
+          styleUrls: [
+            \`./app.component.css\`,
+            '../styles.css'
+          ]
+        })
+        export class MyComponent {}
+      `;
+
+      const actualPaths = [
+        './app.component.css|/path/to/src/app.component.css',
+        '../styles.css|/path/to/styles.css',
+      ];
+
+      const styleUrlsResolver = new StyleUrlsResolver();
+      const resolvedPaths = styleUrlsResolver.resolve(code, id);
+
+      expect(thePathsAreEqual(resolvedPaths, actualPaths)).toBe(true);
+    });
+
+    it('should handle wrapped multi-line styleUrls with backticks', () => {
+      const code = `
+        @Component({
+          styleUrls: [
+            \`./app.component.css\`, \`./another.css\`,
+            \`../styles.css\`
+          ]
+        })
+        export class MyComponent {}
+      `;
+
+      const actualPaths = [
+        './app.component.css|/path/to/src/app.component.css',
+        './another.css|/path/to/src/another.css',
+        '../styles.css|/path/to/styles.css',
+      ];
+
+      const styleUrlsResolver = new StyleUrlsResolver();
+      const resolvedPaths = styleUrlsResolver.resolve(code, id);
+
+      expect(thePathsAreEqual(resolvedPaths, actualPaths)).toBe(true);
+    });
   });
 
   describe('component-resolvers templateUrl', () => {
@@ -236,6 +320,22 @@ describe('component-resolvers', () => {
         const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
 
         expect(resolvedTemplateUrls).toHaveLength(0);
+      });
+
+      it('should handle templateUrl with backticks', () => {
+        const code = `
+        @Component({
+          templateUrl: \`./app.component.html\`
+        })
+        export class MyComponent {}
+      `;
+
+        const actualUrl =
+          './app.component.html|/path/to/src/app.component.html';
+        const templateUrlsResolver = new TemplateUrlsResolver();
+        const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
+
+        expect(thePathsAreEqual(resolvedTemplateUrls, [actualUrl])).toBe(true);
       });
     });
   });

--- a/packages/vite-plugin-angular/src/lib/component-resolvers.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.ts
@@ -52,7 +52,7 @@ function getTextByProperty(name: string, properties: PropertyAssignment[]) {
   return properties
     .filter((property) => property.getName() === name)
     .map((property) =>
-      property.getInitializer()?.getText().replace(/['"]/g, '')
+      property.getInitializer()?.getText().replace(/['"`]/g, '')
     )
     .filter((url): url is string => url !== undefined);
 }
@@ -68,7 +68,7 @@ export function getStyleUrls(code: string) {
     .filter((property) => property.getName() === 'styleUrls')
     .map((property) => property.getInitializer() as ArrayLiteralExpression)
     .flatMap((array) =>
-      array.getElements().map((el) => el.getText().replace(/['"]/g, ''))
+      array.getElements().map((el) => el.getText().replace(/['"`]/g, ''))
     );
 
   return [...styleUrls, ...styleUrl];


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1019

## What is the new behavior?

We account in backticks for templateUrl, styleUrl and styleUrls!

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

![image](https://media.tenor.com/-3k-YA9oxpYAAAAM/john-c-reilly-shocked.gif)

because the tests on component-resolver were always failing without me making any changes as I am on Windows so normalizePaths contains the drive letter in them.