### PR TITLE
fix(vite-plugin-angular): honour user's test.pool choice

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { angularVitestPlugin } from './angular-vitest-plugin';
+import { defineConfig, resolveConfig } from 'vite';
+
+describe(angularVitestPlugin.name, () => {
+  /* Setting the pool to vmThreads by default to avoid issues related to global conflicts when using JSDOM.
+   * This also aligns with the default pool setting in Jest.
+   * This is not ideal as vmThreads comes with its own set of issues, but it's the best option we have for now.
+   * Cf. https://github.com/vitest-dev/vitest/issues/4685
+   * Cf. https://vitest.dev/config/#vmthreads */
+  it('should set pool to vmThreads', async () => {
+    const config = await resolveConfig(
+      defineConfig({
+        plugins: [angularVitestPlugin()],
+      }),
+      'serve'
+    );
+    expect(config.test?.pool).toBe('vmThreads');
+  });
+
+  it('should not override pool option if already set by user', async () => {
+    const config = await resolveConfig(
+      defineConfig({
+        plugins: [angularVitestPlugin()],
+        test: {
+          pool: 'threads',
+        },
+      }),
+      'serve'
+    );
+    expect(config.test?.pool).toBe('threads');
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -5,13 +5,13 @@ export function angularVitestPlugin(): Plugin {
     name: '@analogjs/vitest-angular-esm-plugin',
     apply: 'serve',
     enforce: 'post',
-    config() {
+    config(userConfig) {
       return {
         ssr: {
           noExternal: [/cdk\/fesm2022/],
         },
         test: {
-          pool: 'vmThreads',
+          pool: userConfig.test?.pool ?? 'vmThreads',
         },
       } as UserConfig;
     },


### PR DESCRIPTION
Do not override `test.pool` option if it is already set by the user.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [X] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #937

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
