### PR TITLE
fix(platform): add support in @analogjs/platform for older Angular versions

### DIFF
--- a/apps/docs-app/docs/guides/compatibility.md
+++ b/apps/docs-app/docs/guides/compatibility.md
@@ -12,9 +12,9 @@ The table shows the minimum version of Nx, the supported Angular version, and th
 | ------------------ | --------------- | -------------- | ------------ |
 | 18.0.0             | ^17.0.0         | **latest**     | ^5.0.0       |
 | 17.0.0             | ^17.0.0         | **latest**     | ^5.0.0       |
-| 16.1.0             | ^16.1.0         | **~1.1.0**     | ^5.0.0       |
-| 16.0.0             | ~15.2.X         | **~1.1.0**     | ^5.0.0       |
-| 15.2.0             | ~15.2.X         | **~1.1.0**     | ^5.0.0       |
+| 16.1.0             | ^16.1.0         | **latest**     | ^5.0.0       |
+| 16.0.0             | ~15.2.X         | **latest**     | ^5.0.0       |
+| 15.2.0             | ~15.2.X         | **latest**     | ^5.0.0       |
 
 Additionally, you can check this [guide from Nx](https://nx.dev/packages/angular/documents/angular-nx-version-matrix)
 to learn more about Nx and Angular compatibility.

--- a/apps/docs-app/docs/guides/migrating.md
+++ b/apps/docs-app/docs/guides/migrating.md
@@ -5,6 +5,8 @@ import TabItem from '@theme/TabItem';
 
 An existing Angular Single Page Application can be configured to use Analog using a schematic/generator for Angular CLI or Nx workspaces.
 
+> Analog is compatible with Angular v15 and above.
+
 ## Using a Schematic/Generator
 
 First, install the `@analogjs/platform` package:

--- a/packages/platform/src/lib/router-plugin.ts
+++ b/packages/platform/src/lib/router-plugin.ts
@@ -1,3 +1,4 @@
+import { VERSION } from '@angular/compiler-cli';
 import { normalizePath, Plugin } from 'vite';
 
 /**
@@ -36,7 +37,9 @@ export function routerPlugin(): Plugin[] {
             include: [
               '@angular/common',
               '@angular/common/http',
-              '@angular/core/rxjs-interop',
+              ...(Number(VERSION.major) > 15
+                ? ['@angular/core/rxjs-interop']
+                : []),
             ],
             exclude: ['@angular/platform-server', '@analogjs/router'],
           },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [x] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

The `@analog/platform` package throws an error when used with Angular v15 because it tries to optimize `@angular/core/rxjs-interop` package which doesn't exist.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The `@analog/platform` is compatible with Angular v15. Compatibility guides have also been updated.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
