### PR TITLE
feat(vite-plugin-nitro): add internal deployment support for Netlify

### DIFF
--- a/apps/docs-app/docs/features/deployment/providers.md
+++ b/apps/docs-app/docs/features/deployment/providers.md
@@ -13,14 +13,13 @@ Analog supports deploying on [Netlify](https://netlify.com/) with minimal config
 
 <Tabs groupId="porject-type">
   <TabItem label="Create analog" value="create-analog">
-In the build settings of your Netlify project, set the [publish directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/analog/public` to deploy the static assets and the [functions directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/analog` to deploy the server.
+In the build settings of your Netlify project, set the [publish directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/analog/public` to deploy the static assets.
   </TabItem>
 
   <TabItem label="Nx" value="nx">
 In the build settings of your Netlify project on the web UI, do the following.
 1. Set the [build command](https://docs.netlify.com/configure-builds/overview/#definitions) to `nx build [your-project-name]`
 2. Set the [publish directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/[your-project-name]/analog/public` to deploy the static assets
-3. Set the [functions directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/[your-project-name]/analog` to deploy the server.
 
 You can also configure this by putting a `netlify.toml` at the root of your repository. Below is an example config.
 
@@ -29,7 +28,6 @@ You can also configure this by putting a `netlify.toml` at the root of your repo
 [build]
   command = "nx build my-analog-app"
   publish = "dist/my-analog-app/analog/public"
-  functions = "dist/my-analog-app/analog"
 ```
 
   </TabItem>

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -132,6 +132,10 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
           nitroConfig = withCloudflareOutput(nitroConfig);
         }
 
+        if (isNetlifyPreset(buildPreset)) {
+          nitroConfig = withNetlifyOutput(nitroConfig);
+        }
+
         if (!ssrBuild && !isTest) {
           // store the client output path for the SSR build config
           clientOutputPath = resolve(
@@ -366,5 +370,18 @@ const withCloudflareOutput = (nitroConfig: NitroConfig | undefined) => ({
   output: {
     ...nitroConfig?.output,
     serverDir: '{{ output.publicDir }}/_worker.js',
+  },
+});
+
+const isNetlifyPreset = (buildPreset: string | undefined) =>
+  process.env['NETLIFY'] ||
+  process.env['NETLIFY_LOCAL'] ||
+  (buildPreset && buildPreset.toLowerCase().includes('netlify'));
+
+const withNetlifyOutput = (nitroConfig: NitroConfig | undefined) => ({
+  ...nitroConfig,
+  output: {
+    ...nitroConfig?.output,
+    dir: '{{ rootDir }}/.netlify/functions-internal',
   },
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/analogjs/analog/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] vite-plugin-angular
- [x] vite-plugin-nitro
- [ ] vitest-angular
- [ ] astro-angular
- [ ] create-analog
- [ ] router
- [ ] platform
- [ ] content
- [ ] nx-plugin
- [ ] trpc

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Users deploying to Netlify need to additionally configure location of produced serverless functions

Closes #

## What is the new behavior?

Serverless functions are generated at location that Netlify platform automatically handle removing the need to specify ~custom serverless function directory when configuring deployments to Netlify.

Additional note is that hopefully soon at least non-nx variant would require zero configuration. We recently added Analog to frameworks we automatically detect ( https://github.com/netlify/build/pull/5751 ) which soon will suggest appropiate settings when creating Analog site in Netlify web ui and there is work in-progress to use same detection automatically configure deployment when using Netlify CLI ( https://github.com/netlify/cli/pull/6729 )

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Explanation: users defining Netlify Functions directory with current instructions will still be able to deploy successfully because Netlify always look for functions in adjusted directory, so even if we point functions directory to one that no longer exist (or at least doesn't have Analog function) it will work correctly:

```
Packaging Functions from .netlify/functions-internal directory:
 - server/server.mjs
No Functions were found in dist/analog directory
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
