### PR TITLE
fix(vite-plugin-nitro): make sitemap available for SSR build

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -303,8 +303,6 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
             await buildSSRApp(config, options);
           }
 
-          await buildServer(options, nitroConfig);
-
           if (
             nitroConfig.prerender?.routes?.length &&
             options?.prerender?.sitemap
@@ -315,9 +313,11 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
               config,
               options.prerender.sitemap,
               nitroConfig.prerender.routes,
-              nitroConfig.output?.publicDir!
+              clientOutputPath
             );
           }
+
+          await buildServer(options, nitroConfig);
 
           console.log(
             `\n\nThe '@analogjs/platform' server has been successfully built.`


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] vitest-angular
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The sitemap is built before the server is built, allowing the sitemap to be served through SSR requests.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/VeSvZhPrqgZxx2KpOA/giphy.gif"/>