### PR TITLE
fix(vite-plugin-angular): use JavaScript transformer from Angular Devkit for build optimizations

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -1,68 +1,44 @@
 import { Plugin } from 'vite';
-import { transformAsync } from '@babel/core';
-import { createEs2015LinkerPlugin as linkerPluginCreator } from '@angular/compiler-cli/linker/babel';
 
-import { angularApplicationPreset, requiresLinking } from './utils/devkit.js';
+import { JavaScriptTransformer } from './utils/devkit.js';
 
 export function buildOptimizerPlugin({
   isProd,
-  supportedBrowsers,
 }: {
   isProd: boolean;
   supportedBrowsers: string[];
 }): Plugin {
+  const javascriptTransformer = new JavaScriptTransformer(
+    {
+      sourcemap: false,
+      thirdPartySourcemaps: false,
+      advancedOptimizations: true,
+      jit: true,
+    },
+    1
+  );
+
   return {
     name: '@analogjs/vite-plugin-angular-optimizer',
     apply: 'build',
-    config(userConfig) {
+    config() {
       return {
-        esbuild: !userConfig.esbuild
-          ? {
-              legalComments: 'none',
-              keepNames: false,
-              define: isProd
-                ? {
-                    ngDevMode: 'false',
-                    ngJitMode: 'false',
-                    ngI18nClosureMode: 'false',
-                  }
-                : undefined,
-              supported: {
-                // Native async/await is not supported with Zone.js. Disabling support here will cause
-                // esbuild to downlevel async/await to a Zone.js supported form.
-                'async-await': false,
-                // Zone.js also does not support async generators or async iterators. However, esbuild does
-                // not currently support downleveling either of them. Instead babel is used within the JS/TS
-                // loader to perform the downlevel transformation. They are both disabled here to allow
-                // esbuild to handle them in the future if support is ever added.
-                // NOTE: If esbuild adds support in the future, the babel support for these can be disabled.
-                'async-generator': false,
-                'for-await': false,
-                'class-field': false,
-                'class-static-field': false,
-              },
-            }
-          : {
-              define: isProd
-                ? {
-                    ngDevMode: 'false',
-                    ngJitMode: 'false',
-                    ngI18nClosureMode: 'false',
-                  }
-                : undefined,
-            },
+        esbuild: {
+          define: isProd
+            ? {
+                ngDevMode: 'false',
+                ngJitMode: 'false',
+                ngI18nClosureMode: 'false',
+              }
+            : undefined,
+        },
       };
     },
     async transform(code, id) {
       if (/\.[cm]?js$/.test(id)) {
         const angularPackage = /[\\/]node_modules[\\/]@angular[\\/]/.test(id);
-        const forceAsyncTransformation =
-          !/[\\/][_f]?esm2015[\\/]/.test(id) &&
-          /for\s+await\s*\(|async\s+function\s*\*/.test(code);
-        const shouldLink = await requiresLinking(id, code);
-        const useInputSourcemap = (!isProd ? undefined : false) as undefined;
 
-        if (!forceAsyncTransformation && !isProd && !shouldLink) {
+        if (!angularPackage) {
           return {
             code: isProd
               ? code.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, '')
@@ -73,38 +49,14 @@ export function buildOptimizerPlugin({
           };
         }
 
-        const result = await transformAsync(code, {
-          filename: id,
-          inputSourceMap: useInputSourcemap,
-          sourceMaps: !isProd ? 'inline' : false,
-          compact: false,
-          configFile: false,
-          babelrc: false,
-          browserslistConfigFile: false,
-          plugins: [],
-          presets: [
-            [
-              angularApplicationPreset,
-              {
-                angularLinker: {
-                  shouldLink,
-                  jitMode: false,
-                  linkerPluginCreator,
-                },
-                forceAsyncTransformation,
-                supportedBrowsers,
-                optimize: isProd && {
-                  looseEnums: angularPackage,
-                  pureTopLevel: angularPackage,
-                },
-              },
-            ],
-          ],
-        });
+        const result: Uint8Array = await javascriptTransformer.transformData(
+          id,
+          code,
+          false
+        );
 
         return {
-          code: result?.code || '',
-          map: result?.map as any,
+          code: Buffer.from(result).toString(),
         };
       }
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1,5 +1,4 @@
 import { CompilerHost, NgtscProgram } from '@angular/compiler-cli';
-import { transformAsync } from '@babel/core';
 import { resolve } from 'node:path';
 
 import * as compilerCli from '@angular/compiler-cli';
@@ -25,7 +24,6 @@ import { jitPlugin } from './angular-jit-plugin.js';
 import { buildOptimizerPlugin } from './angular-build-optimizer-plugin.js';
 
 import {
-  angularApplicationPreset,
   createJitResourceTransformer,
   SourceFileCache,
 } from './utils/devkit.js';
@@ -377,10 +375,6 @@ export function angular(options?: PluginOptions): Plugin[] {
             };
           }
 
-          const forceAsyncTransformation =
-            /for\s+await\s*\(|async\s+function\s*\*/.test(data);
-          const useInputSourcemap = (!isProd ? undefined : false) as undefined;
-
           if (
             (id.endsWith('.analog') || id.endsWith('.agx')) &&
             pluginOptions.supportAnalogFormat &&
@@ -396,39 +390,9 @@ export function angular(options?: PluginOptions): Plugin[] {
             }
           }
 
-          if (!forceAsyncTransformation && !isProd) {
-            return {
-              code: data,
-              map: null,
-            };
-          }
-
-          const babelResult = await transformAsync(data, {
-            filename: id,
-            inputSourceMap: (useInputSourcemap
-              ? undefined
-              : false) as undefined,
-            sourceMaps: !isProd ? 'inline' : false,
-            compact: false,
-            configFile: false,
-            babelrc: false,
-            browserslistConfigFile: false,
-            plugins: [],
-            presets: [
-              [
-                angularApplicationPreset,
-                {
-                  supportedBrowsers: pluginOptions.supportedBrowsers,
-                  forceAsyncTransformation,
-                  optimize: isProd && {},
-                },
-              ],
-            ],
-          });
-
           return {
-            code: babelResult?.code ?? '',
-            map: babelResult?.map,
+            code: data,
+            map: null,
           };
         }
 

--- a/packages/vite-plugin-angular/src/lib/utils/devkit.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/devkit.ts
@@ -6,17 +6,13 @@ import * as sfc from './source-file-cache.js';
 const require = createRequire(import.meta.url);
 
 const angularVersion = Number(VERSION.major);
-let requiresLinking: Function;
 let sourceFileCache: any;
 let cjt: Function;
 let jt: any;
-let angularApplicationPreset: Function;
 
 if (angularVersion < 15) {
   throw new Error('AnalogJS is not compatible with Angular v14 and lower');
 } else if (angularVersion >= 15 && angularVersion < 16) {
-  const app = require('@angular-devkit/build-angular/src/babel/presets/application.js');
-  const wbl = require('@angular-devkit/build-angular/src/babel/webpack-loader.js');
   const cp = require('@angular-devkit/build-angular/src/builders/browser-esbuild/compiler-plugin.js');
   const {
     createJitResourceTransformer,
@@ -25,14 +21,10 @@ if (angularVersion < 15) {
     JavaScriptTransformer,
   } = require('@angular-devkit/build-angular/src/builders/browser-esbuild/javascript-transformer.js');
 
-  requiresLinking = wbl.requiresLinking;
   sourceFileCache = cp.SourceFileCache;
   cjt = createJitResourceTransformer;
   jt = JavaScriptTransformer;
-  angularApplicationPreset = app.default;
 } else if (angularVersion >= 16 && angularVersion < 18) {
-  const app = require('@angular-devkit/build-angular/src/tools/babel/presets/application.js');
-  const wbl = require('@angular-devkit/build-angular/src/tools/babel/webpack-loader.js');
   const cp = require('@angular-devkit/build-angular/src/tools/esbuild/angular/compiler-plugin.js');
   const {
     createJitResourceTransformer,
@@ -41,14 +33,6 @@ if (angularVersion < 15) {
     JavaScriptTransformer,
   } = require('@angular-devkit/build-angular/src/tools/esbuild/javascript-transformer.js');
 
-  /**
-   * Workaround for compatibility with Angular 16.2+
-   */
-  if (typeof wbl['requiresLinking'] !== 'undefined') {
-    requiresLinking = wbl.requiresLinking;
-  } else if (typeof app['requiresLinking'] !== 'undefined') {
-    requiresLinking = app['requiresLinking'];
-  }
   /**
    * Workaround for compatibility with Angular 17.0+
    */
@@ -60,25 +44,19 @@ if (angularVersion < 15) {
 
   cjt = createJitResourceTransformer;
   jt = JavaScriptTransformer;
-  angularApplicationPreset = app.default;
 } else {
   const {
     createJitResourceTransformer,
     JavaScriptTransformer,
     SourceFileCache,
   } = require('@angular/build/private');
-  const app = require('@angular-devkit/build-angular/src/tools/babel/presets/application.js');
 
-  requiresLinking = app.requiresLinking;
   sourceFileCache = SourceFileCache;
   cjt = createJitResourceTransformer;
   jt = JavaScriptTransformer;
-  angularApplicationPreset = app.default;
 }
 
 export {
-  requiresLinking,
-  angularApplicationPreset,
   cjt as createJitResourceTransformer,
   jt as JavaScriptTransformer,
   sourceFileCache as SourceFileCache,


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Switches to use the `JavascriptTransformer` from the Angular DevKit (Private API) to prod build optimizations
- Fixes an issue when importing NgModules like `CommonModule` fails at runtime because its declarations were stripped out during the build.
- Also fixes an issue with not being able to use self-closing tags for components

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
