### PR TITLE
fix(create-analog): add proper component naming

### DIFF
--- a/packages/create-analog/template-blog/src/app/pages/blog/[slug].page.ts
+++ b/packages/create-analog/template-blog/src/app/pages/blog/[slug].page.ts
@@ -24,6 +24,6 @@ import PostAttributes from '../../post-attributes';
     `,
   ],
 })
-export default class HomeComponent {
+export default class BlogPostComponent {
   readonly post$ = injectContent<PostAttributes>('slug');
 }

--- a/packages/create-analog/template-blog/src/app/pages/blog/index.page.ts
+++ b/packages/create-analog/template-blog/src/app/pages/blog/index.page.ts
@@ -31,6 +31,6 @@ import { RouterLink } from '@angular/router';
     `,
   ],
 })
-export default class HomeComponent {
+export default class BlogComponent {
   readonly posts = injectContentFiles<PostAttributes>();
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

All components created for the blog template are named **HomeComponent**.

Closes #1236

## What is the new behavior?

Use proper names for components.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
