### PR TITLE
feat(vite-plugin-angular): allow passing options to analogSFC esbuild plugin

### DIFF
--- a/packages/vite-plugin-angular/esbuild.ts
+++ b/packages/vite-plugin-angular/esbuild.ts
@@ -7,11 +7,13 @@ export const analogSFC: (options?: PluginOptions) => esbuild.Plugin = (
 ) => ({
   name: 'analog-sfc-esbuild-plugin',
   async setup(build) {
-    const analogPlugins: any = analog(
-      options ?? {
-        experimental: { supportAnalogFormat: true },
-      }
-    );
+    const analogPlugins: any = analog({
+       ...(options || {}),
+        experimental: {
+          supportAnalogFormat: true,
+          ...(options?.experimental || {})
+        },
+    });
 
     const analogPlugin = analogPlugins[0];
     await analogPlugin.config({ root: '.' }, { command: 'build' });

--- a/packages/vite-plugin-angular/esbuild.ts
+++ b/packages/vite-plugin-angular/esbuild.ts
@@ -1,12 +1,17 @@
 import analog from '@analogjs/vite-plugin-angular';
 import type * as esbuild from 'esbuild';
+import { PluginOptions } from './src';
 
-export const analogSFC: () => esbuild.Plugin = () => ({
+export const analogSFC: (options?: PluginOptions) => esbuild.Plugin = (
+  options
+) => ({
   name: 'analog-sfc-esbuild-plugin',
   async setup(build) {
-    const analogPlugins: any = analog({
-      experimental: { supportAnalogFormat: true },
-    });
+    const analogPlugins: any = analog(
+      options ?? {
+        experimental: { supportAnalogFormat: true },
+      }
+    );
 
     const analogPlugin = analogPlugins[0];
     await analogPlugin.config({ root: '.' }, { command: 'build' });

--- a/packages/vite-plugin-angular/esbuild.ts
+++ b/packages/vite-plugin-angular/esbuild.ts
@@ -8,11 +8,11 @@ export const analogSFC: (options?: PluginOptions) => esbuild.Plugin = (
   name: 'analog-sfc-esbuild-plugin',
   async setup(build) {
     const analogPlugins: any = analog({
-       ...(options || {}),
-        experimental: {
-          supportAnalogFormat: true,
-          ...(options?.experimental || {})
-        },
+      ...(options || {}),
+      experimental: {
+        supportAnalogFormat: true,
+        ...(options?.experimental || {}),
+      },
     });
 
     const analogPlugin = analogPlugins[0];


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

`analogSFC` is not configurable

## What is the new behavior?

Allows supplying optional options object to `analogSFC` (uses existing default value if none is supplied)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/5t3POlVgm29ZiERRXT/giphy.gif"/>
