### PR TITLE
fix(vite-plugin-angular): use resolved config for CSS preprocessor

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
@@ -1,15 +1,15 @@
-import { Plugin, preprocessCSS } from 'vite';
+import { Plugin, ResolvedConfig, preprocessCSS } from 'vite';
 
 export function jitPlugin({
   inlineStylesExtension,
 }: {
   inlineStylesExtension: string;
 }): Plugin {
-  let config: any;
+  let config: ResolvedConfig;
 
   return {
     name: '@analogjs/vite-plugin-angular-jit',
-    config(_config) {
+    configResolved(_config) {
       config = _config;
     },
     resolveId(id: string) {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1262 

## What is the new behavior?

The resolved vite config is passed to the `preprocessCSS` function

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
