### PR TITLE
fix(platform): add support for event replay with SSR

### DIFF
--- a/apps/analog-app/src/app/app.config.ts
+++ b/apps/analog-app/src/app/app.config.ts
@@ -4,7 +4,10 @@ import {
   withInterceptors,
 } from '@angular/common/http';
 import { ApplicationConfig } from '@angular/core';
-import { provideClientHydration } from '@angular/platform-browser';
+import {
+  provideClientHydration,
+  withEventReplay,
+} from '@angular/platform-browser';
 import { provideFileRouter, requestContextInterceptor } from '@analogjs/router';
 import { withNavigationErrorHandler } from '@angular/router';
 
@@ -15,6 +18,6 @@ export const appConfig: ApplicationConfig = {
       withFetch(),
       withInterceptors([requestContextInterceptor])
     ),
-    provideClientHydration(),
+    provideClientHydration(withEventReplay()),
   ],
 };

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -9,6 +9,7 @@ import { contentPlugin } from './content-plugin.js';
 import { clearClientPageEndpointsPlugin } from './clear-client-page-endpoint.js';
 import { ssrXhrBuildPlugin } from './ssr/ssr-xhr-plugin.js';
 import { depsPlugin } from './deps-plugin.js';
+import { injectHTMLPlugin } from './ssr/inject-html-plugin.js';
 
 export function platformPlugin(opts: Options = {}): Plugin[] {
   const { apiPrefix, ...platformOptions } = {
@@ -28,7 +29,7 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
 
   return [
     ...viteNitroPlugin(platformOptions, nitroOptions),
-    (platformOptions.ssr ? ssrBuildPlugin() : false) as Plugin,
+    ...(platformOptions.ssr ? [ssrBuildPlugin(), ...injectHTMLPlugin()] : []),
     ...depsPlugin(),
     ...routerPlugin(platformOptions),
     ...contentPlugin(platformOptions?.content, platformOptions),

--- a/packages/platform/src/lib/ssr/inject-html-plugin.ts
+++ b/packages/platform/src/lib/ssr/inject-html-plugin.ts
@@ -1,0 +1,36 @@
+import { VERSION } from '@angular/compiler-cli';
+import { Plugin } from 'vite';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+function eventReplayPlugin(): Plugin {
+  return {
+    name: 'analogjs-event-replay-plugin',
+    async transformIndexHtml() {
+      const eventReplayScript = await readFile(
+        require.resolve('@angular/core/event-dispatch-contract.min.js'),
+        'utf-8'
+      );
+
+      return [
+        {
+          tag: 'script',
+          attrs: {
+            type: 'text/javascript',
+            id: 'ng-event-dispatch-contract',
+          },
+          children: eventReplayScript,
+          injectTo: 'body',
+        },
+      ];
+    },
+  };
+}
+
+export function injectHTMLPlugin(): Plugin[] {
+  const hasEventReplay = Number(VERSION.major) >= 18;
+
+  return hasEventReplay ? [eventReplayPlugin()] : [];
+}


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1165 

## What is the new behavior?

When SSR is enabled, the event replay script is injected into the `index.html` to support `withEventReplay()` for client hydration.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/ANEko1FtxL46Akz5L9/giphy-downsized-medium.gif"/>
