### PR TITLE
fix(create-analog): update Angular 16 package.json

### DIFF
--- a/packages/create-analog/template-angular-v16/package.json
+++ b/packages/create-analog/template-angular-v16/package.json
@@ -15,8 +15,8 @@
     "test": "ng test"
   },
   "dependencies": {
-    "@analogjs/content": "^0.2.0",
-    "@analogjs/router": "^0.2.0",
+    "@analogjs/content": "~1.1.0",
+    "@analogjs/router": "~1.1.0",
     "@angular/animations": "^16.2.0",
     "@angular/common": "^16.2.0",
     "@angular/compiler": "^16.2.0",
@@ -26,7 +26,7 @@
     "@angular/platform-browser-dynamic": "^16.2.0",
     "@angular/platform-server": "^16.2.0",
     "@angular/router": "^16.2.0",
-    "@nx/angular": "^17.0.0",
+    "@nx/angular": "~18.0.0",
     "front-matter": "^4.0.2",
     "marked": "^5.0.2",
     "marked-gfm-heading-id": "^3.1.0",
@@ -38,15 +38,15 @@
     "zone.js": "~0.13.0"
   },
   "devDependencies": {
-    "@analogjs/platform": "^0.2.0",
+    "@analogjs/platform": "~1.1.0",
     "@angular-devkit/build-angular": "^16.2.0",
     "@angular/cli": "^16.2.0",
     "@angular/compiler-cli": "^16.2.0",
-    "@nx/vite": "~16.8.1",
-    "nx": "^17.0.0",
+    "@nx/vite": "~18.0.0",
+    "nx": "~18.0.0",
     "jsdom": "^22.1.0",
     "typescript": "~5.0.2",
-    "vite": "^4.4.8",
-    "vitest": "^0.32.0"
+    "vite": "^5.0.0",
+    "vitest": "^1.3.1"
   }
 }


### PR DESCRIPTION
This commit pins the Analog version to ~1.1.0 in order for Angular 16 to work. It also updates some other packages.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [X] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

When a new Angular 16 project is created, and you try to run it, the following error is thrown:

failed to load config from /Users/sonukapoor/projects/ng-16-org/vite.config.ts
TypeError: (0 , import_platform.default) is not a function
    at /Users/sonukapoor/projects/ng-16-org/vite.config.ts:46:41
    at loadConfigFromFile (file:///Users/sonukapoor/projects/ng-16-org/node_modules/vite/dist/node/chunks/dep-41cf5ffd.js:66189:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async resolveConfig (file:///Users/sonukapoor/projects/ng-16-org/node_modules/vite/dist/node/chunks/dep-41cf5ffd.js:65782:28)
    at async _createServer (file:///Users/sonukapoor/projects/ng-16-org/node_modules/vite/dist/node/chunks/dep-41cf5ffd.js:65051:20)
    at async viteDevServerExecutor (/Users/sonukapoor/projects/ng-16-org/node_modules/@nx/vite/src/executors/dev-server/dev-server.impl.js:34:24)

Closes #951

## What is the new behavior?

Upgrades the package.json and pins the Analog version to 1.1.0

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
