### PR TITLE
fix(vite-plugin-angular): use Vite preprocessCSS function for JIT CSS transform

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
@@ -1,31 +1,16 @@
-import { Plugin, PluginContainer, ViteDevServer } from 'vite';
+import { Plugin, preprocessCSS } from 'vite';
 
 export function jitPlugin({
   inlineStylesExtension,
 }: {
   inlineStylesExtension: string;
 }): Plugin {
-  let styleTransform: PluginContainer['transform'] | undefined;
-  let watchMode = false;
-  let viteServer: ViteDevServer | undefined;
-  let cssPlugin: Plugin | undefined;
+  let config: any;
 
   return {
     name: '@analogjs/vite-plugin-angular-jit',
-    config(_config, { command }) {
-      watchMode = command === 'serve';
-    },
-    buildStart({ plugins }) {
-      if (Array.isArray(plugins)) {
-        cssPlugin = plugins.find((plugin) => plugin.name === 'vite:css');
-      }
-
-      styleTransform = watchMode
-        ? viteServer!.pluginContainer.transform
-        : (cssPlugin!.transform as PluginContainer['transform']);
-    },
-    configureServer(server) {
-      viteServer = server;
+    config(_config) {
+      config = _config;
     },
     resolveId(id: string) {
       if (id.startsWith('virtual:angular')) {
@@ -46,9 +31,10 @@ export function jitPlugin({
         let styles: string | undefined = '';
 
         try {
-          const compiled = await styleTransform!(
+          const compiled = await preprocessCSS(
             decodedStyles,
-            `${styleId}.${inlineStylesExtension}?direct`
+            `${styleId}.${inlineStylesExtension}?direct`,
+            config
           );
           styles = compiled?.code;
         } catch (e) {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Uses Vite's `preprocessCSS` for transforming CSS in JIT mode

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
