### PR TITLE
docs: make vitest test code compile for easy copy-paste

### DIFF
--- a/apps/docs-app/docs/features/testing/vitest.md
+++ b/apps/docs-app/docs/features/testing/vitest.md
@@ -288,7 +288,7 @@ describe('CardComponent', () => {
   it('should create the app', () => {
     expect(fixture).toMatchSnapshot();
   });
-
+});
 ```
 
 After you run the test, a `card.component.spec.ts.snap` file is created in the`__snapshots__` folder with the below content:


### PR DESCRIPTION
I tried to copy the code and noticed that it didn't compile, technically it is marked with `...` but still this makes it somewhat easier to use. 