### PR TITLE
fix: update peer dependencies for router and vitest-angular packages

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -20,11 +20,9 @@
     "url": "https://github.com/analogjs/analog.git"
   },
   "peerDependencies": {
+    "@analogjs/content": "^1.7.0-beta.6",
     "@angular/core": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
     "@angular/router": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
-  },
-  "optionalDependencies": {
-    "@analogjs/content": "^1.7.0-beta.6"
   },
   "dependencies": {
     "tslib": "^2.0.0"

--- a/packages/vitest-angular/package.json
+++ b/packages/vitest-angular/package.json
@@ -28,7 +28,7 @@
     "save": "devDependencies"
   },
   "peerDependencies": {
-    "@analogjs/vite-plugin-angular": "^1.3.0 || ^1.3.0-beta.0",
+    "@analogjs/vite-plugin-angular": "*",
     "@angular-devkit/architect": "^0.1500.0 || ^0.1600.0 || ^0.1700.0 || ^0.1800.0",
     "vitest": "^1.3.1"
   },


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Allows the `@analogjs/vitest-angular` to install beta versions of `@analogjs/vite-plugin-angular`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
