### PR TITLE
fix(vite-plugin-nitro): correctly merge Nitro config customizations

### DIFF
--- a/packages/nx-plugin/src/utils/versions/dependencies.ts
+++ b/packages/nx-plugin/src/utils/versions/dependencies.ts
@@ -30,8 +30,8 @@ export const getAnalogDependencies = (
 
 const getDependencies = (escapedAngularVersion: string) => {
   // fail out for versions <15.2.0
-  if (lt(escapedAngularVersion, '16.0.0')) {
-    throw new Error(stripIndents`Angular v16.0.0 or newer is required.`);
+  if (lt(escapedAngularVersion, '15.0.0')) {
+    throw new Error(stripIndents`Angular v15.0.0 or newer is required.`);
   }
 
   // install 16.x deps for versions <17.0.0

--- a/packages/nx-plugin/src/utils/versions/dev-dependencies.ts
+++ b/packages/nx-plugin/src/utils/versions/dev-dependencies.ts
@@ -39,7 +39,7 @@ export const getAnalogDevDependencies = (
 
 const getDevDependencies = (escapedAngularVersion: string) => {
   // fail out for versions <15.2.0
-  if (lt(escapedAngularVersion, '16.0.0')) {
+  if (lt(escapedAngularVersion, '15.0.0')) {
     throw new Error(stripIndents`Angular v16.0.0 or newer is required.`);
   }
 

--- a/packages/nx-plugin/src/utils/versions/ng_16_X/versions.ts
+++ b/packages/nx-plugin/src/utils/versions/ng_16_X/versions.ts
@@ -9,4 +9,4 @@ export const V16_X_NX_ANGULAR = '~18.0.0';
 export const V16_X_NX_VITE = '~18.0.0';
 export const V16_X_JSDOM = '^22.0.0';
 export const V16_X_VITE_TSCONFIG_PATHS = '^4.2.0';
-export const V16_X_VITEST = '^1.31.0';
+export const V16_X_VITEST = '^1.3.1';

--- a/packages/vite-plugin-nitro/src/lib/vite-nitro-plugin.spec.data.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-nitro-plugin.spec.data.ts
@@ -12,6 +12,7 @@ export const mockViteDevServer = {
 
 export const mockNitroConfig: NitroConfig = {
   buildDir: resolve('./dist/.nitro'),
+  preset: undefined,
   handlers: [],
   logLevel: 0,
   output: {
@@ -19,7 +20,6 @@ export const mockNitroConfig: NitroConfig = {
     publicDir: resolve('dist/analog/public'),
   },
   rootDir: '.',
-  runtimeConfig: {},
   scanDirs: ['src/server'],
   srcDir: 'src/server',
   prerender: {

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
@@ -247,6 +247,7 @@ describe('nitro', () => {
               ...mockNitroConfig,
               prerender: {
                 routes: ['/blog', '/about', '/blog/first', '/blog/02-second'],
+                crawlLinks: undefined,
               },
               alias: expect.anything(),
               publicAssets: expect.anything(),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

When using the `nitro.rollupConfig` options, the config wasn't being merged correctly.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Related to #977 

## What is the new behavior?

All Nitro customization options passed through `nitro` are merged correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
