### PR TITLE
fix(create-analog): typo on prism highlighter

### DIFF
--- a/packages/create-analog/index.js
+++ b/packages/create-analog/index.js
@@ -167,8 +167,7 @@ async function init() {
   // determine template
   template = variant || framework || template;
   // determine syntax highlighter
-  let highlighter =
-    syntaxHighlighter ?? (template === 'blog' ? 'prismjs' : null);
+  let highlighter = syntaxHighlighter ?? (template === 'blog' ? 'prism' : null);
   skipTailwind = !tailwind || skipTailwind;
 
   console.log(`\nScaffolding project in ${root}...`);


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The expected values for the content highlighter are shiki or prism but the create-analog package adds 'prismjs'.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
