### PR TITLE
fix(nx-plugin): add server context to Nx generator template

### DIFF
--- a/packages/nx-plugin/src/generators/app/files/template-angular-v18/src/app/app.config.server.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v18/src/app/app.config.server.ts__template__
@@ -1,16 +1,10 @@
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
-import {
-  provideServerRendering,
-  ɵSERVER_CONTEXT as SERVER_CONTEXT,
-} from '@angular/platform-server';
+import { provideServerRendering } from '@angular/platform-server';
 
 import { appConfig } from './app.config';
 
 const serverConfig: ApplicationConfig = {
-  providers: [
-    provideServerRendering(),
-    { provide: SERVER_CONTEXT, useValue: 'ssr-analog' },
-  ],
+  providers: [provideServerRendering()],
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v18/src/app/app.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v18/src/app/app.config.ts__template__
@@ -1,7 +1,11 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { provideHttpClient, withFetch } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withFetch,
+  withInterceptors,
+} from '@angular/common/http';
 import { provideClientHydration } from '@angular/platform-browser';
-import { provideFileRouter } from '@analogjs/router';
+import { provideFileRouter, requestContextInterceptor } from '@analogjs/router';
 <% if (addTRPC) { %>
 import { provideTrpcClient } from '../trpc-client';
 <% } %>
@@ -11,7 +15,10 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideFileRouter(),
     provideClientHydration(),
-    provideHttpClient(withFetch()),
+    provideHttpClient(
+      withFetch(),
+      withInterceptors([requestContextInterceptor])
+    ),
 <% if (addTRPC) { %>
     provideTrpcClient(),
 <% } %>

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v18/src/main.server.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v18/src/main.server.ts__template__
@@ -1,23 +1,32 @@
 import 'zone.js/node';
 import '@angular/platform-server/init';
-
 import { enableProdMode } from '@angular/core';
-import { renderApplication } from '@angular/platform-server';
 import { bootstrapApplication } from '@angular/platform-browser';
+import { renderApplication } from '@angular/platform-server';
+import { provideServerContext } from '@analogjs/router/server';
+import { ServerContext } from '@analogjs/router/tokens';
 
-import { AppComponent } from './app/app.component';
 import { config } from './app/app.config.server';
+import { AppComponent } from './app/app.component';
 
 if (import.meta.env.PROD) {
   enableProdMode();
 }
 
-const bootstrap = () => bootstrapApplication(AppComponent, config);
+export function bootstrap() {
+  return bootstrapApplication(AppComponent, config);
+}
 
-export default async function render(url: string, document: string) {
+export default async function render(
+  url: string,
+  document: string,
+  serverContext: ServerContext
+) {
   const html = await renderApplication(bootstrap, {
     document,
     url,
+    platformProviders: [provideServerContext(serverContext)],
   });
+
   return html;
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When generating a new Analog app with Nx, server request context providers/interceptors are configured.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/10tt2DwqDd4AWk/giphy.gif"/>