### PR TITLE
fix(content): export prism highlighter for custom client rendering

### DIFF
--- a/packages/content/prism-highlighter/src/index.ts
+++ b/packages/content/prism-highlighter/src/index.ts
@@ -1,8 +1,13 @@
 import { ContentRenderer, NoopContentRenderer } from '@analogjs/content';
 import { Provider } from '@angular/core';
+import { PrismHighlighter } from './lib/prism-highlighter';
+
 import 'prismjs';
-import 'prismjs/plugins/toolbar/prism-toolbar.js';
-import 'prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard.js';
+import 'prismjs/plugins/toolbar/prism-toolbar';
+import 'prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard';
+import './lib/prism/angular';
+
+export { PrismHighlighter };
 
 export function withPrismHighlighter(): Provider[] {
   return [{ provide: ContentRenderer, useClass: NoopContentRenderer }];

--- a/packages/content/prism-highlighter/src/lib/prism-highlighter.ts
+++ b/packages/content/prism-highlighter/src/lib/prism-highlighter.ts
@@ -1,0 +1,56 @@
+import { MarkedContentHighlighter } from '@analogjs/content';
+import { Injectable } from '@angular/core';
+import { markedHighlight } from 'marked-highlight';
+
+declare const Prism: typeof import('prismjs');
+
+@Injectable()
+export class PrismHighlighter extends MarkedContentHighlighter {
+  override augmentCodeBlock(code: string, lang: string): string {
+    const classes =
+      lang.startsWith('diff') && Prism.languages['diff']
+        ? `language-${lang} diff-highlight`
+        : `language-${lang.replace('diff-', '')}`;
+    return `<pre class="${classes}"><code class="${classes}">${code}</code></pre>`;
+  }
+
+  override getHighlightExtension() {
+    return markedHighlight({
+      async: true,
+      highlight: (code: string, lang: string) => {
+        let diff = lang?.startsWith('diff-');
+        lang = diff ? lang.replace('diff-', '') : lang || 'typescript';
+
+        if (diff && !Prism.languages['diff']) {
+          diff = false;
+          console.warn(`Notice:
+    ---------------------------------------------------------------------------------------
+    The \`diff\` language and plugin are not available in the provided setup.
+    To enable it, add the following imports your \`app.config.ts\`:
+      import 'prismjs/components/prism-diff';
+      import 'prismjs/plugins/diff-highlight/prism-diff-highlight';
+    ---------------------------------------------------------------------------------------
+            `);
+        }
+
+        if (!Prism.languages[lang]) {
+          if (lang !== 'mermaid') {
+            console.warn(`Notice:
+    ---------------------------------------------------------------------------------------
+    The requested language '${lang}' is not available in the provided setup.
+    To enable it, add the following import your \`app.config.ts\`:
+      import 'prismjs/components/prism-${lang}';
+    ---------------------------------------------------------------------------------------
+              `);
+          }
+          return code;
+        }
+        return Prism.highlight(
+          code,
+          diff ? Prism.languages['diff'] : Prism.languages[lang],
+          lang
+        );
+      },
+    });
+  }
+}

--- a/packages/content/prism-highlighter/src/lib/prism/angular.js
+++ b/packages/content/prism-highlighter/src/lib/prism/angular.js
@@ -1,0 +1,23 @@
+(function () {
+  if (typeof Prism === 'undefined') {
+    return;
+  }
+
+  Prism.languages.angular = Prism.languages.extend('markup', {
+    keyword:
+      /(?:@if|@for|@switch|@defer|@loading|@error|@placeholder|prefetch)\b/,
+    operator: /\b(?:on|when)\b/,
+    number: {
+      pattern: /\b(minimum|after)\s+\d+(?:s|ms|)/gi,
+      lookbehind: true,
+    },
+    builtin: {
+      pattern:
+        /\b(?:viewport|timer|minimum|after|hover|idle|immediate|interaction)/,
+    },
+    function:
+      /#?(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\s*(?:\.\s*(?:apply|bind|call)\s*)?\()/,
+  });
+
+  Prism.languages.ng = Prism.languages.angular;
+})();


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1203 

## What is the new behavior?

By default, all markdown rendering and syntax highlighting are done at build time. This exports the `PrismHighlighter` to be used with `withHighlighter({ useClass: PrismHighlighter })` for custom client side markdown rendering and syntax highlighting.

```ts
export const appConfig: ApplicationConfig = {
  providers: [
    provideContent(
      withMarkdownRenderer(), 
      withHighlighter({ useClass: PrismHighlighter })
    ),
    { provide: ContentRenderer, useClass: MarkdownContentRendererService },
    MarkedSetupService,
  ],
};
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/VeSvZhPrqgZxx2KpOA/giphy.gif"/>