### PR TITLE
fix(create-analog): add dev dependency when using yarn

### DIFF
--- a/packages/create-analog/index.js
+++ b/packages/create-analog/index.js
@@ -202,7 +202,8 @@ async function init() {
   pkg.name = packageName || getProjectName();
   pkg.scripts.start = getStartCommand(pkgManager);
 
-  if (!skipTailwind) addDevDependencies(pkg);
+  if (!skipTailwind) addTailwindDevDependencies(pkg);
+  if (pkgManager === 'yarn') addYarnDevDependencies(pkg);
 
   write('package.json', JSON.stringify(pkg, null, 2));
 
@@ -345,13 +346,17 @@ function addTailwindConfig(write, filesDir) {
   );
 }
 
-function addDevDependencies(pkg) {
+function addTailwindDevDependencies(pkg) {
   ['tailwindcss@^3.3.1', 'postcss@^8.4.21', 'autoprefixer@^10.4.14'].forEach(
     (packageName) => {
       const [name, version] = packageName.split('@');
       pkg.devDependencies[name] = version;
     }
   );
+}
+
+function addYarnDevDependencies(pkg) {
+  pkg.devDependencies['@angular-devkit/build-angular'] = ['^17.3.5'];
 }
 
 init().catch((e) => {

--- a/packages/create-analog/index.js
+++ b/packages/create-analog/index.js
@@ -203,7 +203,8 @@ async function init() {
   pkg.scripts.start = getStartCommand(pkgManager);
 
   if (!skipTailwind) addTailwindDevDependencies(pkg);
-  if (pkgManager === 'yarn') addYarnDevDependencies(pkg);
+  if (pkgManager === 'yarn' && variant === 'angular-v17')
+    addYarnDevDependencies(pkg);
 
   write('package.json', JSON.stringify(pkg, null, 2));
 


### PR DESCRIPTION
Fixes `yarn dev` script error due to missing peer dependencies installation

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [X] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

When using `yarn` as the package manager, an exception is thrown while running `yarn dev`. This happens because `yarn` doesn't install the peer dependency.

Closes #1045 

## What is the new behavior?

Adds the missing dependency

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
