### PR TITLE
fix: cookie interceptor

### DIFF
--- a/apps/analog-app/src/app/interceptors/cookies.interceptor.ts
+++ b/apps/analog-app/src/app/interceptors/cookies.interceptor.ts
@@ -1,15 +1,17 @@
 import { isPlatformServer } from '@angular/common';
 import { HttpHandlerFn, HttpHeaders, HttpRequest } from '@angular/common/http';
 import { PLATFORM_ID, inject } from '@angular/core';
+import { injectRequest } from '@analogjs/router/tokens';
 
 export function cookieInterceptor(
   req: HttpRequest<unknown>,
   next: HttpHandlerFn,
-  location = inject(PLATFORM_ID)
+  location = inject(PLATFORM_ID),
+  serverRequest = injectRequest()
 ) {
   if (isPlatformServer(location)) {
     let headers = new HttpHeaders();
-    const cookies = req.headers.get('cookie');
+    const cookies = serverRequest?.headers.cookie;
     headers = headers.set('cookie', cookies ?? '');
 
     const cookiedRequest = req.clone({


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes: None.

## What is the new behavior?

When the load server function runs, it does not have loaded cookies. This is because of https://github.com/angular/angular/issues/15730. Therefore, the original request object is injected to get the cookies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

* None.

## What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/TilmLMmWrRYYHjLfub/giphy.gif"/>
😂
