### PR TITLE
fix(platform): prevent rxfire package from being externalized during SSR

### DIFF
--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -13,7 +13,12 @@ export function depsPlugin(options?: Options): Plugin[] {
       config() {
         return {
           ssr: {
-            noExternal: ['@analogjs/**', 'firebase/**', 'firebase-admin/**'],
+            noExternal: [
+              '@analogjs/**',
+              'firebase/**',
+              'firebase-admin/**',
+              'rxfire',
+            ],
           },
           optimizeDeps: {
             include: [
@@ -40,6 +45,7 @@ export function depsPlugin(options?: Options): Plugin[] {
               '@nx/workspace',
               '@nx/eslint',
               'webpack',
+              'fsevents',
             ],
           },
         };


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1296 

## What is the new behavior?

The `rxfire` package was being externalized during SSR package discovery. This prevents that so it can be transformed during SSR.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
