### PR TITLE
fix(content): adjust peer dependencies meta for different highlighters

### DIFF
--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -25,15 +25,28 @@
     "@angular/router": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
     "@nx/devkit": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "rxjs": "^6.5.0 || ^7.5.0",
-    "marked": "^5.0.2",
+    "marked": ">=5.0.2",
     "marked-gfm-heading-id": "^3.0.4",
     "marked-highlight": "^2.0.1",
     "marked-mangle": "^1.1.7",
     "marked-shiki": "^1.1.0",
-    "mermaid": "^10.2.4",
     "prismjs": "^1.29.0",
     "shiki": "^1.6.1",
     "front-matter": "^4.0.2"
+  },
+  "peerDependenciesMeta": {
+    "shiki": {
+      "optional": true
+    },
+    "marked-shiki": {
+      "optional": true
+    },
+    "prismjs": {
+      "optional": true
+    },
+    "marked-highlight": {
+      "optional": true
+    }
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/create-analog/template-blog/package.json
+++ b/packages/create-analog/template-blog/package.json
@@ -30,7 +30,7 @@
     "marked": "^5.0.2",
     "marked-gfm-heading-id": "^3.1.0",
     "marked-highlight": "^2.0.1",
-    "mermaid": "^10.2.4",
+    "marked-mangle": "^1.1.7",
     "prismjs": "^1.29.0",
     "rxjs": "~7.5.6",
     "tslib": "^2.4.0",

--- a/packages/create-analog/template-latest/package.json
+++ b/packages/create-analog/template-latest/package.json
@@ -30,7 +30,7 @@
     "marked": "^5.0.2",
     "marked-gfm-heading-id": "^3.1.0",
     "marked-highlight": "^2.0.1",
-    "mermaid": "^10.2.4",
+    "marked-mangle": "^1.1.7",
     "prismjs": "^1.29.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] vitest-angular
- [ ] astro-angular
- [x] create-analog
- [ ] router
- [ ] platform
- [x] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Dependency errors on missing peer dependencies of unused highlighters.

## What is the new behavior?

Should not have dependency errors on missing peer dependencies of unused highlighters.

`mermaid` is also removed from the `@analogjs/content` peer dependencies because it is not a peer dependency. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media3.giphy.com/media/tmQrpA8zpG4a16SSxm/giphy-downsized-medium.gif"/>