### PR TITLE
fix(vite-plugin-angular): use conditional imports across Angular Devkit versions

### DIFF
--- a/packages/vite-plugin-angular/src/lib/utils/compiler-plugin-options.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/compiler-plugin-options.ts
@@ -1,0 +1,15 @@
+import { SourceFileCache } from './source-file-cache';
+
+export interface CompilerPluginOptions {
+  sourcemap: boolean;
+  tsconfig: string;
+  jit?: boolean;
+  /** Skip TypeScript compilation setup. This is useful to re-use the TypeScript compilation from another plugin. */
+  noopTypeScriptCompilation?: boolean;
+  advancedOptimizations?: boolean;
+  thirdPartySourcemaps?: boolean;
+  fileReplacements?: Record<string, string>;
+  sourceFileCache?: SourceFileCache;
+  // loadResultCache?: LoadResultCache;
+  incremental: boolean;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Angular v18 introduces a new `@angular/build` package and some of the esbuild tooling files have moved into the `@angular/build/private` export. This adds conditional imports based on the major version of Angular to continue to support multiple versions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
