### PR TITLE
refactor(router): remove unnecessary type casting

### DIFF
--- a/packages/router/src/lib/provide-file-router.ts
+++ b/packages/router/src/lib/provide-file-router.ts
@@ -2,7 +2,6 @@ import {
   ENVIRONMENT_INITIALIZER,
   EnvironmentProviders,
   makeEnvironmentProviders,
-  Provider,
 } from '@angular/core';
 import { provideRouter, RouterFeatures } from '@angular/router';
 
@@ -21,13 +20,7 @@ export function provideFileRouter(
   ...features: RouterFeatures[]
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
-    // TODO: remove type casting after Angular >=15.1.1 upgrade
-    // https://github.com/angular/angular/pull/48720
-    (
-      provideRouter(routes, ...features) as unknown as {
-        ɵproviders: Provider[];
-      }
-    ).ɵproviders,
+    provideRouter(routes, ...features),
     {
       provide: ENVIRONMENT_INITIALIZER,
       multi: true,


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Type casting for `provideRouter` result is not needed since Angular v16

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

🧹 
