### PR TITLE
fix(vite-plugin-angular): add additionalContentDirs to analog globs

### DIFF
--- a/apps/blog-app/vite.config.ts
+++ b/apps/blog-app/vite.config.ts
@@ -19,6 +19,11 @@ export default defineConfig(() => {
     plugins: [
       analog({
         static: true,
+        vite: {
+          experimental: {
+            supportAnalogFormat: true,
+          },
+        },
         additionalPagesDirs: ['/libs/shared/feature'],
         additionalContentDirs: ['/libs/shared/feature/src/content'],
         content: {

--- a/libs/shared/feature/src/content/test.agx
+++ b/libs/shared/feature/src/content/test.agx
@@ -1,0 +1,12 @@
+---
+title: Shared Test Agx
+slug: shared-test-agx
+---
+
+<script lang="ts">
+  const name = 'Analog';
+</script>
+
+<template lang="md">
+  My First Post on {{ name }}
+</template>

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -41,6 +41,7 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
           (pageDir) => `${pageDir}/**/*.page.ts`
         ),
       ],
+      additionalContentDirs: platformOptions.additionalContentDirs,
       ...(opts?.vite ?? {}),
     }),
     ssrXhrBuildPlugin(),

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -473,7 +473,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       `${appRoot}/**/*.{analog,agx}`,
       ...extraGlobs.map((glob) => `${workspaceRoot}${glob}.{analog,agx}`),
       ...(pluginOptions.additionalContentDirs || [])?.map(
-        (glob) => `${workspaceRoot}${glob}/**/*.{analog,agx}`
+        (glob) => `${workspaceRoot}${glob}/**/*.agx`
       ),
     ];
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -66,6 +66,7 @@ export interface PluginOptions {
    * Additional files to include in compilation
    */
   include?: string[];
+  additionalContentDirs?: string[];
 }
 
 interface EmitFileResult {
@@ -113,6 +114,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       options?.experimental?.markdownTemplateTransforms ??
       defaultMarkdownTemplateTransforms,
     include: options?.include ?? [],
+    additionalContentDirs: options?.additionalContentDirs ?? [],
   };
 
   // The file emitter created during `onStart` that will be used during the build in `onLoad` callbacks for TS files
@@ -470,6 +472,9 @@ export function angular(options?: PluginOptions): Plugin[] {
     const globs = [
       `${appRoot}/**/*.{analog,agx}`,
       ...extraGlobs.map((glob) => `${workspaceRoot}${glob}.{analog,agx}`),
+      ...(pluginOptions.additionalContentDirs || [])?.map(
+        (glob) => `${workspaceRoot}${glob}/**/*.{analog,agx}`
+      ),
     ];
 
     return fg


### PR DESCRIPTION
## PR Checklist

When attempting to use `.agx` files from directories listed in `additionalContentDirs` no default export is present, only the metadata export.

It seems like it is possible to workaround this without any changes by also adding the `additionalContentDirs` directories to the `supportAnalogFormat` `include` configuration, e.g:

```ts
        additionalContentDirs: [
          '/libs/shared/data-access/src/content',
        ],
        vite: {
          experimental: {
            supportAnalogFormat: {
              include: ['/libs/shared/data-access/src/content/**/*'],
            },
          },
        },
```

But not having to duplicate this seems preferable to me.

## What is the new behavior?

Any directories listed in `additionalContentDirs` will be added to the globs for finding analog files automatically.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/FoH28ucxZFJZu/giphy.gif"/>
