### PR TITLE
fix: disable esbuild if not configured to enable correct sourcemaps

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -161,6 +161,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           );
 
         return {
+          esbuild: config.esbuild ?? false,
           optimizeDeps: {
             include: ['rxjs/operators', 'rxjs'],
             exclude: ['@angular/platform-server'],
@@ -363,10 +364,8 @@ export function angular(options?: PluginOptions): Plugin[] {
 
           if (jit) {
             return {
-              code: data.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, ''),
-              map: {
-                mappings: '',
-              },
+              code: data,
+              map: null,
             };
           }
 
@@ -391,10 +390,8 @@ export function angular(options?: PluginOptions): Plugin[] {
 
           if (!forceAsyncTransformation && !isProd) {
             return {
-              code: data.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, ''),
-              map: {
-                mappings: '',
-              },
+              code: data,
+              map: null,
             };
           }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] vitest-angular
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

Sourcemaps were not working correctly.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #86 
Closes #1147 
Closes #822 

## What is the new behavior?

- Sourcemaps are working correctly if esbuild is disabled. If the user provides a custom esbuild config, it is respected.
- Sourcemaps are working for `.analog` files
- Breakpoints are working correctly in the browser devtools

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/jVStxzak9yk2Q/giphy.gif"/>
