### PR TITLE
fix(vite-plugin-angular): disable esbuild during testing to support correct sourcemaps/coverage reports

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -1,4 +1,4 @@
-import { Plugin, UserConfig, transformWithEsbuild } from 'vite';
+import { Plugin, transformWithEsbuild } from 'vite';
 
 export function angularVitestPlugin(): Plugin {
   return {
@@ -7,6 +7,8 @@ export function angularVitestPlugin(): Plugin {
     enforce: 'post',
     config(userConfig) {
       return {
+        // Disable esbuild for proper support for sourcemaps/coverage
+        esbuild: false,
         ssr: {
           noExternal: [/cdk\/fesm2022/],
         },


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1211
Closes #1212
Related to https://github.com/vitest-dev/vscode/issues/400

## What is the new behavior?

- Sourcemaps and coverage reports are correct when running tests with Vitest
- The internal vitest plugin disables `esbuild` only during testing

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/ZCi9kgY4xnz84RTU5I/giphy.gif"/>