### PR TITLE
feat(vite-plugin-angular): add remark/rehype support for agx files

### DIFF
--- a/apps/blog-app/vite.config.ts
+++ b/apps/blog-app/vite.config.ts
@@ -22,6 +22,12 @@ export default defineConfig(() => {
         vite: {
           experimental: {
             supportAnalogFormat: true,
+            markdownTemplateTransforms: [
+              remarkRehypeMarkdownTemplateTransform({
+                remarkPlugins: [someRemarkPlugin, someOtherRemarkPlugin],
+                rehypePlugins: [[someRehypePlugin, { withOptions: 0.4 }]],
+              }),
+            ],
           },
         },
         additionalPagesDirs: ['/libs/shared/feature'],

--- a/packages/vite-plugin-angular/package.json
+++ b/packages/vite-plugin-angular/package.json
@@ -24,7 +24,13 @@
     "@ngtools/webpack": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "ts-morph": "^21.0.0"
+    "ts-morph": "^21.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.5",
+    "unist": "^0.0.1",
+    "unist-util-visit": "^5.0.0"
   },
   "ng-update": {
     "packageGroup": [

--- a/packages/vite-plugin-angular/src/index.ts
+++ b/packages/vite-plugin-angular/src/index.ts
@@ -3,6 +3,7 @@ export { PluginOptions } from './lib/angular-vite-plugin.js';
 export { compileAnalogFile } from './lib/authoring/analog.js';
 export {
   MarkdownTemplateTransform,
+  remarkRehypeMarkdownTemplateTransform,
   defaultMarkdownTemplateTransforms,
 } from './lib/authoring/markdown-transform.js';
 

--- a/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
@@ -29,10 +29,11 @@ export const defaultMarkdownTemplateTransform: MarkdownTemplateTransform =
     return mdContent;
   };
 
-export const remarkRehypeMarkdownTemplateTransform: MarkdownTemplateTransform =
+export const remarkRehypeMarkdownTemplateTransform =
+  (options: RemarkRehypeOptions = {}): MarkdownTemplateTransform =>
   async (content: string) => {
-    // TODO: can I add an optional config here for passing in remark/rehype plugins?
-    const remarkSetupService = new RemarkSetupService();
+    const { RemarkSetupService } = await import('./remark-setup.service.js');
+    const remarkSetupService = new RemarkSetupService(options);
     const mdContent = await remarkSetupService
       .getRemarkInstance()
       .process(content);

--- a/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
@@ -1,7 +1,20 @@
+import type { Plugin, Settings } from 'unified';
+
 export type MarkdownTemplateTransform = (
   content: string,
   fileName: string
 ) => string | Promise<string>;
+
+export type PluginWithSettings<
+  S extends any[] = [Settings?],
+  P extends Plugin<S> = Plugin<S>
+> = [P, ...S];
+export type UnifiedPlugins = Array<PluginWithSettings | Plugin>;
+
+export interface RemarkRehypeOptions {
+  remarkPlugins?: UnifiedPlugins;
+  rehypePlugins?: UnifiedPlugins;
+}
 
 export const defaultMarkdownTemplateTransform: MarkdownTemplateTransform =
   async (content: string) => {
@@ -16,6 +29,24 @@ export const defaultMarkdownTemplateTransform: MarkdownTemplateTransform =
     return mdContent;
   };
 
+export const remarkRehypeMarkdownTemplateTransform: MarkdownTemplateTransform =
+  async (content: string) => {
+    // TODO: can I add an optional config here for passing in remark/rehype plugins?
+    const remarkSetupService = new RemarkSetupService();
+    const mdContent = await remarkSetupService
+      .getRemarkInstance()
+      .process(content);
+
+    return fixDoubleEscape(String(mdContent));
+  };
+
 export const defaultMarkdownTemplateTransforms: MarkdownTemplateTransform[] = [
   defaultMarkdownTemplateTransform,
 ];
+
+function fixDoubleEscape(content: string) {
+  return content
+    .replace(/&#x26;#64;/g, '&#64;')
+    .replace(/&#x26;#x2774;/g, '&#x2774;')
+    .replace(/&#x26;#x2775;/g, '&#x2775;');
+}

--- a/packages/vite-plugin-angular/src/lib/authoring/remark-setup.service.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/remark-setup.service.ts
@@ -1,0 +1,96 @@
+import { unified, type Processor } from 'unified';
+import { type Plugin } from 'unified';
+import { Literal } from 'unist';
+import { visit } from 'unist-util-visit';
+import rehypeStringify from 'rehype-stringify';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { UnifiedPlugins } from './markdown-transform';
+
+const rehypeAnalog: Plugin = () => {
+  return (tree) => {
+    visit(tree, 'element', (node) => {
+      if ((node as any).tagName === 'p') {
+        visit(node, 'text', (childNode) => {
+          const literal = childNode as Literal;
+          if (detectAngularControlFlow(literal.value as string)) {
+            literal.type = 'raw';
+          } else {
+            literal.value = escapeBreakingCharacters(literal.value as string);
+          }
+        });
+      }
+
+      if ((node as any).tagName === 'code') {
+        visit(node, 'text', (childNode) => {
+          const literal = childNode as Literal;
+          literal.value = escapeBreakingCharacters(literal.value as string);
+        });
+      }
+    });
+  };
+};
+
+function escapeBreakingCharacters(code: string) {
+  // Escape commonly used HTML characters
+  // in Angular templates that cause template parse errors
+  // such as @, {, and ,}.
+  code = code.replace(/@/g, '&#64;');
+  code = code.replace(/{/g, '&#x2774;').replace(/}/g, '&#x2775;');
+  return code;
+}
+
+function detectAngularControlFlow(text: string) {
+  return (
+    (text.trim().startsWith('@if') ||
+      text.trim().startsWith('@for') ||
+      text.trim().startsWith('@switch') ||
+      text.trim().startsWith('@defer')) &&
+    text.trim().endsWith('}')
+  );
+}
+
+const applyPlugins = (plugins: UnifiedPlugins, parser: Processor) => {
+  (plugins as UnifiedPlugins).forEach((plugin) => {
+    if (Array.isArray(plugin)) {
+      if (plugin[1] && plugin[1]) parser.use(plugin[0], plugin[1]);
+      else parser.use(plugin[0]);
+    } else {
+      parser.use(plugin);
+    }
+  });
+
+  return parser;
+};
+
+export class RemarkSetupService {
+  constructor() {
+    // TODO:
+    const remarkPlugins: any = [];
+    const rehypePlugins: any = [];
+
+    const toMDAST = unified().use(remarkParse);
+    applyPlugins(remarkPlugins, toMDAST);
+    const toHAST = toMDAST.use(remarkRehype, { allowDangerousHtml: true });
+    applyPlugins(rehypePlugins, toHAST);
+
+    const processor = toHAST
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+      })
+      .use(rehypeAnalog);
+  }
+  // private readonly remark = unified()
+  //   .use(remarkParse)
+  //   // TODO: add remark plugins here
+  //   .use(remarkRehype, { allowDangerousHtml: true })
+  //   // TODO: add rehype plugins here
+  //   .use(rehypeStringify, {
+  //     allowDangerousHtml: true,
+  //   })
+  //   .use(rehypeAnalog);
+  //
+  // getRemarkInstance() {
+  //   return this.remark;
+  // }
+}

--- a/packages/vite-plugin-angular/src/lib/authoring/remark-setup.service.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/remark-setup.service.ts
@@ -5,7 +5,7 @@ import { visit } from 'unist-util-visit';
 import rehypeStringify from 'rehype-stringify';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
-import { UnifiedPlugins } from './markdown-transform';
+import { RemarkRehypeOptions, UnifiedPlugins } from './markdown-transform';
 
 const rehypeAnalog: Plugin = () => {
   return (tree) => {
@@ -64,33 +64,22 @@ const applyPlugins = (plugins: UnifiedPlugins, parser: Processor) => {
 };
 
 export class RemarkSetupService {
-  constructor() {
-    // TODO:
-    const remarkPlugins: any = [];
-    const rehypePlugins: any = [];
+  private processor!: Processor;
 
+  constructor(options: RemarkRehypeOptions) {
     const toMDAST = unified().use(remarkParse);
-    applyPlugins(remarkPlugins, toMDAST);
+    applyPlugins(options.remarkPlugins || [], toMDAST);
     const toHAST = toMDAST.use(remarkRehype, { allowDangerousHtml: true });
-    applyPlugins(rehypePlugins, toHAST);
+    applyPlugins(options.rehypePlugins || [], toHAST);
 
-    const processor = toHAST
+    this.processor = toHAST
       .use(rehypeStringify, {
         allowDangerousHtml: true,
       })
       .use(rehypeAnalog);
   }
-  // private readonly remark = unified()
-  //   .use(remarkParse)
-  //   // TODO: add remark plugins here
-  //   .use(remarkRehype, { allowDangerousHtml: true })
-  //   // TODO: add rehype plugins here
-  //   .use(rehypeStringify, {
-  //     allowDangerousHtml: true,
-  //   })
-  //   .use(rehypeAnalog);
-  //
-  // getRemarkInstance() {
-  //   return this.remark;
-  // }
+
+  getRemarkInstance() {
+    return this.processor;
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,31 @@ importers:
         specifier: ~5.2.2
         version: 5.2.2
 
+  packages/vite-plugin-angular:
+    dependencies:
+      ts-morph:
+        specifier: ^21.0.0
+        version: 21.0.1
+    devDependencies:
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: ^11.1.0
+        version: 11.1.0
+      remark-stringify:
+        specifier: ^11.0.0
+        version: 11.0.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist:
+        specifier: ^0.0.1
+        version: 0.0.1
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
+
 packages:
 
   '@aashutoshrathi/word-wrap@1.2.6':
@@ -12307,6 +12332,9 @@ packages:
   unified@11.0.4:
     resolution: {integrity: sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unimport@3.7.1:
     resolution: {integrity: sha512-V9HpXYfsZye5bPPYUgs0Otn3ODS1mDUciaBlXljI4C2fTwfFpvFZRywmlOu943puN9sncxROMZhsZCjNXEpzEQ==}
 
@@ -12373,6 +12401,10 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  unist@0.0.1:
+    resolution: {integrity: sha512-bnzuF8b6d47WubA4a5yLqFbuZz/v/NS6eRwUIdOaDmsqzwTlyv8yS1g3M7ISdtBQrigPD3qKK87Cu7zhEfCF3A==}
+    deprecated: Use @types/unist instead
 
   universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
@@ -18530,7 +18562,7 @@ snapshots:
   '@ts-morph/common@0.22.0':
     dependencies:
       fast-glob: 3.3.2
-      minimatch: 9.0.3
+      minimatch: 9.0.4
       mkdirp: 3.0.1
       path-browserify: 1.0.1
 
@@ -21112,6 +21144,10 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
+
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
 
   debug@4.3.4(supports-color@8.1.1):
     dependencies:
@@ -24271,7 +24307,7 @@ snapshots:
 
   mdast-util-from-markdown@2.0.0:
     dependencies:
-      '@types/mdast': 4.0.1
+      '@types/mdast': 4.0.3
       '@types/unist': 3.0.0
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
@@ -24406,13 +24442,13 @@ snapshots:
 
   mdast-util-phrasing@4.0.0:
     dependencies:
-      '@types/mdast': 4.0.1
+      '@types/mdast': 4.0.3
       unist-util-is: 6.0.0
 
   mdast-util-to-hast@13.1.0:
     dependencies:
       '@types/hast': 3.0.3
-      '@types/mdast': 4.0.1
+      '@types/mdast': 4.0.3
       '@ungap/structured-clone': 1.2.0
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.0
@@ -24423,7 +24459,7 @@ snapshots:
 
   mdast-util-to-markdown@2.1.0:
     dependencies:
-      '@types/mdast': 4.0.1
+      '@types/mdast': 4.0.3
       '@types/unist': 3.0.0
       longest-streak: 3.0.1
       mdast-util-phrasing: 4.0.0
@@ -24436,7 +24472,7 @@ snapshots:
 
   mdast-util-to-string@4.0.0:
     dependencies:
-      '@types/mdast': 4.0.1
+      '@types/mdast': 4.0.3
 
   mdn-data@2.0.28: {}
 
@@ -24912,7 +24948,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -27178,19 +27214,19 @@ snapshots:
 
   remark-parse@11.0.0:
     dependencies:
-      '@types/mdast': 4.0.1
+      '@types/mdast': 4.0.3
       mdast-util-from-markdown: 2.0.0
       micromark-util-types: 2.0.0
-      unified: 11.0.4
+      unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
   remark-rehype@11.1.0:
     dependencies:
       '@types/hast': 3.0.3
-      '@types/mdast': 4.0.1
+      '@types/mdast': 4.0.3
       mdast-util-to-hast: 13.1.0
-      unified: 11.0.4
+      unified: 11.0.5
       vfile: 6.0.1
 
   remark-smartypants@2.0.0:
@@ -27208,9 +27244,9 @@ snapshots:
 
   remark-stringify@11.0.0:
     dependencies:
-      '@types/mdast': 4.0.1
+      '@types/mdast': 4.0.3
       mdast-util-to-markdown: 2.1.0
-      unified: 11.0.4
+      unified: 11.0.5
 
   renderkid@3.0.0:
     dependencies:
@@ -28662,6 +28698,16 @@ snapshots:
       trough: 2.1.0
       vfile: 6.0.1
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.0
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.1.0
+      vfile: 6.0.1
+
   unimport@3.7.1(rollup@4.18.0):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
@@ -28764,6 +28810,8 @@ snapshots:
       '@types/unist': 3.0.0
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
+
+  unist@0.0.1: {}
 
   universal-user-agent@6.0.1: {}
 


### PR DESCRIPTION
Rough (non functional) draft of implementation to support remark/rehype pipelines in Analog via this API:

```ts
            markdownTemplateTransforms: [
              remarkRehypeMarkdownTemplateTransform({
                remarkPlugins: [someRemarkPlugin, someOtherRemarkPlugin],
                rehypePlugins: [[someRehypePlugin, { withOptions: 0.4 }]],
              }),
            ],
```
