### PR TITLE
fix(router): skip default export warning for redirect page routes

### DIFF
--- a/packages/router/src/lib/routes.spec.ts
+++ b/packages/router/src/lib/routes.spec.ts
@@ -608,7 +608,7 @@ describe('routes', () => {
   });
 
   describe('a route without default export', () => {
-    it('should throw error when default export is falsy', async () => {
+    it('should log a warning when default export is falsy', async () => {
       const fileName = '/app/routes/index.ts';
       const files: Files = {
         [fileName]: () => Promise.resolve({} as unknown as RouteExport),
@@ -622,6 +622,27 @@ describe('routes', () => {
       await route.loadChildren?.();
 
       expect(spy).toHaveBeenCalledWith(
+        `[Analog] Missing default export at ${fileName}`
+      );
+    });
+
+    it('should not log a warning default export is falsy with a redirect', async () => {
+      const fileName = '/app/routes/index.ts';
+      const files: Files = {
+        [fileName]: () =>
+          Promise.resolve({
+            routeMeta: { redirectTo: '/home' },
+          } as unknown as RouteExport),
+      };
+
+      const routes = createRoutes(files);
+      const route = routes[0];
+
+      const spy = vi.spyOn(console, 'warn');
+
+      await route.loadChildren?.();
+
+      expect(spy).not.toHaveBeenCalledWith(
         `[Analog] Missing default export at ${fileName}`
       );
     });

--- a/packages/router/src/lib/routes.ts
+++ b/packages/router/src/lib/routes.ts
@@ -185,8 +185,9 @@ function toRoutes(rawRoutes: RawRoute[], files: Files): Route[] {
             module!().then((m) => {
               if (!import.meta.env.PROD) {
                 const hasModuleDefault = !!m.default;
+                const hasRedirect = !!m.routeMeta?.redirectTo;
 
-                if (!hasModuleDefault) {
+                if (!hasModuleDefault && !hasRedirect) {
                   console.warn(
                     `[Analog] Missing default export at ${rawRoute.filename}`
                   );

--- a/packages/router/vite.config.ts
+++ b/packages/router/vite.config.ts
@@ -6,15 +6,13 @@ import { defineConfig } from 'vite';
 export default defineConfig(({ mode }) => {
   return {
     root: __dirname,
+    cacheDir: `../../node_modules/.vitest`,
     test: {
       reporters: ['default'],
       globals: true,
       environment: 'jsdom',
       setupFiles: ['src/test-setup.ts'],
       include: ['**/*.spec.ts'],
-      cache: {
-        dir: `../../node_modules/.vitest`,
-      },
     },
     define: {
       'import.meta.vitest': mode !== 'production',


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

No longer logs a warning for page routes used only for redirects

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
