### PR TITLE
fix(vite-plugin-angular): prevent context loss for "each" tests

### DIFF
--- a/packages/vite-plugin-angular/setup-vitest.ts
+++ b/packages/vite-plugin-angular/setup-vitest.ts
@@ -229,22 +229,25 @@ const bindDescribe = (originalVitestFn: {
 /**
  * bind test method to wrap test.each function
  */
-const bindTest = (originalVitestFn: {
-  apply: (
-    arg0: any,
-    arg1: any[]
-  ) => {
-    (): any;
-    new (): any;
-    apply: { (arg0: any, arg1: any[]): any; new (): any };
-  };
-}) =>
+const bindTest = (
+  self: any,
+  originalVitestFn: {
+    apply: (
+      arg0: any,
+      arg1: any[]
+    ) => {
+      (): any;
+      new (): any;
+      apply: { (arg0: any, arg1: any[]): any; new (): any };
+    };
+  }
+) =>
   function (...eachArgs: any) {
     return function (...args: any[]) {
       args[1] = wrapTestInZone(args[1]);
 
       // @ts-ignore
-      return originalVitestFn.apply(this, eachArgs).apply(this, args);
+      return originalVitestFn.apply(self, eachArgs).apply(self, args);
     };
   };
 
@@ -269,9 +272,9 @@ const bindTest = (originalVitestFn: {
 
     return originalvitestFn.apply(this, args);
   };
-  env[methodName].each = bindTest(originalvitestFn.each);
-  env[methodName].only = bindTest(originalvitestFn.only);
-  env[methodName].skip = bindTest(originalvitestFn.skip);
+  env[methodName].each = bindTest(originalvitestFn, originalvitestFn.each);
+  env[methodName].only = bindTest(originalvitestFn, originalvitestFn.only);
+  env[methodName].skip = bindTest(originalvitestFn, originalvitestFn.skip);
 
   if (methodName === 'test' || methodName === 'it') {
     env[methodName].todo = function (...args: any) {

--- a/packages/vitest-angular/setup-zone.ts
+++ b/packages/vitest-angular/setup-zone.ts
@@ -229,22 +229,25 @@ const bindDescribe = (originalVitestFn: {
 /**
  * bind test method to wrap test.each function
  */
-const bindTest = (originalVitestFn: {
-  apply: (
-    arg0: any,
-    arg1: any[]
-  ) => {
-    (): any;
-    new (): any;
-    apply: { (arg0: any, arg1: any[]): any; new (): any };
-  };
-}) =>
+const bindTest = (
+  self: any,
+  originalVitestFn: {
+    apply: (
+      arg0: any,
+      arg1: any[]
+    ) => {
+      (): any;
+      new (): any;
+      apply: { (arg0: any, arg1: any[]): any; new (): any };
+    };
+  }
+) =>
   function (...eachArgs: any) {
     return function (...args: any[]) {
       args[1] = wrapTestInZone(args[1]);
 
       // @ts-ignore
-      return originalVitestFn.apply(this, eachArgs).apply(this, args);
+      return originalVitestFn.apply(self, eachArgs).apply(self, args);
     };
   };
 
@@ -269,9 +272,9 @@ const bindTest = (originalVitestFn: {
 
     return originalvitestFn.apply(this, args);
   };
-  env[methodName].each = bindTest(originalvitestFn.each);
-  env[methodName].only = bindTest(originalvitestFn.only);
-  env[methodName].skip = bindTest(originalvitestFn.skip);
+  env[methodName].each = bindTest(originalvitestFn, originalvitestFn.each);
+  env[methodName].only = bindTest(originalvitestFn, originalvitestFn.only);
+  env[methodName].skip = bindTest(originalvitestFn, originalvitestFn.skip);
 
   if (methodName === 'test' || methodName === 'it') {
     env[methodName].todo = function (...args: any) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] vitest-angular
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, when zones are wrapping the test function the context is lost causing an error "Cannot read `withContext()` of undefined".

Closes #1115

## What is the new behavior?

The original fn contains the mentioned `withContext()` method. I added reference to the initial method to the bounding function in order to preserve context.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm not sure how to properly test this change. I did not find tests for `setup-vitest`. I also failed to test this package using `npm link` as it failed complaining 

```
failed to load config from /Users/crush/Projects/analog-vitest-repro/apps/analog-vitest/vite.config.mts
Error: Cannot find module '@angular/build/private'
```

The original fix was found by tinkering the `setup-vitest.js` file from node_modules from the repro in the issue. I applied the same changes to the .ts file.

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXc1bHo4dHl3dXV5OTdmZHZvZXEwbGhod2dmcDVueDF3aDA4N3Y5ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SKwLNJpa2XJr6nyzMH/giphy.gif)
