### PR TITLE
fix(content): ensure content has been rendered before SSR serialization

### DIFF
--- a/packages/content/src/lib/markdown-content-renderer.service.spec.ts
+++ b/packages/content/src/lib/markdown-content-renderer.service.spec.ts
@@ -2,11 +2,16 @@ import { TestBed } from '@angular/core/testing';
 
 import { MarkdownContentRendererService } from './markdown-content-renderer.service';
 import { MarkedSetupService } from './marked-setup.service';
+import { RenderTaskService } from './render-task.service';
 
 describe('MarkdownContentRendererService', () => {
   function setup() {
     TestBed.configureTestingModule({
-      providers: [MarkdownContentRendererService, MarkedSetupService],
+      providers: [
+        MarkdownContentRendererService,
+        MarkedSetupService,
+        RenderTaskService,
+      ],
     });
     return { service: TestBed.inject(MarkdownContentRendererService) };
   }

--- a/packages/content/src/lib/markdown.component.ts
+++ b/packages/content/src/lib/markdown.component.ts
@@ -1,7 +1,6 @@
 import { AsyncPipe, isPlatformBrowser } from '@angular/common';
 import {
   AfterViewChecked,
-  ChangeDetectorRef,
   Component,
   Input,
   NgZone,
@@ -48,7 +47,7 @@ export default class AnalogMarkdownComponent
   });
   private mermaid: typeof import('mermaid') | undefined;
 
-  public content$: Observable<SafeHtml> = of('');
+  public content$: Observable<SafeHtml> = this.getContentSource();
 
   @Input() content!: string | object | undefined | null;
   @Input() classes = 'analog-markdown';
@@ -79,13 +78,17 @@ export default class AnalogMarkdownComponent
       const componentRef = this.container.createComponent(this.content as any);
       componentRef.changeDetectorRef.detectChanges();
     } else {
-      this.content$ = this.route.data.pipe(
-        map<Data, string>((data) => this.content ?? data['_analogContent']),
-        mergeMap((contentString) => this.renderContent(contentString)),
-        map((content) => this.sanitizer.bypassSecurityTrustHtml(content)),
-        catchError((e) => of(`There was an error ${e}`))
-      );
+      this.content$ = this.getContentSource();
     }
+  }
+
+  getContentSource() {
+    return this.route.data.pipe(
+      map<Data, string>((data) => this.content ?? data['_analogContent']),
+      mergeMap((contentString) => this.renderContent(contentString)),
+      map((content) => this.sanitizer.bypassSecurityTrustHtml(content)),
+      catchError((e) => of(`There was an error ${e}`))
+    );
   }
 
   async renderContent(content: string): Promise<string> {

--- a/packages/content/src/lib/render-task.service.ts
+++ b/packages/content/src/lib/render-task.service.ts
@@ -1,0 +1,31 @@
+import {
+  Injectable,
+  inject,
+  ɵPendingTasks as PendingTasks,
+} from '@angular/core';
+import { filter, first, timeout } from 'rxjs';
+
+@Injectable()
+export class RenderTaskService {
+  pendingTasks = inject(PendingTasks);
+  private readonly renderTask = this.pendingTasks.add();
+
+  constructor() {
+    this.pendingTasks.hasPendingTasks
+      .pipe(
+        filter((isStable) => !isStable),
+        timeout(100),
+        first()
+      )
+      .subscribe({
+        next: () => {},
+        error: () => {
+          this.clearRenderTask();
+        },
+      });
+  }
+
+  clearRenderTask() {
+    this.pendingTasks.remove(this.renderTask);
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [x] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

When rendering markdown content using the `analog-markdown` component, there is a flicker when the content renders. This happens because the markdown is compiled asynchronously, and the SSR serialization has already happened before the content is rendered.

This causes the content to be re-rendered on the client instead of hydrated after SSR.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1038 

## What is the new behavior?

This uses the `ɵPendingTasks` (internal) API to add a pending task as soon as possible to delay SSR serialization until after the content is rendered. As a fallback, if nothing is rendered within 100ms, the pending task is cleared. Open to suggestions on a better solution here. Using the router navigation events as a fallback happens too quickly.

AFTER/BEFORE:


https://github.com/analogjs/analog/assets/42211/a5849b12-898c-4159-9ef7-93906fd83bd9


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/l0HlAvWVOKVN5Ws80/giphy.gif"/>
