### PR TITLE
fix(nx-plugin): remove fileReplacements from vite build schema

### DIFF
--- a/apps/docs-app/docs/guides/migrating.md
+++ b/apps/docs-app/docs/guides/migrating.md
@@ -51,7 +51,7 @@ npx nx generate @analogjs/platform:init --project [your-project-name]
 
 ## Updating Global Styles and Scripts
 
-If you have any global scripts or styles configured in the `angular.json`, move them inside the `head` tag in the `index.html`.
+If you have any global scripts or styles configured in the `angular.json`, reference them inside the `head` tag in the `index.html`.
 
 ```html
 <!DOCTYPE html>
@@ -69,4 +69,106 @@ If you have any global scripts or styles configured in the `angular.json`, move 
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>
+```
+
+## Setting Up Environments
+
+In an Angular application, `fileReplacements` are configured in the `angular.json` for different environments.
+
+### Using Environment Variables
+
+In Analog, you can setup and use environment variables. This is the **recommended** approach.
+
+Add a `.env` file to the root of your application, and prefix any **public** environment variables with `VITE_`. **Do not** check this file into your source code repository.
+
+```sh
+VITE_MY_API_KEY=development-key
+
+# Only available in the server build
+MY_SERVER_API_KEY=development-server-key
+```
+
+Import and use the environment variable in your code.
+
+```ts
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthService {
+  private readonly apiKey = import.meta.env['VITE_MY_API_KEY'];
+
+  constructor(private http: HttpClient) {}
+}
+```
+
+When deploying, set up your environment variables to their production equivalents.
+
+```sh
+VITE_MY_API_KEY=production-key
+
+# Only available in the server build
+MY_SERVER_API_KEY=production-server-key
+```
+
+Read [here](https://vitejs.dev/guide/env-and-mode.html) for about more information on environment variables.
+
+### Using File Replacements
+
+You can also use the `replaceFiles()` plugin from Nx to replace files during your build.
+
+Import the plugin and set it up:
+
+```ts
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite';
+import analog from '@analogjs/platform';
+import { replaceFiles } from '@nx/vite/plugins/rollup-replace-files.plugin';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => ({
+  build: {
+    target: ['es2020'],
+  },
+  resolve: {
+    mainFields: ['module'],
+  },
+  plugins: [
+    analog(),
+    mode === 'production' &&
+      replaceFiles([
+        {
+          replace: 'src/environments/environment.ts',
+          with: 'src/environments/environment.prod.ts',
+        },
+      ]),
+  ],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['src/test-setup.ts'],
+    include: ['**/*.spec.ts'],
+    reporters: ['default'],
+  },
+  define: {
+    'import.meta.vitest': mode !== 'production',
+  },
+}));
+```
+
+Add the environment files to `files` array in the `tsconfig.app.json` may also be necessary.
+
+```json
+{
+  "extends": "./tsconfig.json",
+  // other config
+  "files": [
+    "src/main.ts",
+    "src/main.server.ts",
+    "src/environments/environment.prod.ts"
+  ]
+}
 ```

--- a/packages/nx-plugin/src/executors/vite/schema.json
+++ b/packages/nx-plugin/src/executors/vite/schema.json
@@ -39,28 +39,6 @@
       "x-completion-type": "file",
       "x-completion-glob": "vite.config.@(js|ts)"
     },
-    "fileReplacements": {
-      "description": "Replace files with other files in the build.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "replace": {
-            "type": "string",
-            "description": "The file to be replaced.",
-            "x-completion-type": "file"
-          },
-          "with": {
-            "type": "string",
-            "description": "The file to replace with.",
-            "x-completion-type": "file"
-          }
-        },
-        "additionalProperties": false,
-        "required": ["replace", "with"]
-      },
-      "default": []
-    },
     "emptyOutDir": {
       "description": "When set to false, outputPath will not be emptied during the build process.",
       "type": "boolean",

--- a/packages/nx-plugin/src/utils/versions/ng_18_X/versions.ts
+++ b/packages/nx-plugin/src/utils/versions/ng_18_X/versions.ts
@@ -1,15 +1,15 @@
 // V18_X
-export const V18_X_ANALOG_JS_ROUTER = '^1.5.0';
-export const V18_X_ANALOG_JS_CONTENT = '^1.5.0';
+export const V18_X_ANALOG_JS_ROUTER = '^1.7.0';
+export const V18_X_ANALOG_JS_CONTENT = '^1.7.0';
 export const V18_X_MARKED = '^5.0.2';
 export const V18_X_MARKED_GFM_HEADING_ID = '^3.0.4';
 export const V18_X_MARKED_HIGHLIGHT = '^2.0.1';
 export const V18_X_PRISMJS = '^1.29.0';
 
 // devDependencies
-export const V18_X_ANALOG_JS_PLATFORM = '^1.5.0';
-export const V18_X_ANALOG_JS_VITE_PLUGIN_ANGULAR = '^1.5.0';
-export const V18_X_ANALOG_JS_VITEST_ANGULAR = '^1.5.0';
+export const V18_X_ANALOG_JS_PLATFORM = '^1.7.0';
+export const V18_X_ANALOG_JS_VITE_PLUGIN_ANGULAR = '^1.7.0';
+export const V18_X_ANALOG_JS_VITEST_ANGULAR = '^1.7.0';
 export const V18_X_NX_ANGULAR = '~19.1.0';
 export const V18_X_NX_VITE = '~19.1.0';
 export const V18_X_JSDOM = '^22.0.0';


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1040
Closes #1241

## What is the new behavior?

- The `fileReplacements` property in the schema doesn't do anything. Removing it so it will show a validation error. 
- Docs have been added on setting up environments in the Analog migration guide https://analogjs.org/docs/guides/migrating

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
