### PR TITLE
fix(router): add error message when default export is missing from component

### DIFF
--- a/packages/router/src/lib/routes.spec.ts
+++ b/packages/router/src/lib/routes.spec.ts
@@ -1,5 +1,6 @@
 import { Route } from '@angular/router';
 import { of } from 'rxjs';
+import { expect, vi } from 'vitest';
 import { RouteExport, RouteMeta } from './models';
 import { createRoutes, Files } from './routes';
 import { ROUTE_META_TAGS_KEY } from './meta-tags';
@@ -608,19 +609,21 @@ describe('routes', () => {
 
   describe('a route without default export', () => {
     it('should throw error when default export is falsy', async () => {
+      const fileName = '/app/routes/index.ts';
       const files: Files = {
-        '/app/routes/index.ts': () =>
-          Promise.resolve({} as unknown as RouteExport),
+        [fileName]: () => Promise.resolve({} as unknown as RouteExport),
       };
 
       const routes = createRoutes(files);
       const route = routes[0];
 
-      try {
-        await route.loadChildren?.();
-      } catch (error) {
-        expect(error?.toString()).toMatch('Missing default export');
-      }
+      const spy = vi.spyOn(console, 'warn');
+
+      await route.loadChildren?.();
+
+      expect(spy).toHaveBeenCalledWith(
+        `[Analog] Missing default export at ${fileName}`
+      );
     });
   });
 });

--- a/packages/router/src/lib/routes.spec.ts
+++ b/packages/router/src/lib/routes.spec.ts
@@ -605,4 +605,22 @@ describe('routes', () => {
       expect(routes[1].path).toBe('static');
     });
   });
+
+  describe('a route without default export', () => {
+    it('should throw error when default export is falsy', async () => {
+      const files: Files = {
+        '/app/routes/index.ts': () =>
+          Promise.resolve({} as unknown as RouteExport),
+      };
+
+      const routes = createRoutes(files);
+      const route = routes[0];
+
+      try {
+        await route.loadChildren?.();
+      } catch (error) {
+        expect(error?.toString()).toMatch('Missing default export');
+      }
+    });
+  });
 });

--- a/packages/router/src/lib/routes.ts
+++ b/packages/router/src/lib/routes.ts
@@ -182,15 +182,27 @@ function toRoutes(rawRoutes: RawRoute[], files: Files): Route[] {
       ? {
           path: rawRoute.segment,
           loadChildren: () =>
-            module!().then((m) => [
-              {
-                path: '',
-                component: m.default,
-                ...toRouteConfig(m.routeMeta as RouteMeta | undefined),
-                children,
-                [ANALOG_META_KEY]: analogMeta,
-              },
-            ]),
+            module!().then((m) => {
+              const hasModuleDefault = !!m.default;
+              if (
+                process.env['NODE_ENV'] !== 'production' &&
+                !hasModuleDefault
+              ) {
+                throw new Error(
+                  `[Analog] Missing default export at ${rawRoute.filename}`
+                );
+              }
+
+              return [
+                {
+                  path: '',
+                  component: m.default,
+                  ...toRouteConfig(m.routeMeta as RouteMeta | undefined),
+                  children,
+                  [ANALOG_META_KEY]: analogMeta,
+                },
+              ];
+            }),
         }
       : { path: rawRoute.segment, children };
 

--- a/packages/router/src/lib/routes.ts
+++ b/packages/router/src/lib/routes.ts
@@ -183,14 +183,14 @@ function toRoutes(rawRoutes: RawRoute[], files: Files): Route[] {
           path: rawRoute.segment,
           loadChildren: () =>
             module!().then((m) => {
-              const hasModuleDefault = !!m.default;
-              if (
-                process.env['NODE_ENV'] !== 'production' &&
-                !hasModuleDefault
-              ) {
-                throw new Error(
-                  `[Analog] Missing default export at ${rawRoute.filename}`
-                );
+              if (!import.meta.env.PROD) {
+                const hasModuleDefault = !!m.default;
+
+                if (!hasModuleDefault) {
+                  console.warn(
+                    `[Analog] Missing default export at ${rawRoute.filename}`
+                  );
+                }
               }
 
               return [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] vitest-angular
- [ ] astro-angular
- [ ] create-analog
- [X] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1129 

## What is the new behavior?

Show a console.warn when default export is missing from component

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/rt96ekQ9jrWg/giphy.gif"/>