### PR TITLE
fix: update templates to use vitest-angular import for testing

### DIFF
--- a/packages/create-analog/template-angular-v16/src/test.ts
+++ b/packages/create-analog/template-angular-v16/src/test.ts
@@ -1,4 +1,4 @@
-import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@analogjs/vitest-angular/setup-zone';
 
 import {
   BrowserDynamicTestingModule,

--- a/packages/create-analog/template-angular-v17/src/test.ts
+++ b/packages/create-analog/template-angular-v17/src/test.ts
@@ -1,4 +1,4 @@
-import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@analogjs/vitest-angular/setup-zone';
 
 import {
   BrowserDynamicTestingModule,

--- a/packages/create-analog/template-blog/src/test-setup.ts
+++ b/packages/create-analog/template-blog/src/test-setup.ts
@@ -1,4 +1,4 @@
-import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@analogjs/vitest-angular/setup-zone';
 
 import {
   BrowserDynamicTestingModule,

--- a/packages/create-analog/template-latest/src/test-setup.ts
+++ b/packages/create-analog/template-latest/src/test-setup.ts
@@ -1,4 +1,4 @@
-import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@analogjs/vitest-angular/setup-zone';
 
 import {
   BrowserDynamicTestingModule,

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/src/test-setup.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/src/test-setup.ts__template__
@@ -1,4 +1,4 @@
-import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@analogjs/vitest-angular/setup-zone';
 
 import {
   BrowserDynamicTestingModule,

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/src/test-setup.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/src/test-setup.ts__template__
@@ -1,4 +1,4 @@
-import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@analogjs/vitest-angular/setup-zone';
 
 import {
   BrowserDynamicTestingModule,

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v17/src/test-setup.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v17/src/test-setup.ts__template__
@@ -1,4 +1,4 @@
-import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@analogjs/vitest-angular/setup-zone';
 
 import {
   BrowserDynamicTestingModule,

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v18/src/test-setup.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v18/src/test-setup.ts__template__
@@ -1,4 +1,4 @@
-import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@analogjs/vitest-angular/setup-zone';
 
 import {
   BrowserDynamicTestingModule,

--- a/packages/nx-plugin/src/generators/init/test-files/src/test-setup.ts__template__
+++ b/packages/nx-plugin/src/generators/init/test-files/src/test-setup.ts__template__
@@ -1,4 +1,4 @@
-import '@analogjs/vite-plugin-angular/setup-vitest';
+import '@analogjs/vitest-angular/setup-zone';
 
 import {
   BrowserDynamicTestingModule,


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When generating the testing setup, `@analogjs/vitest-angular/setup-zone` is used to setup zone.js for testing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
