### PR TITLE
docs: german translation for `Testing`/`Version Compatibilty`/`Migrating an Angular app to Analog`/`Contributing`/`Vite`/`Angular Material`/`Nx`/`Adding Vitest`/`Astro`/`Ionic Framework`

### DIFF
--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/contributing.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/contributing.md
@@ -3,11 +3,216 @@ sidebar_position: 4
 title: Beitragen
 ---
 
-import Contributing, { toc as ContributingToc } from '../../../../../../CONTRIBUTING.md';
+# Beitragen
 
-<Contributing />
+Analog ist ein MIT-lizenziertes Open-Source-Projekt, das von den Mitwirkenden ständig weiterentwickelt wird.
 
-<!-- Workaround for generating table of contents -->
-<!-- See https://github.com/facebook/docusaurus/issues/3915#issuecomment-896193142 -->
+## Zum Projekt beitragen
 
-export const toc = [...ContributingToc];
+### Struktur der Verzeichnisse
+
+Der Quellcode für das Analog-Framework befindet sich im Ordner `packages/`. Um Funktionen oder Fehlerbehebungen zum Framework beizutragen, suche den entsprechenden Code in einem der `packages`-Unterordner. Zusätzlich zum Unterordner `create-analog` gibt es einen Unterordner für jedes der `npm`-Pakete im Bereich `@analogjs/*`:
+
+- `packages/create-analog` → `create-analog`
+- `packages/vite-plugin-angular` → `@analogjs/vite-plugin-angular`
+
+### Einrichtung
+
+Analog verwendet [pnpm](https://pnpm.io/), um seine Abhängigkeiten zu verwalten.
+
+Bevor du eine Pull-Anfrage öffnest, führen Sie den folgenden Befehl im Stammverzeichnis aus, um sicherzustellen, dass Ihre Entwicklungsabhängigkeiten auf dem neuesten Stand sind:
+
+```shell
+pnpm i
+```
+
+### Lokaler Betrieb
+
+Um die Beispielanwendung lokal bereitzustellen, führen den folgenden Befehl im Stammordner aus:
+
+```shell
+pnpm dev
+```
+
+### Bauen
+
+Analog verwendet [Nx](https://nx.dev) für Builds. Um alle Projekte lokal zu erstellen, führen den folgenden Befehl im Stammordner aus:
+
+```shell
+pnpm build
+```
+
+### Testen
+
+Analog verwendet [Vitest](https://vitest.dev) für Tests. Um alle Projekte lokal zu testen, führen den folgenden Befehl im Stammverzeichnis aus:
+
+```shell
+pnpm test
+```
+
+## Zu den Docs und zur analogjs.org Website beitragen
+
+### Struktur der Verzeichnisse
+
+Der Quellcode für die Analog-Dokumentation und die analogjs.org Website befindet sich im Projektordner `apps/docs-app`. Um Dokumentation oder Website-Inhalte beizusteuern, suchen den entsprechenden Quellcode in einem der Unterordner:
+
+- `blog` - Blog (ungenutzt).
+- `docs` - Dokumentationsseiten mit React MDX-Unterstützung.
+- `src/components` - React-Komponenten.
+- `src/css` - Global Styles.
+- `src/pages` - React-Seitenkomponenten.
+- `static` - Bilder und andere statische Elemente.
+
+### Einrichtung
+
+Analog verwendet [pnpm](https://pnpm.io/), um seine Abhängigkeiten zu verwalten.
+
+Bevor du eine Pull-Anfrage öffnest, führen Sie den folgenden Befehl im Stammverzeichnis aus, um sicherzustellen, dass Ihre Entwicklungsabhängigkeiten auf dem neuesten Stand sind:
+
+```shell
+pnpm i
+```
+
+### Lokaler Betrieb
+
+Analog verwendet [Docusaurus](https://docusaurus.io/) zur Entwicklung der Dokumentation und der analogjs.org Website. Führe den folgenden Befehl aus dem Ordner `apps/docs-app` aus, um die Website bereitzustellen:
+
+```shell
+pnpm nx serve
+```
+
+oder führe alternativ diesen Befehl vom Stammverzeichnis aus:
+
+```shell
+pnpm nx serve docs-app
+```
+
+Sobald der Entwicklungsserver in Betrieb ist, kann die Dokumentation und die Website unter [http://localhost:3000](http://localhost:3000) eingesehen werden.
+
+### Bauen
+
+Analog verwendet [Nx](https://nx.dev), um die Docs und die analogjs.org-Website zu erstellen. Um die Website lokal zu erstellen, führe den folgenden Befehl aus dem Ordner `apps/docs-app` aus:
+
+```shell
+pnpm nx build
+```
+
+oder führe alternativ diesen Befehl vom Stammverzeichnis aus:
+
+```shell
+pnpm nx build docs-app
+```
+
+### Statische Website lokal bereitstellen
+
+Um die generierte statische Website lokal bereitzustellen, führe den folgenden Befehl aus dem Ordner `apps/docs-app` aus:
+
+```shell
+pnpm nx serve-static
+```
+
+oder führe alternativ diesen Befehl vom Stammverzeichnis aus:
+
+```shell
+pnpm nx serve-static docs-app
+```
+
+## Einreichen von Pull-Requests
+
+**Bitte befolge diese grundlegenden Schritte, um die Überprüfung von Pull-Anfragen zu vereinfachen. Wenn du das nicht tust, wirst du wahrscheinlich trotzdem darum gebeten.**
+
+- Bitte rebase deinen Branch gegen den aktuellen `beta` Branch.
+- Befolge die obigen `Setup`-Schritte, um sicherzustellen, dass die Entwicklungsabhängigkeiten aktuell sind.
+- Bitte stelle sicher, dass die Testsuite erfolgreich ist, bevor du einen PR einreichst.
+- Wenn neue Funktionen hinzugefügt wurden, **bitte** fügen Tests ein, die das Verhalten dieser Funktionen überprüfen.
+- Verweisen Sie auf mögliche [Issues] (https://github.com/analogjs/analog/issues) im PR-Kommentar.
+- PRs können mehrere Commits enthalten. Bitte behalte jedoch den Inhalt aller Commits im Zusammenhang. Erstelle separate PRs für unzusammenhängende Änderungen.
+
+### Richtlinien für Pull Request-Titel
+
+Dadurch wird der Commit sowohl auf GitHub als auch in verschiedenen Git-Tools leichter zu lesen.
+
+Beispiele: (noch mehr [Beispiele](https://github.com/analogjs/analog/commits/beta))
+
+```
+feat(content): update prismjs to latest version
+```
+
+```
+fix(content): fix error when rendering markdown
+```
+
+### Typ
+
+Muss einer der folgenden sein:
+
+- **build**: Änderungen, die das Build-System oder externe Abhängigkeiten betreffen (Beispielbereiche: gulp, broccoli, npm)
+- **ci**: Änderungen an unseren CI-Konfigurationsdateien und Skripten (Beispielbereiche: Travis, Circle, BrowserStack, SauceLabs)
+- **docs**: Nur Dokumentation ändert sich
+- **feat**: Eine neue Funktion
+- **fix**: Eine Fehlerbehebung
+- **perf**: Eine Codeänderung, die die Leistung verbessert
+- **refactor**: Eine Codeänderung, die weder einen Fehler behebt noch eine Funktion hinzufügt
+- **style**: Änderungen, die den Sinn des Codes nicht beeinträchtigen (Leerzeichen, Formatierung, fehlende Semikolons usw.)
+- **test**: Hinzufügen fehlender Tests oder Korrigieren vorhandener Tests
+
+### Bereich
+
+Der Bereich sollte der Name des betroffenen npm-Pakets sein (so wie es die Person sieht, die den aus den Commit-Meldungen generierte Changelog liest).
+
+Im Folgenden findest du eine Liste der derzeit unterstützten Bereiche:
+
+- **astro-angular**
+- **content**
+- **content-plugin**
+- **create-analog**
+- **nx-plugin**
+- **platform**
+- **router**
+- **trpc**
+- **vite-plugin-angular**
+- **vite-plugin-nitro**
+- **vitest-angular**
+
+### Einschneidende Veränderungen
+
+Falls einschneidende Änderungen vorgenommen werden, sollten diese im Text des Pull Requests erläutert werden.
+
+Beispiel:
+
+```
+feat(scope): commit message
+
+BREAKING CHANGES:
+
+Describe breaking changes here
+
+BEFORE:
+
+Previous code example here
+
+AFTER:
+
+New code example here
+```
+
+## Einreichen von Fehlerberichten
+
+- Durchsuche die Issues, um festzustellen, ob ein früheres Issue bereits gemeldet und/oder behoben wurde.
+- Stellen eine _kleine_ Reproduktion über ein [StackBlitz-Projekt] (https://analogjs.org/new) oder ein GitHub-Repository bereit.
+- Bitte geben den/die betroffenen Browser und das/die betroffene(n) Betriebssystem(e) an.
+- Bitte geben unbedingt an, welche Version von Angular, Node und Paketmanager (npm, pnpm, yarn) verwendet wird.
+
+## Neue Funktionen einreichen
+
+- Wir legen Wert darauf, die API-Oberfläche klein und übersichtlich zu halten, was sich auf die Akzeptanz neuer Funktionen auswirkt.
+- Reichen eine Anfrage mit dem Präfix `Feature:` mit der Feature-Anfrage ein. Verwenden den Präfix `RFC:` für ein großes Feature mit größeren Auswirkungen auf die Codebasis.
+- Die Funktion wird diskutiert und geprüft.
+- Nachdem der PR eingereicht, geprüft und genehmigt wurde, wird er zusammengeführt.
+
+## Fragen und Anfragen an den Support
+
+Fragen und Supportanfragen sollten nicht als Probleme eröffnet werden, sondern auf folgende Weise behandelt werden:
+
+- Starte eine neue [Q&A Diskussion](https://github.com/analogjs/analog/discussions/new?category=q-a) auf GitHub.
+- Starte ein neues Thema im Forum `#help` auf dem [Discord-Server](https://chat.analogjs.org/)

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/testing/overview.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/testing/overview.md
@@ -1,0 +1,68 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Tests durchführen
+
+Analog unterstützt [Vitest] (https://vitest.dev) zur Durchführung von Unit-Tests.
+
+## Vitest Features
+
+Vitest unterstützt viele Funktionen:
+
+- Eine Jest-kompatible API.
+- Unterstützt Vites Konfiguration, Transformationen, Resolver und Plugins.
+- Smart & Instant Watch Modus.
+- TypeScript-Unterstützung.
+- Jest-kompatible Snapshots.
+- jsdom für DOM Mocking.
+- In-Source-Tests.
+- Und mehr ...
+
+## Durchführung von Unit-Tests
+
+Um Unit-Tests durchzuführen, verwende den Befehl `test`:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm run test
+```
+
+  </TabItem>
+
+  <TabItem label="Yarn" value="yarn">
+
+```shell
+yarn test
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm run test
+```
+
+  </TabItem>
+</Tabs>
+
+Es kann auch [Vitest](/docs/features/testing/vitest) zu einem bestehenden Projekt hinzufügt werden.
+
+## Bekannte Einschränkungen
+
+- Nur Globalen sind mit Zone.js gepatcht. Das bedeutet, dass wenn `it`, `describe` etc. direkt aus `vitest` importiert wird, kann `fakeAsync` nicht ausgeführt werden. Verwende stattdessen die Funktionen (`it`, `describe` etc.) so, wie es in Jest/Jasmine getan wird - ohne Import dieser Funktionen in der Testdatei.
+- `vmThreads` wird verwendet. Dies kann zu potentiellen Speicherlecks führen und wird standardmäßig verwendet, um eine Umgebung zu schaffen, die näher an Jest mit JSDOM ist. Weitere Details können unter [hier](https://github.com/vitest-dev/vitest/issues/4685) nachgelesen werden.
+
+Um das zu ändern, passe die `vite.config.mts` an.
+
+```typescript
+export default defineConfig(({ mode }) => {
+  return {
+    test: {
+      pool: 'threads', // add this property
+    },
+  };
+});
+```

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/testing/vitest.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/testing/vitest.md
@@ -1,0 +1,368 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Hinzufügen von Vitest zu einem bestehenden Projekt
+
+[Vitest](https://vitest.dev) kann mit wenigen Schritten zu bestehenden Angular-Workspaces hinzugefügt werden.
+
+## Verwendung eines Schemas/Generators
+
+Vitest kann mit Hilfe eines Schemas/Generators für Angular CLI- oder Nx-Workspaces installiert und eingerichtet werden.
+
+Installiere zunächst das Paket `@analogjs/platform`:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install @analogjs/platform --save-dev
+```
+
+  </TabItem>
+
+  <TabItem label="Yarn" value="yarn">
+
+```shell
+yarn add @analogjs/platform --dev
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install -w @analogjs/platform --save-dev
+```
+
+  </TabItem>
+</Tabs>
+
+Führe anschließend das Schema aus, um die Vite-Konfiguration und die Testkonfigurationsdateien einzurichten und die Testkonfiguration zu aktualisieren.
+
+```shell
+ng g @analogjs/platform:setup-vitest --project [your-project-name]
+```
+
+Gehe dann zu [Tests durchführen](#tests-durchführen)
+
+## Manuelle Installation
+
+Um Vitest manuell hinzuzufügen, installiere die erforderlichen Pakete:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install @analogjs/vite-plugin-angular @analogjs/vitest-angular jsdom --save-dev
+```
+
+  </TabItem>
+
+  <TabItem label="Yarn" value="yarn">
+
+```shell
+yarn add @analogjs/vite-plugin-angular @analogjs/vitest-angular jsdom --dev
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install -w @analogjs/vite-plugin-angular @analogjs/vitest-angular jsdom --save-dev
+```
+
+  </TabItem>
+</Tabs>
+
+## Einrichtung für die Durchführung von Tests für Node
+
+Um Vitest einzurichten, erstelle eine `vite.config.ts` im Stammverzeichnis des Projekts:
+
+```ts
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+import angular from '@analogjs/vite-plugin-angular';
+
+export default defineConfig(({ mode }) => ({
+  plugins: [angular()],
+  test: {
+    globals: true,
+    setupFiles: ['src/test-setup.ts'],
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+  },
+  define: {
+    'import.meta.vitest': mode !== 'production',
+  },
+}));
+```
+
+Als nächstes wird eine Datei `src/test-setup.ts` definiert, um das `TestBed` einzurichten:
+
+```ts
+import '@analogjs/vitest-angular/setup-zone';
+
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+import { getTestBed } from '@angular/core/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+```
+
+Als Nächstes aktualisiere das Ziel `test` in der Datei `angular.json`, um den Builder `@analogjs/vitest-angular:test` zu verwenden:
+
+```json
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "your-project": {
+      "projectType": "application",
+      "architect": {
+        "build": ...,
+        "serve": ...,
+        "extract-i18n": ...,
+        "test": {
+          "builder": "@analogjs/vitest-angular:test"
+        }
+      }
+    }
+  }
+}
+```
+
+> Du kannst auch ein neues Ziel hinzufügen und es `vitest` nennen, um es neben deinem `test`-Ziel auszuführen.
+
+Schließlich füge die Datei `src/test-setup.ts` zum Array `files` in der Datei `tsconfig.spec.json` im Stammverzeichnis des Projekts hinzu, setze das `target` auf `es2016` und aktualisiere die `types`.
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "target": "es2016",
+    "types": ["vitest/globals", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}
+```
+
+Gehe dann zu [Tests durchführen](#tests-durchführen)
+
+## Einrichtung für die Ausführung von Tests im Browser
+
+Wenn die Tests lieber in einem Browser durchgeführt werden sollen, bietet Vitest auch experimentelle Unterstützung für Browsertests.
+
+Führe zunächst die Schritte für die [Einrichtung für die Durchführung von Tests für Node](#einrichtung-für-die-durchführung-von-tests-für-node) aus.
+
+Installiere dann die erforderlichen Pakete für die Ausführung von Tests im Browser:
+
+<Tabs groupId="package-manager-browser">
+  <TabItem value="npm">
+
+```shell
+npm install @vitest/browser playwright --save-dev
+```
+
+  </TabItem>
+
+  <TabItem label="Yarn" value="yarn">
+
+```shell
+yarn add @vitest/browser playwright --dev
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install -w @vitest/browser playwright
+```
+
+  </TabItem>
+</Tabs>
+
+Aktualisiere das Objekt `test` in der Datei `vite.config.ts`.
+
+- Entferne die Eigenschaft `environment: 'jsdom'`.
+- Füge eine `browser`-Konfiguration für Vitest hinzu.
+
+```ts
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+import angular from '@analogjs/vite-plugin-angular';
+
+export default defineConfig(({ mode }) => ({
+  plugins: [angular()],
+  test: {
+    globals: true,
+    setupFiles: ['src/test-setup.ts'],
+    // environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    // Vitest browser config
+    browser: {
+      enabled: true,
+      name: 'chromium',
+      headless: false, // set to true in CI
+      provider: 'playwright',
+    },
+  },
+  define: {
+    'import.meta.vitest': mode !== 'production',
+  },
+}));
+```
+
+## Tests durchführen
+
+Um Unit-Tests durchzuführen, verwende den Befehl `test`:
+
+<Tabs groupId="package-manager-node">
+  <TabItem value="npm">
+
+```shell
+npm run test
+```
+
+  </TabItem>
+
+  <TabItem label="Yarn" value="yarn">
+
+```shell
+yarn test
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm test
+```
+
+  </TabItem>
+</Tabs>
+
+## Snapshot-Tests
+
+Für Snapshot-Tests kann `toMatchSnapshot` aus der API `expect` verwendet werden.
+
+Im Folgenden findest du ein kleines Beispiel für die Erstellung eines Snapshot-Tests:
+
+```ts
+// card.component.spec.ts
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardComponent } from './card.component';
+
+describe('CardComponent', () => {
+  let fixture: ComponentFixture<CardComponent>;
+  let component: CardComponent;
+
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [CardComponent],
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the app', () => {
+    expect(fixture).toMatchSnapshot();
+  });
+});
+```
+
+Nachdem der Test ausgeführ wurde, wird im Ordner `__snapshots__` eine Datei `card.component.spec.ts.snap` mit dem folgenden Inhalt erstellt:
+
+```ts
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CardComponent > should create the app 1`] = `
+  <component-code>
+`;
+```
+
+Die erstellten Snapshots sollten überprüft und zur Versionskontrolle hinzugefügt werden.
+
+## Verwendung von TypeScript-Konfigurationspfad-Aliasen
+
+Wenn `paths` in der `tsconfig.json` verwendet werden, kann die Unterstützung für diese Aliase in der `vite.config.ts` hinzufügt werden.
+
+### Mit Angular-CLI
+
+Installiere zunächst das Paket `vite-tsconfig-paths`.
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install vite-tsconfig-paths --save-dev
+```
+
+  </TabItem>
+
+  <TabItem label="Yarn" value="yarn">
+
+```shell
+yarn add vite-tsconfig-paths --dev
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install -w vite-tsconfig-paths --save-dev
+```
+
+  </TabItem>
+</Tabs>
+
+Als Nächstes füge das Plugin zum Array `plugins` in der Datei `vite.config.ts` hinzu, wobei `root` als relativer Pfad zum Stamm des Projekts festgelegt wird.
+
+```ts
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+import angular from '@analogjs/vite-plugin-angular';
+import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig(({ mode }) => ({
+  plugins: [angular(), viteTsConfigPaths()],
+}));
+```
+
+### Mit Nx
+
+Für Nx-Arbeitsbereiche importiere und verwende das Plugin `nxViteTsPaths` aus dem Paket `@nx/vite`.
+
+```ts
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+import angular from '@analogjs/vite-plugin-angular';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig(({ mode }) => ({
+  plugins: [angular(), nxViteTsPaths()],
+}));
+```

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/guides/compatibility.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/guides/compatibility.md
@@ -1,0 +1,20 @@
+# Kompatibilität der Versionen
+
+Analog ist mit mehreren Versionen von Angular, Nx und Vite kompatibel.
+
+Es wird immer empfohlen, die neueste Version von Analog zu verwenden, da laufend Fehlerbehebungen und neue Funktionen hinzugefügt werden.
+
+Nachfolgend ist eine Referenztabelle, die die Versionen von Nx und Angular mit der entsprechenden Analog-Version abgleicht.
+
+Die Tabelle zeigt die Mindestversion von Nx, die unterstützte Angular-Version und die minimal unterstützte Version von Analog und Vite.
+
+| Nx Version _(min)_ | Angular Version | Analog Version | Vite Version |
+| ------------------ | --------------- | -------------- | ------------ |
+| 18.0.0             | ^17.0.0         | **latest**     | ^5.0.0       |
+| 17.0.0             | ^17.0.0         | **latest**     | ^5.0.0       |
+| 16.1.0             | ^16.1.0         | **latest**     | ^5.0.0       |
+| 16.0.0             | ~15.2.X         | **latest**     | ^5.0.0       |
+| 15.2.0             | ~15.2.X         | **latest**     | ^5.0.0       |
+
+Zusätzlich kann der [Leitfaden von Nx](https://nx.dev/packages/angular/documents/angular-nx-version-matrix) geprüft werden
+um mehr über die Kompatibilität von Nx und Angular zu erfahren.

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/guides/migrating.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/guides/migrating.md
@@ -1,0 +1,72 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Migrieren einer Angular-Anwendung zu Analog
+
+Eine bestehende Angular Single Page Application kann mit Hilfe eines Schemas/Generators für Angular CLI oder Nx Workspaces für die Verwendung von Analog konfiguriert werden.
+
+> Analog ist kompatibel mit Angular v15 und höher.
+
+## Verwendung eines Schemas/Generators
+
+Installiere zunächst das Paket `@analogjs/platform`:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install @analogjs/platform --save-dev
+```
+
+  </TabItem>
+
+  <TabItem label="Yarn" value="yarn">
+
+```shell
+yarn add @analogjs/platform --dev
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install -w @analogjs/platform
+```
+
+  </TabItem>
+</Tabs>
+
+Führe anschließend den Befehl aus, um die Vite-Konfiguration einzurichten, aktualisiere die Build/Serve-Ziele in der Projektkonfiguration, verschieben die erforderlichen Dateien und richte optional Vitest für Unit-Tests ein.
+
+```shell
+npx ng generate @analogjs/platform:init --project [your-project-name]
+```
+
+Für Nx-Projekte:
+
+```shell
+npx nx generate @analogjs/platform:init --project [your-project-name]
+```
+
+## Aktualisierung der globalen Stile und Skripte
+
+Wenn globale Skripte oder Stile in der `angular.json` konfiguriert sind, verschiebe diese in den `head`-Tag in der `index.html`.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>My Analog app</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <app-root></app-root>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>
+```

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/integrations/angular-material/index.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/integrations/angular-material/index.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 3
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Angular Material Integration mit Analog
+
+Dieses Tutorial führt dich durch den Prozess der Integration der Angular Material-Bibliothek in deine Analog-Anwendung.
+
+## Schritt 1: Installieren der Angular Material-Bibliothek
+
+Um zu beginnen, müssen die Pakete `@angular/cdk` und `@angular/material` installiert werden. Je nach bevorzugten Paketmanager führen eine der folgenden Befehle aus:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install @angular/cdk @angular/material
+```
+
+  </TabItem>
+
+  <TabItem label="yarn" value="yarn">
+
+```shell
+yarn add @angular/cdk @angular/material
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install @angular/cdk @angular/material
+```
+
+  </TabItem>
+</Tabs>
+
+## Schritt 2: Konfigurieren der Angular Material-Bibliothek
+
+1. Benennen die Datei `styles.css` in `styles.scss` um.
+2. Setze die Eigenschaft `inlineStylesExtension` in der Datei `vite.config.ts` auf `'scss`:
+
+```ts
+export default defineConfig(({ mode }) => {
+  return {
+    plugins: [
+      analog({
+        vite: {
+          inlineStylesExtension: 'scss',
+        },
+      }),
+    ],
+  };
+});
+```
+
+3. Aktualisiere die Datei `index.html`, um auf die SCSS-Datei zu verweisen:
+
+```html
+<head>
+  <!-- other headers -->
+  <link rel="stylesheet" href="/src/styles.scss" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    rel="stylesheet"
+  />
+</head>
+<body class="mat-typography">
+  <!-- content -->
+</body>
+```
+
+4. Aktualisiere die Datei `styles.scss`, um die Angular-Material-Stile zu importieren und das benutzerdefinierte Thema zu definieren:
+
+```scss
+@use '@angular/material' as mat;
+
+$theme: mat.define-theme(
+  (
+    color: (
+      theme-type: light,
+      primary: mat.$azure-palette,
+      tertiary: mat.$blue-palette,
+    ),
+  )
+);
+
+body {
+  @include mat.all-component-themes($theme);
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
+  margin: 0;
+  padding: 30px;
+  height: 100%;
+}
+
+html {
+  height: 100%;
+}
+
+@include mat.core();
+@include mat.color-variants-backwards-compatibility($theme);
+```
+
+## Optionaler Schritt: Konfigurieren von Animationen
+
+Wenn du bei Bedarf Animationen aktivieren oder deaktivieren möchtest, führen die entsprechenden Schritte aus:
+
+1. Öffne die Datei `app.config.ts` und fügen `provideAnimations()` als provider hinzu
+
+```ts
+providers: [
+  // other providers
+  provideAnimations(),
+],
+```
+
+2. Öffne die Datei `app.config.server.ts` und füge `provideNoopAnimations()` als provider hinzu
+
+```ts
+providers: [
+  // other providers
+  provideNoopAnimations(),
+],
+```
+
+Mit diesen Schritten sind Animationen so konfiguriert, dass sie auf dem Client aktiviert und auf dem Server in der Analog-Anwendung deaktiviert sind.
+
+Das war's! Du hast die Angular Material-Bibliothek für die Analog-Anwendung erfolgreich installiert und konfiguriert. Du kannst nun damit beginnen, die Komponenten und Styles von Angular Material im Projekt zu verwenden.
+
+Weitere Informationen zum Theming mit Angular Material findest du in dem [Angular Material Theming Guide](https://material.angular.io/guide/theming).

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/integrations/ionic/index.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/integrations/ionic/index.md
@@ -1,0 +1,422 @@
+---
+sidebar_position: 4
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Ionic Framework Integration mit Analog
+
+Dieses Tutorial führt durch den Prozess der Integration von Ionic Framework in eine Analog-Anwendung, damit die Leistungsfähigkeit der iOS- und Android-Komponenten von Ionic in einer Anwendungen genutzt werden kann.
+
+## Schritt 1: Ionic Framework installieren
+
+Zu Beginn muss das Paket `@ionic/angular@latest` installiert werden. Je nach bevorzugten Paketmanager führe einen der folgenden Befehle aus:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install @ionic/angular@latest
+```
+
+  </TabItem>
+
+  <TabItem label="yarn" value="yarn">
+
+```shell
+yarn add @ionic/angular@latest
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install @ionic/angular@latest
+```
+
+  </TabItem>
+</Tabs>
+
+### Optional: Ionic Angular Toolkit für Schemata installieren
+
+Ionic bietet auch eine Reihe von Schemata, die helfen können, Komponenten zu erstellen, die der Ionic-Struktur folgen. Du kannst diese hinzufügen, indem du das Paket `@ionic/angular-toolkit` zu den devDependencies installierst
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install -D @ionic/angular-toolkit
+```
+
+  </TabItem>
+
+  <TabItem label="yarn" value="yarn">
+
+```shell
+yarn add -D @ionic/angular-toolkit
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install -D @ionic/angular-toolkit
+```
+
+  </TabItem>
+</Tabs>
+
+### Optional: Installieren von Ionicons: Ionic Bibliothek mit benutzerdefinierten Symbolen
+
+Ionic bietet auch eine Icon-Bibliothek, die mehr als 500 Icons für die meisten Bedürfnisse einer mobilen Anwendungen enthält. Diese können installiert werden, indem das Paket `ionicons` zu dem Projekt hinzugefügt wird:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install ionicons
+```
+
+  </TabItem>
+
+  <TabItem label="yarn" value="yarn">
+
+```shell
+yarn add ionicons
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install ionicons
+```
+
+  </TabItem>
+</Tabs>
+
+## Schritt 2: Konfigurieren von Ionic Framework in der Anwendung
+
+1. Aktualisiere die `vite.config.ts`-Datei, um Ionic-Pakete in den **SSR**-Prozess einzubeziehen, indem es zum Array `noExternal` hinzugefügt wird. ionicons ist nur erforderlich, wenn das ionicons-Paket installiert wurde. Wenn du Vitest verwendest, binde das @ionic/angular-Paket ein, damit Vitest dieses Paket korrekt für Vitest bauen kann.
+
+```ts
+export default defineConfig(({ mode }) => {
+  return {
+    // ...
+
+    // add these lines
+    ssr: {
+      noExternal: ['@ionic/**', '@stencil/**', 'ionicons'],
+    },
+
+    // ...
+
+    // add these lines if you use Vitest
+    test: {
+      server: {
+        deps: {
+          inline: ['@ionic/angular'],
+        },
+      },
+    },
+  };
+});
+```
+
+2. Füge in der `app.config.ts` die Methode `provideIonicAngular` und den Provider `IonicRouteStrategy` hinzu.
+
+```ts
+import { RouteReuseStrategy, provideRouter } from '@angular/router';
+import {
+  IonicRouteStrategy,
+  provideIonicAngular,
+} from '@ionic/angular/standalone';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideFileRouter(),
+    provideClientHydration(),
+    provideHttpClient(withFetch()),
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
+    provideIonicAngular(),
+  ],
+};
+```
+
+3. Aktualisiere die `app.component.ts`-Datei, um in der Vorlage die erforderlichen Ionic-Tags zu setzen. Du solltest dir die [Vorsichtsmaßnahme für serverseitiges Rendern](#vorsichtsmaßnahme-für-serverseitiges-Rendern) ansehen, da [Ionic noch keine Client-Hydrierung unterstützt](https://github.com/ionic-team/ionic-framework/issues/28625#issuecomment-1843919548)
+
+```ts
+import { Component } from '@angular/core';
+import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'demo-root',
+  standalone: true,
+  imports: [IonApp, IonRouterOutlet],
+  template: `<ion-app><ion-router-outlet></ion-router-outlet></ion-app>`,
+})
+export class AppComponent {}
+```
+
+4. Benennen Sie die Datei `styles.css` in `styles.scss` um.
+5. Setze die Eigenschaft `inlineStylesExtension` in der Datei `vite.config.ts` auf `'scss`:
+
+```ts
+export default defineConfig(({ mode }) => {
+  return {
+    plugins: [
+      analog({
+        vite: {
+          inlineStylesExtension: 'scss',
+        },
+      }),
+    ],
+  };
+});
+```
+
+6. Aktualisiere die Datei `index.html`, um auf die SCSS-Datei zu verweisen:
+
+```html
+<head>
+  <!-- other headers -->
+  <link rel="stylesheet" href="/src/styles.scss" />
+</head>
+<body>
+  <!-- content -->
+</body>
+```
+
+7. Aktualisiere die Datei `styles.scss`, um die Ionic-Styles zu importieren und ein [benutzerdefiniertes Theme](https://ionicframework.com/docs/theming/color-generator) zu definieren:
+
+```scss
+/* Core CSS required for Ionic components to work properly */
+@import '@ionic/angular/css/core.css';
+
+/* Basic CSS for apps built with Ionic */
+@import '@ionic/angular/css/normalize.css';
+@import '@ionic/angular/css/structure.css';
+@import '@ionic/angular/css/typography.css';
+@import '@ionic/angular/css/display.css';
+
+/* Optional CSS utils that can be commented out */
+@import '@ionic/angular/css/padding.css';
+@import '@ionic/angular/css/float-elements.css';
+@import '@ionic/angular/css/text-alignment.css';
+@import '@ionic/angular/css/text-transformation.css';
+@import '@ionic/angular/css/flex-utils.css';
+
+/**
+ * Ionic Dark Mode
+ * -----------------------------------------------------
+ * For more info, please see:
+ * https://ionicframework.com/docs/theming/dark-mode
+ */
+
+/* @import "@ionic/angular/css/palettes/dark.always.css"; */
+/* @import "@ionic/angular/css/palettes/dark.class.css"; */
+@import '@ionic/angular/css/palettes/dark.system.css';
+```
+
+### Vorsichtsmaßnahme für serverseitiges Rendern
+
+Das Ionic Framework [unterstützt nicht Angulars neue Client Hydration](https://github.com/ionic-team/ionic-framework/issues/28625#issuecomment-1843919548), wie Angular [unterstützt es nicht SSR mit Webkomponenten](https://github.com/angular/angular/issues/52275), und wenn sie unterstützt werden, muss an den Stencil-Komponenten gearbeitet werden, um sie zu aktivieren. Im Moment gibt es also drei Möglichkeiten, dies zu handhaben:
+
+1. Entfernen `provideClientHydration()` aus den `app.config.ts` Providern.
+
+- Dies entfernt den neuen Client-Hydrierungsmechanismus von Angular und kehrt zum vorherigen Mechanismus zurück, der ein Flackern verursacht, wenn das DOM vom Client neu gerendert wird.
+
+```ts
+import { RouteReuseStrategy, provideRouter } from '@angular/router';
+import {
+  IonicRouteStrategy,
+  provideIonicAngular,
+} from '@ionic/angular/standalone';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideFileRouter(),
+    //provideClientHydration(), // remove this.
+    provideHttpClient(withFetch()),
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
+    provideIonicAngular(),
+  ],
+};
+```
+
+2. Hinzufügen des Attributs `ngSkipHydration` zum Tag `ion-app`.
+
+- Dadurch wird der Client-Hydrierungsmechanismus für das Element `ion-app` und seine Kinder deaktiviert, aber die Client-Hydrierung wird weiterhin für andere Elemente verwendet. Dies wird auch ein Flackern auf der Seite für die Ionic-Komponenten verursachen. Dies ist für andere Elemente/Komponenten nicht sehr hilfreich, da bei Ionic-Apps alle Ionic-Komponenten innerhalb des Tags `ion-app` existieren.
+
+  ```ts
+  import { Component } from '@angular/core';
+  import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+
+  @Component({
+    selector: 'demo-root',
+    standalone: true,
+    imports: [IonApp, IonRouterOutlet],
+    template: `
+      <ion-app ngSkipHydration>
+        <ion-router-outlet></ion-router-outlet>
+      </ion-app>
+    `,
+  })
+  export class AppComponent {}
+  ```
+
+3. SSR vollständig deaktivieren
+
+- Deaktiviere SSR in der Datei `vite.config.ts`. Dadurch **wird das Flackern beseitigt**, aber du verlierst alle Vorteile von SSR in der Anwendung.
+
+  ```ts
+  plugins: [
+    analog({
+      ssr: false,
+    }),
+  ],
+  ```
+
+Du **musst** eine der vorherigen Optionen wählen, da die Nichtkonfiguration dazu führt, dass die Anwendung zur Laufzeit Fehler wie folgende auslöst:
+
+```js
+ERROR Error: NG0500: During hydration Angular expected <ion-toolbar> but found a comment node.
+
+Angular expected this DOM:
+
+  <ion-toolbar color="secondary">…</ion-toolbar>  <-- AT THIS LOCATION
+  …
+
+
+Actual DOM is:
+
+<ion-header _ngcontent-ng-c1775393043="">
+  <!--  -->  <-- AT THIS LOCATION
+  …
+</ion-header>
+
+Note: attributes are only displayed to better represent the DOM but have no effect on hydration mismatches.
+
+To fix this problem:
+  * check the "AppComponent" component for hydration-related issues
+  * check to see if your template has valid HTML structure
+  * or skip hydration by adding the `ngSkipHydration` attribute to its host node in a template
+```
+
+## Schritt 3: Hinzufügen von Capacitor (optional)
+
+Mit Capacitor können native Webanwendungen erstellt werden, die problemlos auf iOS- und Android-Geräten ausgeführt werden können.
+
+### Schritt 3.1 Installieren und konfigurieren der Capacitor-App
+
+1. Zuerst müssen die Pakete `@capacitor/core` und `@capacitor/cli` installiert werden. Abhängig vom bevorzugten Paketmanager, führen einen der folgenden Befehle aus:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install @capacitor/core
+npm install -D @capacitor/cli
+```
+
+  </TabItem>
+
+  <TabItem label="yarn" value="yarn">
+
+```shell
+yarn add @capacitor/core
+yarn add -D @capacitor/cli
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install @capacitor/core
+pnpm install -D @capacitor/cli
+```
+
+  </TabItem>
+</Tabs>
+
+2. Dann muss das Capacitor-Projekt mit dem folgenden Befehl initialisiert werden. Die CLI wird einige Fragen stellen, beginnend mit dem Namen der Anwendung und der Paket-ID, die für die Anwendung verwendet werden soll.
+
+```shell
+npx cap init
+```
+
+3. Aktualisiere die Eigenschaft `webDir` der Datei `capacitor.config.ts` so, dass sie auf den dist-Ordner des Analog Builds zeigt
+
+```ts
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.ionic.capacitor',
+  appName: 'ionic-capacitor',
+  webDir: 'dist/analog/public',
+};
+
+export default config;
+```
+
+### Schritt 3.2 Erstellen des Android- und iOS-Projektes
+
+1. Installiere die Pakete `@capacitor/android` und/oder `@capacitor/ios` basierend auf den Plattformen, die unterstützt werden sollen.
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install @capacitor/android
+npm install @capacitor/ios
+```
+
+  </TabItem>
+
+  <TabItem label="yarn" value="yarn">
+
+```shell
+yarn add @capacitor/android
+yarn add @capacitor/ios
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install @capacitor/android
+pnpm install @capacitor/ios
+```
+
+  </TabItem>
+</Tabs>
+
+2. Füge das Android- und/oder iOS-Projekt zu der App hinzu
+
+```shell
+npx cap add android
+npx cap add ios
+```
+
+3. Synchronisiere die Projektdateien mit den installierten Plattformen
+
+```shell
+npx cap sync
+```
+
+4. Die App nun mit den folgenden Befehlen ausgeführt werden
+
+```shell
+npx cap run android
+npx cap run ios
+```
+
+---
+
+Das war's! Du hast das Ionic Framework mit (oder ohne) Capacitor für deine Analog-Anwendung erfolgreich installiert und konfiguriert!

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/integrations/nx/index.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/integrations/nx/index.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 2
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Nx
+
+## Übersicht
+
+[Nx](https://nx.dev) ist ein intelligentes, schnelles, erweiterbares Build-System mit erstklassiger Monorepo-Unterstützung und leistungsfähigen Integrationen.
+
+Analog bietet die Integration mit Nx-Monorepos und -Arbeitsbereichen durch eine Arbeitsbereichsvoreinstellung und einen Anwendungsgenerator. Eine Analog-Anwendung kann als eigenständiges Projekt erstellt oder zu einem bestehenden Nx-Arbeitsbereich hinzugefügt werden.
+
+## Erstellen eines eigenständigen Nx-Projekts
+
+Um ein eigenständiges Nx-Projekt zu erstellen, verwende den Befehl `create-nx-workspace` mit der Voreinstellung `@analogjs/platform`.
+
+Erstellen eines neuen Nx-Arbeitsbereich mit einer vorkonfigurierten Analog-Anwendung:
+
+```shell
+npx create-nx-workspace@latest --preset=@analogjs/platform
+```
+
+Bei der Analog Voreinstellung wirst du aufgefordert, den Namen Ihrer Anwendung anzugeben. In diesem Beispiel verwenden wir einfach `analog-app`.
+Außerdem wirst du gefragt, ob du [TailwindCSS] (https://tailwindcss.com) und [tRPC] (https://trpc.io) in dein neues Projekt aufnehmen möchtest.
+Wenn du dich dafür entscheidest, werden alle erforderlichen Abhängigkeiten automatisch installiert,
+und alle notwendigen Konfigurationen werden hinzugefügt.
+
+### Bereitstellen der Anwendung
+
+Um den Entwicklungsserver für Ihre Anwendung zu starten, führe den Befehl `nx serve` aus.
+
+```shell
+npx nx serve analog-app
+```
+
+Navigiere in deinem Browser zu `http://localhost:4200`, um die Anwendung laufen zu sehen.
+
+### Erstellung der Anwendung
+
+Um die Anwendung für die Veröffentlichung zu erstellen, führe folgendes aus:
+
+```shell
+npx nx build analog-app
+```
+
+### Artefakte bauen
+
+Die Client-Build-Artefakte befinden sich im Ordner dist deines Nx-Arbeitsbereichs.
+
+Im Layout des standalone Arbeitsbereichs befinden sich die Client-Artefakte der `analog-app` im Verzeichnis `dist/analog/public`.
+Der Server für die API/SSR-Build-Artefakte befinden sich im Verzeichnis `dist/analog/server`.
+
+## Hinzufügen zu einem bestehenden Nx-Arbeitsbereich
+
+Eine Analog Anwendung kann innerhalb eines bestehenden Nx-Arbeitsbereichs erstellt werden. Um eine Anwendung zu generieren:
+
+Installiere zunächst das Paket `@analogjs/platform`:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install @analogjs/platform --save-dev
+```
+
+  </TabItem>
+
+  <TabItem label="Yarn" value="yarn">
+
+```shell
+yarn add @analogjs/platform --dev
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install @analogjs/platform --save-dev
+```
+
+  </TabItem>
+</Tabs>
+
+Als nächstes verwende den Anwendungsgenerator, um eine neue Anwendung zu erstellen:
+
+```shell
+npx nx g @analogjs/platform:app analog-app
+```

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/packages/astro-angular/overview.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/packages/astro-angular/overview.md
@@ -1,0 +1,344 @@
+---
+title: ''
+---
+
+# @analogjs/astro-angular
+
+[Astro](https://astro.build) ist ein modernes Web-Framework, das für die Erstellung schneller, inhaltsorientierter Websites entwickelt wurde und mit allen wichtigen Frontend-Frameworks kompatibel ist. Obwohl es in erster Linie ein Werkzeug für die statische Website-Generierung (SSG) ist, kann es auch dynamische Komponenten, sogenannte "islands", integrieren, die eine "partial hydration" unterstützen.
+
+Dieses Paket ermöglicht das Rendern von [Angular](https://angular.dev) Komponenten als "islands" in Astro.
+
+## Einrichtung
+
+### Astro CLI verwenden
+
+Verwende den Befehl `astro add`, um die Integration zu installieren
+
+Mit npm:
+
+```sh
+npx astro add @analogjs/astro-angular
+```
+
+Mit pnpm:
+
+```sh
+pnpm astro add @analogjs/astro-angular
+```
+
+Mit yarn:
+
+```sh
+yarn astro add @analogjs/astro-angular
+```
+
+Dieser Befehl:
+
+- Installiert das Paket `@analogjs/astro-angular`.
+- Fügt die Integration von `@analogjs/astro-angular` zur Datei `astro.config.mjs` hinzu.
+- Installiert die notwendigen Abhängigkeiten zum Rendern von Angular-Komponenten auf dem Server und dem Client sowie allgemeine Angular-Abhängigkeiten, wie `@angular/common`.
+
+### Einrichten der TypeScript-Konfiguration
+
+Die Integration benötigt eine `tsconfig.app.json` im Stammverzeichnis des Projekts zur Kompilierung.
+
+Erstelle eine `tsconfig.app.json` im Stammverzeichnis des Projekts.
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "noEmit": false,
+    "target": "es2020",
+    "module": "es2020",
+    "lib": ["es2020", "dom"],
+    "skipLibCheck": true
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true,
+    "allowJs": false
+  },
+  "files": [],
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}
+```
+
+Gehe zu [Definieren einer Komponente](#definieren-einer-komponente), um eine Angular-Komponente hinzufügen zur Verwendung in einer Astro-Komponente einzurichten.
+
+## Manuelle Installation
+
+Die Integration kann auch manuell installiert werden
+
+### Installation der Astro-Integration
+
+```sh
+yarn add @analogjs/astro-angular
+```
+
+### Installation der notwendigen Angular-Abhängigkeiten
+
+```sh
+yarn add @angular-devkit/build-angular @angular/{animations,common,compiler-cli,compiler,core,language-service,forms,platform-browser,platform-browser-dynamic,platform-server} rxjs zone.js tslib
+```
+
+### Hinzufügen der Integration
+
+Füge die Integration in die Datei `astro.config.mjs` ein.
+
+```js
+import { defineConfig } from 'astro/config';
+import angular from '@analogjs/astro-angular';
+
+export default defineConfig({
+  integrations: [angular()],
+});
+```
+
+Weiter zu [Definieren einer Komponente](#definieren-einer-komponente)
+
+## Konfiguration
+
+### Vite Angular Plugin konfigurieren
+
+Geben Sie ein Optionsobjekt an, um das `@analogjs/vite-plugin-angular` zu konfigurieren, das dieses Plugin antreibt.
+
+```js
+import { defineConfig } from 'astro/config';
+import angular from '@analogjs/astro-angular';
+
+export default defineConfig({
+  integrations: [
+    angular({
+      vite: {
+        inlineStylesExtension: 'scss|sass|less',
+      },
+    }),
+  ],
+});
+```
+
+### Pakete für SSR-Kompatibilität umwandeln
+
+Um sicherzustellen, dass Angular-Bibliotheken während des SSR-Prozesses von Astro umgewandelt werden, füge diese dem Array `ssr.noExternal` in der Vite-Konfiguration hinzu.
+
+```js
+import { defineConfig } from 'astro/config';
+
+import angular from '@analogjs/astro-angular';
+
+export default defineConfig({
+  integrations: [angular()],
+  vite: {
+    ssr: {
+      // transform these packages during SSR. Globs supported
+      noExternal: ['@rx-angular/**'],
+    },
+  },
+});
+```
+
+## Definieren einer Komponente
+
+Die Astro-Angular-Integration unterstützt **nur** das Rendern von standalone Komponenten:
+
+```ts
+import { NgIf } from '@angular/common';
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-hello',
+  standalone: true,
+  imports: [NgIf],
+  template: `
+    <p>Hello from Angular!!</p>
+
+    <p *ngIf="show">{{ helpText }}</p>
+
+    <button (click)="toggle()">Toggle</button>
+  `,
+})
+export class HelloComponent {
+  @Input() helpText = 'help';
+
+  show = false;
+
+  toggle() {
+    this.show = !this.show;
+  }
+}
+```
+
+Füge die Angular-Komponente zur Vorlage der Astro-Komponente hinzu. Dadurch wird nur der HTML-Code der Angular-Komponente gerendert.
+
+```tsx
+---
+import { HelloComponent } from '../components/hello.component';
+
+const helpText = "Helping binding";
+---
+
+<HelloComponent />
+<HelloComponent helpText="Helping" />
+<HelloComponent helpText={helpText} />
+```
+
+Um die Komponente auf dem Client zu hydrieren, verwende eine der Astro-[Client-Direktiven](https://docs.astro.build/en/reference/directives-reference/#client-directives):
+
+```tsx
+---
+import { HelloComponent } from '../components/hello.component';
+---
+
+<HelloComponent client:visible />
+```
+
+Weitere Informationen über [Client Directives](https://docs.astro.build/en/reference/directives-reference/#client-directives) findest du in der Astro-Dokumentation.
+
+### Abhören der Komponentenausgänge
+
+Ausgaben, die von der Angular-Komponente ausgegeben werden können, werden als HTML-Ereignisse an die Astro-Insel weitergeleitet.
+Um diese Funktion zu aktivieren, füge eine Client-Direktive und eine eindeutige `[data-analog-id]`-Eigenschaft zu jeder Angular-Komponente hinzu:
+
+```tsx
+---
+import { HelloComponent } from '../components/hello.component';
+---
+
+<HelloComponent client:visible data-analog-id="hello-component-1" />
+```
+
+Dann höre auf das Ereignis in der Astro-Komponente mit der Funktion `addOutputListener`:
+
+```tsx
+---
+import { HelloComponent } from '../components/hello.component';
+---
+
+<HelloComponent client:visible data-analog-id="hello-component-1" />
+
+<script>
+  import { addOutputListener } from '@analogjs/astro-angular/utils';
+
+  addOutputListener('hello-component-1', 'outputName', (event) => {
+    console.log(event.detail);
+  });
+</script>
+```
+
+## Hinzufügen von Komponentenprovidern
+
+Zusätzliche Provider können zu einer Komponente für statisches Rendering und Client-Hydrierung hinzugefügt werden.
+
+Diese sind `renderProviders` bzw. `clientProviders`. Diese Provider sind als statische Arrays in der Komponenten Klasse definiert und werden registriert, wenn die Komponente gerendert wird, und auf dem Client hydriert.
+
+```ts
+import { Component, OnInit, inject } from '@angular/core';
+import { NgFor } from '@angular/common';
+import { provideHttpClient, HttpClient } from '@angular/common/http';
+
+interface Todo {
+  id: number;
+  title: string;
+  completed: boolean;
+}
+
+@Component({
+  selector: 'app-todos',
+  standalone: true,
+  imports: [NgFor],
+  template: `
+    <h2>Todos</h2>
+
+    <ul>
+      <li *ngFor="let todo of todos">
+        {{ todo.title }}
+      </li>
+    </ul>
+  `,
+})
+export class TodosComponent implements OnInit {
+  static clientProviders = [provideHttpClient()];
+  static renderProviders = [];
+
+  http = inject(HttpClient);
+  todos: Todo[] = [];
+
+  ngOnInit() {
+    this.http
+      .get<Todo[]>('https://jsonplaceholder.typicode.com/todos')
+      .subscribe((todos) => (this.todos = todos));
+  }
+}
+```
+
+## Verwendung von Komponenten in MDX-Seiten
+
+Um Komponenten mit MDX-Seiten zu verwenden, muss die MDX-Unterstützung installieren und konfiguriert werden, indem die Astro-Integration von [@astrojs/mdx](https://docs.astro.build/en/guides/integrations-guide/mdx/) befolgt wird. Die `astro.config.mjs` sollte nun die Integration von `@astrojs/mdx` enthalten.
+
+> Hinweis: Shiki ist der Standard-Syntax-Highlighter für das MDX-Plugin und wird derzeit nicht unterstützt. `astro-angular` wird dies mit `prism` überschreiben, aber es sollte in der Konfiguration angeben werden, um Warnungen oder Probleme zu vermeiden.
+
+```js
+import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
+import angular from '@analogjs/astro-angular';
+
+export default defineConfig({
+  integrations: [mdx({ syntaxHighlight: 'prism' }), angular()],
+});
+```
+
+Erstelle eine `.mdx`-Datei im Verzeichnis `src/pages` und füge den Import der Angular-Komponente unter Frontmatter hinzu.
+
+```md
+---
+layout: '../../layouts/BlogPost.astro'
+title: 'Using Angular in MDX'
+description: 'Lorem ipsum dolor sit amet'
+pubDate: 'Sep 22 2022'
+---
+
+import { HelloComponent } from "../../components/hello.component.ts";
+
+<HelloComponent />
+<HelloComponent helpText="Helping" />
+```
+
+Um die Komponente auf dem Client zu hydrieren, verwende eine der Astro-[Client-Direktiven](https://docs.astro.build/en/reference/directives-reference/#client-directives):
+
+```md
+---
+layout: '../../layouts/BlogPost.astro'
+title: 'Using Angular in MDX'
+description: 'Lorem ipsum dolor sit amet'
+pubDate: 'Sep 22 2022'
+---
+
+import { HelloComponent } from "../../components/hello.component.ts";
+
+<HelloComponent client:load />
+<HelloComponent client:visible helpText="Helping" />
+```
+
+> Wichtig: In `.mdx`-Dateien muss der Komponentenimport mit dem Suffix `.ts` enden. Andernfalls schlägt der dynamische Import der Komponente fehl und die Komponente kann nicht hydriert werden.
+
+## Aktuelle Einschränkungen
+
+- Es werden nur standalone Angular-Komponenten der Version v14.2+ unterstützt

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/packages/router/overview.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/packages/router/overview.md
@@ -1,0 +1,9 @@
+---
+title: ''
+---
+
+# Analog
+
+Das Fullstack-Meta-Framework für Angular
+
+Weitere Informationen unter [analogjs.org](https://analogjs.org)

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/packages/vite-plugin-angular/css-preprocessors.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/packages/vite-plugin-angular/css-preprocessors.md
@@ -1,0 +1,68 @@
+---
+title: 'Verwendung von CSS-Präprozessoren'
+---
+
+Das Vite Plugin unterstützt die CSS-Vorverarbeitung mit externen `styleUrls` und Inline `styles` in den Metadaten des Komponentendekorators.
+
+Externe `styleUrls` können ohne zusätzliche Konfiguration verwendet werden.
+
+Ein Beispiel mit `styleUrls`:
+
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  standalone: true,
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss'],
+})
+export class AppComponent {}
+```
+
+Um die Vorverarbeitung von Inline-`styles` zu unterstützen, muss das Plugin so konfiguriert werden, dass es die Erweiterung des Typs der verwendeten Styles bereitstellt.
+
+Ein Beispiel für die Verwendung von `scss` mit inline `styles`:
+
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  standalone: true,
+  templateUrl: './app.component.html',
+  styles: [
+    `
+      $neon: #cf0;
+
+      @mixin background($color: #fff) {
+        background: $color;
+      }
+
+      h2 {
+        @include background($neon);
+      }
+    `,
+  ],
+})
+export class AppComponent {}
+```
+
+Stelle in der Datei `vite.config.ts` der Plugin-Funktion `angular` ein Objekt zur Verfügung, dessen Eigenschaft `inlineStylesExtension` auf die Dateierweiterung für die CSS-Vorverarbeitung gesetzt ist.
+
+```ts
+import { defineConfig } from 'vite';
+import angular from '@analogjs/vite-plugin-angular';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => {
+  return {
+    // ... other config
+    plugins: [
+      angular({
+        inlineStylesExtension: 'scss',
+      }),
+    ],
+  };
+});
+```
+
+Unterstützte CSS-Präprozessor-Erweiterungen sind `scss`, `sass` und `less`. Weitere Informationen über CSS-Präprozessoren finden Sie in der [Vite Dokumentation](https://vitejs.dev/guide/features.html#css-pre-processors).

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/packages/vite-plugin-angular/overview.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/packages/vite-plugin-angular/overview.md
@@ -1,0 +1,93 @@
+---
+title: ''
+---
+
+# @analogjs/vite-plugin-angular
+
+Ein Vite-Plugin für die Erstellung von Angular-Anwendungen
+
+## Installation
+
+Mit npm:
+
+```sh
+npm install @analogjs/vite-plugin-angular --save-dev
+```
+
+Mit pnpm:
+
+```sh
+pnpm install @analogjs/vite-plugin-angular --save-dev
+```
+
+Mit yarn:
+
+```sh
+yarn install @analogjs/vite-plugin-angular --dev
+```
+
+Mit bun:
+
+```sh
+bun install @analogjs/vite-plugin-angular --dev
+```
+
+## Einrichtung
+
+Füge das Plugin zum Array `plugins` in der Vite-Konfiguration hinzu
+
+```ts
+import { defineConfig } from 'vite';
+import angular from '@analogjs/vite-plugin-angular';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  resolve: {
+    mainFields: ['module'],
+  },
+
+  plugins: [angular()],
+});
+```
+
+## Einrichtung der TypeScript-Konfiguration
+
+Die Integration benötigt eine `tsconfig.app.json` im Stammverzeichnis des Projekts zur Kompilierung.
+
+Erstelle eine `tsconfig.app.json` im Stammverzeichnis des Projekts.
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "noEmit": false,
+    "target": "es2020",
+    "module": "es2020",
+    "lib": ["es2020", "dom"],
+    "skipLibCheck": true
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  },
+  "files": [],
+  "include": ["src/**/*.ts"]
+}
+```


### PR DESCRIPTION
## PR Checklist

This PR adds german translation for following doc pages:
- Testing / Overview
- Guides / Version Compatibilty
- Guides / Migrating an Angular app to Analog
- Contributing
- packages/router/overview
- Integrations / Vite
- packages/vite-plugin-angular/css-preprocessors
- Integrations / Angular Material
- Integrations / Nx
- Testing / Adding Vitest
- Integrationen / Astro
- Integrationen / Ionic Framework

Thisis also the last PR for translating the docs into german

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media3.giphy.com/media/26u4lOMA8JKSnL9Uk/giphy.gif"/>