### PR TITLE
fix(vite-plugin-angular): prevent context loss for "each" describe bl…

### DIFF
--- a/packages/vite-plugin-angular/setup-vitest.ts
+++ b/packages/vite-plugin-angular/setup-vitest.ts
@@ -207,22 +207,25 @@ function fixtureVitestSerializer(fixture: any) {
 /**
  * bind describe method to wrap describe.each function
  */
-const bindDescribe = (originalVitestFn: {
-  apply: (
-    arg0: any,
-    arg1: any[]
-  ) => {
-    (): any;
-    new (): any;
-    apply: { (arg0: any, arg1: any[]): any; new (): any };
-  };
-}) =>
+const bindDescribe = (
+  self: any,
+  originalVitestFn: {
+    apply: (
+      arg0: any,
+      arg1: any[]
+    ) => {
+      (): any;
+      new (): any;
+      apply: { (arg0: any, arg1: any[]): any; new (): any };
+    };
+  }
+) =>
   function (...eachArgs: any) {
     return function (...args: any[]) {
       args[1] = wrapDescribeInZone(args[1]);
 
       // @ts-ignore
-      return originalVitestFn.apply(this, eachArgs).apply(this, args);
+      return originalVitestFn.apply(self, eachArgs).apply(self, args);
     };
   };
 
@@ -258,10 +261,16 @@ const bindTest = (
 
     return originalvitestFn.apply(this, args);
   };
-  env[methodName].each = bindDescribe(originalvitestFn.each);
+  env[methodName].each = bindDescribe(originalvitestFn, originalvitestFn.each);
   if (methodName === 'describe') {
-    env[methodName].only = bindDescribe(originalvitestFn.only);
-    env[methodName].skip = bindDescribe(originalvitestFn.skip);
+    env[methodName].only = bindDescribe(
+      originalvitestFn,
+      originalvitestFn.only
+    );
+    env[methodName].skip = bindDescribe(
+      originalvitestFn,
+      originalvitestFn.skip
+    );
   }
 });
 

--- a/packages/vitest-angular/setup-zone.ts
+++ b/packages/vitest-angular/setup-zone.ts
@@ -207,22 +207,25 @@ function fixtureVitestSerializer(fixture: any) {
 /**
  * bind describe method to wrap describe.each function
  */
-const bindDescribe = (originalVitestFn: {
-  apply: (
-    arg0: any,
-    arg1: any[]
-  ) => {
-    (): any;
-    new (): any;
-    apply: { (arg0: any, arg1: any[]): any; new (): any };
-  };
-}) =>
+const bindDescribe = (
+  self: any,
+  originalVitestFn: {
+    apply: (
+      arg0: any,
+      arg1: any[]
+    ) => {
+      (): any;
+      new (): any;
+      apply: { (arg0: any, arg1: any[]): any; new (): any };
+    };
+  }
+) =>
   function (...eachArgs: any) {
     return function (...args: any[]) {
       args[1] = wrapDescribeInZone(args[1]);
 
       // @ts-ignore
-      return originalVitestFn.apply(this, eachArgs).apply(this, args);
+      return originalVitestFn.apply(self, eachArgs).apply(self, args);
     };
   };
 
@@ -258,10 +261,16 @@ const bindTest = (
 
     return originalvitestFn.apply(this, args);
   };
-  env[methodName].each = bindDescribe(originalvitestFn.each);
+  env[methodName].each = bindDescribe(originalvitestFn, originalvitestFn.each);
   if (methodName === 'describe') {
-    env[methodName].only = bindDescribe(originalvitestFn.only);
-    env[methodName].skip = bindDescribe(originalvitestFn.skip);
+    env[methodName].only = bindDescribe(
+      originalvitestFn,
+      originalvitestFn.only
+    );
+    env[methodName].skip = bindDescribe(
+      originalvitestFn,
+      originalvitestFn.skip
+    );
   }
 });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] vite-plugin-angular
- [ ] vite-plugin-nitro
- [x] vitest-angular
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A followup to #1190

## What is the new behavior?

When running `describe.each` the tests fail with the error that `Cannot read "withContext()" of undefined`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
