### PR TITLE
fix(create-analog): update templates to use Vite 5.x

### DIFF
--- a/packages/create-analog/template-blog/package.json
+++ b/packages/create-analog/template-blog/package.json
@@ -43,7 +43,7 @@
     "@angular/compiler-cli": "^18.0.0",
     "jsdom": "^22.1.0",
     "typescript": "~5.4.2",
-    "vite": "~5.2.0",
+    "vite": "^5.0.0",
     "vitest": "^1.3.1"
   }
 }

--- a/packages/create-analog/template-latest/package.json
+++ b/packages/create-analog/template-latest/package.json
@@ -45,7 +45,7 @@
     "@angular/compiler-cli": "^18.0.0",
     "jsdom": "^22.0.0",
     "typescript": "~5.4.2",
-    "vite": "~5.2.0",
+    "vite": "^5.0.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^1.3.1"
   }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Unpins Vite from 5.2.x in the template apps

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
