### PR TITLE
docs: fix the page with inconsistent menu and title

### DIFF
--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current.json
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current.json
@@ -85,7 +85,7 @@
     "description": "The label for the doc item Content Routes in sidebar docsSidebar, linking to the doc features/routing/content"
   },
   "sidebar.docsSidebar.doc.Providers": {
-    "message": "依赖提供者",
+    "message": "服务器提供商",
     "description": "The label for the doc item Providers in sidebar docsSidebar, linking to the doc features/deployment/providers"
   },
   "sidebar.docsSidebar.doc.Adding Vitest": {

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/guides/migrating.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/guides/migrating.md
@@ -5,7 +5,7 @@ title: 从Angular迁移到Analog
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# 将 Angular 应用转换成 Analog
+# 从 Angular 迁移到 Analog
 
 一个现有的 Angular 单页应用可以通过一个 Angular CLI 或者 Nx 工作区的原理器/生成器配置成使用 Analog。
 


### PR DESCRIPTION
## PR Checklist

Fix 2 pages with inconsistent menu and title:
- https://analogjs.org/zh-hans/docs/features/deployment/providers
- https://analogjs.org/zh-hans/docs/guides/migrating

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
