### PR TITLE
fix(vite-plugin-nitro): support server middleware in development

### DIFF
--- a/apps/analog-app/src/server/middleware/redirect.ts
+++ b/apps/analog-app/src/server/middleware/redirect.ts
@@ -1,0 +1,13 @@
+import { eventHandler, sendRedirect, setHeaders } from 'h3';
+
+export default eventHandler((event) => {
+  if (event.node.req.originalUrl === '/checkout') {
+    console.log('event url', event.node.req.originalUrl);
+
+    setHeaders(event, {
+      'x-analog-test': 'true',
+    });
+
+    sendRedirect(event, '/cart');
+  }
+});

--- a/apps/analog-app/tsconfig.app.json
+++ b/apps/analog-app/tsconfig.app.json
@@ -7,6 +7,10 @@
     "useDefineForClassFields": false
   },
   "files": ["src/main.ts", "src/main.server.ts"],
-  "include": ["src/**/*.d.ts", "src/app/pages/**/*.page.ts"],
+  "include": [
+    "src/**/*.d.ts",
+    "src/app/pages/**/*.page.ts",
+    "src/server/middleware/**/*.ts"
+  ],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"]
 }

--- a/apps/analog-app/tsconfig.json
+++ b/apps/analog-app/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "files": [],
   "include": [],
-  "exclude": ["./src/server/**/*"],
   "references": [
     {
       "path": "./tsconfig.app.json"

--- a/apps/docs-app/docs/features/routing/middleware.md
+++ b/apps/docs-app/docs/features/routing/middleware.md
@@ -1,0 +1,52 @@
+# Middleware
+
+Analog supports server-side middleware that can be used to modify requests, check for authentication, send redirects, and more.
+
+## Setting up Middleware
+
+Middleware is automatically registered when placed in the `src/server/middleware` folder.
+
+```treeview
+src/
+└── server/
+    └── middleware/
+        └── auth.ts
+```
+
+Middleware is defined using the `defineEventHandler` function.
+
+```ts
+import { defineEventHandler, sendRedirect, setHeaders } from 'h3';
+
+export default eventHandler((event) => {
+  if (event.node.req.originalUrl === '/checkout') {
+    console.log('event url', event.node.req.originalUrl);
+
+    setHeaders(event, {
+      'x-analog-checkout': 'true',
+    });
+  }
+});
+```
+
+- Middleware should only modify requests and should not return anything!
+- Middleware is run in order of the defined filenames. Prefix filenames with numbers to enforce a particular order.
+
+## Filtering in Middleware
+
+Middleware can only be applied to specific routes using filtering.
+
+```ts
+export default defineEventHandler(async (event) => {
+  // Only execute for /admin routes
+  if (getRequestURL(event).pathname.startsWith('/admin')) {
+    const cookies = parseCookies(event);
+    const isLoggedIn = cookies['authToken'];
+
+    // check auth and redirect
+    if (!isLoggedIn) {
+      sendRedirect(event, '/login', 401);
+    }
+  }
+});
+```

--- a/apps/docs-app/sidebars.js
+++ b/apps/docs-app/sidebars.js
@@ -49,6 +49,11 @@ const sidebars = {
               id: 'features/routing/content',
               label: 'Content Routes',
             },
+            {
+              type: 'doc',
+              id: 'features/routing/middleware',
+              label: 'Middleware',
+            },
           ],
         },
         {

--- a/packages/create-analog/template-blog/tsconfig.app.json
+++ b/packages/create-analog/template-blog/tsconfig.app.json
@@ -8,7 +8,7 @@
   "files": ["src/main.ts", "src/main.server.ts"],
   "include": [
     "src/**/*.d.ts",
-    "src/app/routes/**/*.ts",
-    "src/app/pages/**/*.page.ts"
+    "src/app/pages/**/*.page.ts",
+    "src/server/middleware/**/*.ts"
   ]
 }

--- a/packages/create-analog/template-latest/tsconfig.app.json
+++ b/packages/create-analog/template-latest/tsconfig.app.json
@@ -6,5 +6,9 @@
     "types": []
   },
   "files": ["src/main.ts", "src/main.server.ts"],
-  "include": ["src/**/*.d.ts", "src/app/pages/**/*.page.ts"]
+  "include": [
+    "src/**/*.d.ts",
+    "src/app/pages/**/*.page.ts",
+    "src/server/middleware/**/*.ts"
+  ]
 }

--- a/packages/vite-plugin-nitro/src/lib/utils/register-dev-middleware.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/register-dev-middleware.ts
@@ -1,0 +1,21 @@
+import { ViteDevServer } from 'vite';
+import { EventHandler, createEvent } from 'h3';
+import fg from 'fast-glob';
+
+export async function registerDevServerMiddleware(
+  root: string,
+  viteServer: ViteDevServer
+) {
+  const middlewareFiles = fg.sync([`${root}/src/server/middleware/**/*.ts`]);
+
+  middlewareFiles.forEach((file) => {
+    viteServer.middlewares.use(async (req, res, next) => {
+      const middlewareHandler: EventHandler = await viteServer
+        .ssrLoadModule(file)
+        .then((m: unknown) => (m as { default: EventHandler }).default);
+
+      middlewareHandler(createEvent(req, res));
+      next();
+    });
+  });
+}

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -39,12 +39,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
   let nitroConfig: NitroConfig;
 
   return [
-    (options?.ssr
-      ? devServerPlugin({
-          entryServer: options?.entryServer,
-          index: options?.index,
-        })
-      : false) as Plugin,
+    (options?.ssr ? devServerPlugin(options) : false) as Plugin,
     {
       name: '@analogjs/vite-plugin-nitro',
       async config(_config, { command }) {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Middleware in the `src/server/middleware` folder can be used in development.
This makes testing server-side auth/cookies/protected routes easier to implement.

The `src/server/middleware/**/*.ts` entry must be added to the `include` array in the `tsconfig.app.json`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/0fvqHJ467OxhthLAoD/giphy.gif"/>
