### PR TITLE
fix(vitest-angular): update peerDependencies for @angular-devkit/architect version pattern range

### DIFF
--- a/packages/vitest-angular/package.json
+++ b/packages/vitest-angular/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@analogjs/vite-plugin-angular": "^1.3.0",
-    "@angular-devkit/architect": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+    "@angular-devkit/architect": "0.1500.0-0.1599.999 || 0.1600.0-0.1699.999 || 0.1700.0-0.1799.999 || 0.1800.0-0.1899.999",
     "vitest": "^1.3.1"
   },
   "ng-update": {

--- a/packages/vitest-angular/package.json
+++ b/packages/vitest-angular/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@analogjs/vite-plugin-angular": "^1.3.0",
-    "@angular-devkit/architect": "0.1500.0-0.1599.999 || 0.1600.0-0.1699.999 || 0.1700.0-0.1799.999 || 0.1800.0-0.1899.999",
+    "@angular-devkit/architect": "^0.1500.0 || ^0.1600.0 || ^0.1700.0 || ^0.1800.0",
     "vitest": "^1.3.1"
   },
   "ng-update": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [x] vitest-angular
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1112

## What is the new behavior?

This should resolve the related bug when attempting to install the `@analogjs/vitest-angular` package.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm not 100% certain how to test this fix myself, but GPT-4o tells me this is new pattern should satisfy the correct versioning conventions that would enable the package to be properly installed.