### PR TITLE
fix(create-analog): correctly set package versions for yarn and pin Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ With pnpm:
 pnpm create analog@latest
 ```
 
-With Yarn:
-
-```sh
-yarn create analog@latest
-```
-
 With Bun:
 
 ```sh
 bun create analog@latest
+```
+
+With Yarn:
+
+```sh
+yarn create analog
 ```
 
 Follow the prompts to scaffold the project and start the development server.

--- a/packages/create-analog/index.js
+++ b/packages/create-analog/index.js
@@ -375,12 +375,12 @@ function addTailwindDevDependencies(pkg) {
 function addYarnDevDependencies(pkg, template) {
   // v18
   if (template === 'latest' || template === 'blog') {
-    pkg.devDependencies['@nx/angular'] = ['^19.1.0'];
-    pkg.devDependencies['@nx/devkit'] = ['^19.1.0'];
-    pkg.devDependencies['@nx/vite'] = ['^19.1.0'];
-    pkg.devDependencies['nx'] = ['^19.1.0'];
+    pkg.devDependencies['@nx/angular'] = '^19.1.0';
+    pkg.devDependencies['@nx/devkit'] = '^19.1.0';
+    pkg.devDependencies['@nx/vite'] = '^19.1.0';
+    pkg.devDependencies['nx'] = '^19.1.0';
   } else if (template === 'angular-v17') {
-    pkg.devDependencies['@angular-devkit/build-angular'] = ['^17.3.5'];
+    pkg.devDependencies['@angular-devkit/build-angular'] = '^17.2.0';
   }
 }
 

--- a/packages/create-analog/template-blog/_gitignore
+++ b/packages/create-analog/template-blog/_gitignore
@@ -31,6 +31,7 @@ yarn-error.log
 # Miscellaneous
 /.angular/cache
 /.nx/cache
+/.nx/workspace-data
 .sass-cache/
 /connect.lock
 /coverage

--- a/packages/create-analog/template-blog/package.json
+++ b/packages/create-analog/template-blog/package.json
@@ -42,7 +42,7 @@
     "@angular/compiler-cli": "^18.0.0",
     "jsdom": "^22.1.0",
     "typescript": "~5.4.2",
-    "vite": "^5.0.0",
+    "vite": "~5.2.0",
     "vitest": "^1.3.1"
   }
 }

--- a/packages/create-analog/template-latest/_gitignore
+++ b/packages/create-analog/template-latest/_gitignore
@@ -31,6 +31,7 @@ yarn-error.log
 # Miscellaneous
 /.angular/cache
 /.nx/cache
+/.nx/workspace-data
 .sass-cache/
 /connect.lock
 /coverage

--- a/packages/create-analog/template-latest/package.json
+++ b/packages/create-analog/template-latest/package.json
@@ -44,7 +44,7 @@
     "@angular/compiler-cli": "^18.0.0",
     "jsdom": "^22.0.0",
     "typescript": "~5.4.2",
-    "vite": "^5.0.0",
+    "vite": "~5.2.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^1.3.1"
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] vitest-angular
- [ ] astro-angular
- [x] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Fixes issue where package.json versions were being set incorrectly when using `yarn`
- Vite version mismatch causes an error to be logged to the console. The Angular CLI is on version `5.2.x`, while the latest current version is `5.3.0`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
