### PR TITLE
fix(astro-angular): pass Astro/Starlight defaults for esbuild

### DIFF
--- a/packages/astro-angular/src/index.ts
+++ b/packages/astro-angular/src/index.ts
@@ -17,6 +17,9 @@ function getRenderer(): AstroRenderer {
 
 function getViteConfiguration(vite?: PluginOptions) {
   return {
+    esbuild: {
+      jsxDev: true,
+    },
     optimizeDeps: {
       include: [
         '@angular/platform-browser',
@@ -28,17 +31,7 @@ function getViteConfiguration(vite?: PluginOptions) {
         '@analogjs/astro-angular/server.js',
       ],
     },
-    /**
-     *
-     * Why I am casting viteAngular as any
-     *
-     * The vite angular plugins is shipped as commonjs, while this astro
-     * integration is shipped using ESM and if you call the default
-     * function, you get the following error: viteAngular is not a function.
-     * Attempt to use ESM for the angular vite plugin broke something, hence
-     * this workaround for now.
-     *
-     */
+
     plugins: [
       viteAngular(vite),
       {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Fixes a bug where using Analog with Angular and Astro produces an error because the Analog Vite plugin for Angular disables esbuild if its not configured by default.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/cn36VpLKgGVBvPPdGx/giphy.gif"/>
