### PR TITLE
fix(trpc): support running with Zoneless change detection

### DIFF
--- a/packages/trpc/src/lib/utils/wait-for.ts
+++ b/packages/trpc/src/lib/utils/wait-for.ts
@@ -6,6 +6,11 @@ export async function waitFor<T>(prom: Promise<T> | Observable<T>): Promise<T> {
   if (isObservable(prom)) {
     prom = firstValueFrom(prom);
   }
+
+  if (typeof Zone === 'undefined') {
+    return prom;
+  }
+
   const macroTask = Zone.current.scheduleMacroTask(
     `AnalogContentResolve-${Math.random()}`,
     () => {},


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- `pnpm test` ran successfully
- Tested the `trpc-app` to work in zoneless change detection including this patch
- Closes #1295

## What is the new behavior?

Now also the trpc package works, when running in zoneless change detection.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
