### PR TITLE
docs(platform): add glob pattern to the contentDir value

### DIFF
--- a/apps/docs-app/docs/features/server/static-site-generation.md
+++ b/apps/docs-app/docs/features/server/static-site-generation.md
@@ -39,6 +39,7 @@ Therefore, you have to pass a `transform` function which maps the file paths to 
 The returning string should be the URL path in your app.
 Using `transform` allows you also filter out some routes by returning `false`.
 This does not include them in the prerender process, such as files marked as `draft` in the frontmatter.
+The `contentDir` value of that object can be a glob pattern, not just a specific path.
 
 ```ts
 import { defineConfig } from 'vite';

--- a/apps/docs-app/docs/features/server/static-site-generation.md
+++ b/apps/docs-app/docs/features/server/static-site-generation.md
@@ -39,7 +39,7 @@ Therefore, you have to pass a `transform` function which maps the file paths to 
 The returning string should be the URL path in your app.
 Using `transform` allows you also filter out some routes by returning `false`.
 This does not include them in the prerender process, such as files marked as `draft` in the frontmatter.
-The `contentDir` value of that object can be a glob pattern, not just a specific path.
+The `contentDir` value of that object can be a glob pattern or just a specific path.
 
 ```ts
 import { defineConfig } from 'vite';

--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -38,7 +38,7 @@ export interface Options {
 
 export interface PrerenderContentDir {
   /**
-   * The directory glob pattern where the files should be grabbed from.
+   * The directory or glob pattern where the files should be grabbed from.
    * @example `/src/contents/blog`
    */
   contentDir: string;

--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -38,7 +38,7 @@ export interface Options {
 
 export interface PrerenderContentDir {
   /**
-   * The directory where files should be grabbed from.
+   * The directory glob pattern where the files should be grabbed from.
    * @example `/src/contents/blog`
    */
   contentDir: string;


### PR DESCRIPTION
The documentation wasn't obvious that we can pass not just a direct path, but a glob pattern too to this property

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [x] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
