### PR TITLE
fix(platform): use workspace root when discovering packages for SSR transform

### DIFF
--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -1,7 +1,6 @@
 import { VERSION } from '@angular/compiler-cli';
 import { Plugin } from 'vite';
 import { crawlFrameworkPkgs } from 'vitefu';
-import { relative } from 'node:path';
 
 import { Options } from './options.js';
 
@@ -49,10 +48,8 @@ export function depsPlugin(options?: Options): Plugin[] {
     {
       name: 'analogjs-auto-discover-deps',
       async config(config, { command }) {
-        const root = relative(workspaceRoot, config.root || '.') || '.';
-
         const pkgConfig = await crawlFrameworkPkgs({
-          root,
+          root: workspaceRoot,
           isBuild: command === 'build',
           viteUserConfig: config,
           isSemiFrameworkPkgByJson(pkgJson) {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Fixes an issue where packages that need SSR transform were not discovered when creating an Nx workspace using the Analog preset. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
