### PR TITLE
feat(vite-plugin-angular): add internal plugin to detect Storybook environment

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-storybook-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-storybook-plugin.ts
@@ -1,0 +1,15 @@
+export function angularStorybookPlugin() {
+  return {
+    name: 'analogjs-storybook-import-plugin',
+    transform(code: string) {
+      if (code.includes('"@storybook/angular"')) {
+        return code.replace(
+          /\"@storybook\/angular\"/g,
+          '"@storybook/angular/dist/client"'
+        );
+      }
+
+      return;
+    },
+  };
+}

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -32,6 +32,7 @@ import {
   SourceFileCache,
 } from './utils/devkit.js';
 import { angularVitestPlugin } from './angular-vitest-plugin.js';
+import { angularStorybookPlugin } from './angular-storybook-plugin.js';
 
 const require = createRequire(import.meta.url);
 
@@ -136,6 +137,11 @@ export function angular(options?: PluginOptions): Plugin[] {
   const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
   const isStackBlitz = !!process.versions['webcontainer'];
   const isAstroIntegration = process.env['ANALOG_ASTRO'] === 'true';
+  const isStorybook =
+    process.env['npm_lifecycle_script']?.includes('storybook') ||
+    process.env['_']?.includes('storybook') ||
+    process.env['ANALOG_STORYBOOK'] === 'true';
+
   const jit =
     typeof pluginOptions?.jit !== 'undefined' ? pluginOptions.jit : isTest;
   let viteServer: ViteDevServer | undefined;
@@ -404,6 +410,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       isProd,
       supportedBrowsers: pluginOptions.supportedBrowsers,
     }),
+    (isStorybook && angularStorybookPlugin()) as Plugin,
   ].filter(Boolean) as Plugin[];
 
   function findAnalogFiles(config: ResolvedConfig) {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Adds an internal plugin to detect the storybook command and enable the storybook plugin for zero config usage

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/teUZA3PGsRDQHDJ8Mo/giphy.gif"/>