### PR TITLE
build: fix migrate by removing @analogjs/trpc from packageGroup

### DIFF
--- a/packages/astro-angular/package.json
+++ b/packages/astro-angular/package.json
@@ -50,7 +50,6 @@
       "@analogjs/platform",
       "@analogjs/content",
       "@analogjs/router",
-      "@analogjs/trpc",
       "@analogjs/vite-plugin-angular",
       "@analogjs/vite-plugin-nitro",
       "@analogjs/vitest-angular"

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -56,7 +56,6 @@
       "@analogjs/platform",
       "@analogjs/content",
       "@analogjs/router",
-      "@analogjs/trpc",
       "@analogjs/vite-plugin-angular",
       "@analogjs/vite-plugin-nitro",
       "@analogjs/vitest-angular"

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -42,7 +42,6 @@
       "@analogjs/platform",
       "@analogjs/content",
       "@analogjs/router",
-      "@analogjs/trpc",
       "@analogjs/vite-plugin-angular",
       "@analogjs/vite-plugin-nitro",
       "@analogjs/vitest-angular"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -34,7 +34,6 @@
       "@analogjs/platform",
       "@analogjs/content",
       "@analogjs/router",
-      "@analogjs/trpc",
       "@analogjs/vite-plugin-angular",
       "@analogjs/vite-plugin-nitro",
       "@analogjs/vitest-angular"

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -33,7 +33,6 @@
       "@analogjs/platform",
       "@analogjs/content",
       "@analogjs/router",
-      "@analogjs/trpc",
       "@analogjs/vite-plugin-angular",
       "@analogjs/vite-plugin-nitro",
       "@analogjs/vitest-angular"

--- a/packages/vite-plugin-angular/package.json
+++ b/packages/vite-plugin-angular/package.json
@@ -31,7 +31,6 @@
       "@analogjs/platform",
       "@analogjs/content",
       "@analogjs/router",
-      "@analogjs/trpc",
       "@analogjs/vite-plugin-angular",
       "@analogjs/vite-plugin-nitro",
       "@analogjs/vitest-angular"

--- a/packages/vite-plugin-nitro/package.json
+++ b/packages/vite-plugin-nitro/package.json
@@ -32,7 +32,6 @@
       "@analogjs/platform",
       "@analogjs/content",
       "@analogjs/router",
-      "@analogjs/trpc",
       "@analogjs/vite-plugin-angular",
       "@analogjs/vite-plugin-nitro",
       "@analogjs/vitest-angular"

--- a/packages/vitest-angular/package.json
+++ b/packages/vitest-angular/package.json
@@ -37,7 +37,6 @@
       "@analogjs/platform",
       "@analogjs/content",
       "@analogjs/router",
-      "@analogjs/trpc",
       "@analogjs/vite-plugin-angular",
       "@analogjs/vite-plugin-nitro",
       "@analogjs/vitest-angular"


### PR DESCRIPTION
Refs: #1123

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [x] vite-plugin-nitro
- [x] vitest-angular
- [x] astro-angular
- [ ] create-analog
- [x] router
- [x] platform
- [x] content
- [ ] nx-plugin
- [x] trpc

## What is the current behavior?

nx migrate failes with cannot find package @analogjs/trpc@v1.4.0

Closes #1123 

## What is the new behavior?

nx migate works

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
