### PR TITLE
fix(nx-plugin): add vitest types in tsconfig.spec.json

### DIFF
--- a/packages/nx-plugin/src/generators/setup-vitest/lib/update-tsconfig.ts
+++ b/packages/nx-plugin/src/generators/setup-vitest/lib/update-tsconfig.ts
@@ -7,6 +7,7 @@ interface TsConfig {
   compilerOptions: {
     module?: string;
     target?: string;
+    types?: string[];
   };
 }
 
@@ -29,6 +30,9 @@ export function updateTsConfig(tree: Tree, schema: SetupVitestGeneratorSchema) {
         json.compilerOptions.module = undefined;
         json.compilerOptions.target ??= 'es2016';
         json.files ??= ['src/test-setup.ts'];
+        json.compilerOptions.types = (json.compilerOptions.types ?? ['node'])
+          .filter((type) => type !== 'jest')
+          .concat(['vitest/globals']);
 
         return json;
       },


### PR DESCRIPTION
Add "vitest/globals" to types, and remove jest from the existing types.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [ ] vite-plugin-nitro
- [ ] vitest-angular
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [x] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

When the `tsconfig.spec.ts` is updated the types are missing "vitest/globals" type which leads to in-editor errors.

## What is the new behavior?

1. The "vitest/globals" is added to the list of types
2. The type "jest" is removed from the array if it was previously there (a small improvement of life when migrating)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
