### PR TITLE
docs: add zh-hans on support and og image page

### DIFF
--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current.json
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current.json
@@ -112,6 +112,10 @@
     "message": "Angular Material",
     "description": "The label for the doc item Angular Material in sidebar docsSidebar, linking to the doc integrations/angular-material/index"
   },
+  "sidebar.docsSidebar.doc.Storybook": {
+    "message": "Storybook",
+    "description": "The label for the doc item Storybook in sidebar docsSidebar, linking to the doc integrations/storybook/index"
+  },
   "sidebar.docsSidebar.category.Experimental": {
     "message": "实验性功能",
     "description": "The label for category Experimental in sidebar docsSidebar"

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current.json
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current.json
@@ -23,6 +23,10 @@
     "message": "API路由",
     "description": "The label for category API Routes in sidebar docsSidebar"
   },
+  "sidebar.docsSidebar.doc.OG Image Generation": {
+    "message": "OG 图片生成",
+    "description": "The label for doc item OG Image Generation in sidebar docsSidebar"
+  },
   "sidebar.docsSidebar.category.Data Fetching": {
     "message": "数据获取",
     "description": "The label for category Data Fetching in sidebar docsSidebar"
@@ -127,5 +131,9 @@
   "sidebar.docsSidebar.doc.Sponsoring": {
     "message": "赞助",
     "description": "The label for the doc item Sponsoring in sidebar docsSidebar, linking to the doc sponsoring"
+  },
+  "sidebar.docsSidebar.doc.Support": {
+    "message": "支持",
+    "description": "The label for the doc item Support in sidebar docsSidebar, linking to the doc support"
   }
 }

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/api/og-image-generation.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/api/og-image-generation.md
@@ -1,0 +1,103 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# 开放图谱 (OG) 图片生成
+
+开放图谱图片可以用来在例如：Twitter/X，LinkedIn，Facebook 等社交媒体上分享时展示页面的预览。Analog 支持通过[API Routes](./overview)来生成开放图谱图片
+
+## 设置
+
+首先，安装所需的 [satori](https://github.com/vercel/satori) 依赖：
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install satori satori-html sharp --save
+```
+
+  </TabItem>
+
+  <TabItem label="Yarn" value="yarn">
+
+```shell
+yarn add satori satori-html sharp
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install -w satori satori-html sharp
+```
+
+  </TabItem>
+</Tabs>
+
+## 设置一个 API 路由
+
+然后，在 `src/server/routes` 目录下定义一个 API 路由。
+
+```ts
+// src/server/routes/v1/og-images.ts
+import { defineEventHandler, getQuery } from 'h3';
+
+import { ImageResponse } from '@analogjs/content/og';
+
+export default defineEventHandler(async (event) => {
+  const fontFile = await fetch(
+    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff'
+  );
+  const fontData: ArrayBuffer = await fontFile.arrayBuffer();
+  const query = getQuery(event); // query params
+
+  const template = `
+    <div tw="bg-gray-50 flex w-full h-full items-center justify-center">
+        <div tw="flex flex-col md:flex-row w-full py-12 px-4 md:items-center justify-between p-8">
+          <h2 tw="flex flex-col text-3xl sm:text-4xl font-bold tracking-tight text-gray-900 text-left">
+            <span>${query['title'] ? `${query['title']}` : 'Hello World'}</span>
+          </h2>
+        </div>
+      </div>    
+  `;
+
+  return new ImageResponse(template, {
+    debug: true, // disable caching
+    fonts: [
+      {
+        name: 'Inter Latin',
+        data: fontData,
+        style: 'normal',
+      },
+    ],
+  });
+});
+```
+
+- 该 API 路由从 `@analogjs/content/og` 子包中引用了 `ImageResponse` 类。
+- 提供的 HTML 被渲染成了 png 图像。
+- 支持 Tailwind 类，而且是可选的。
+
+## 添加开放图谱元数据
+
+开放图谱图片由 HTML 里的 `head` 标签里的 meta 标签注册。
+
+```html
+<html>
+  <head>
+    <meta
+      property="og:image"
+      content="https://your-url.com/api/v1/og-images?name=Developer"
+    />
+    <meta
+      name="twitter:image"
+      content="https://your-url.com/api/v1/og-images?name=Developer"
+      key="twitter:image"
+    />
+    ...
+  </head>
+</html>
+```
+
+meta 标签可以通过在 `index.html` 里手动设置或者通过 [Route Metadata](/docs/features/routing/metadata#open-graph-meta-tags) 动态设置。

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/integrations/storybook/index.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/integrations/storybook/index.md
@@ -61,7 +61,7 @@ bun install @analogjs/vite-plugin-angular @storybook/builder-vite --save-dev
   </TabItem>  
 </Tabs>
 
-## 配置 Storybook 使用 View 构建器
+## 配置 Storybook 使用 Vite 构建器
 
 更新 `.storybook/main.ts` 文件并使用 `@storybook/builder-vite` 并且添加 `viteFinal` 配置函数来配置 Angular 的 Vite 插件。
 

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/integrations/storybook/index.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/integrations/storybook/index.md
@@ -1,0 +1,156 @@
+---
+sidebar_position: 3
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# 用 Vite 集成 Storybook
+
+[Storybook](https://storybook.js.org) 是一个用于独立构建 UI 组件和页面的前端工作室。
+
+默认情况下，Angular 和 Storybook 使用 Webpack 构建和提供 Storybook 应用。
+
+这里将展示如何切换成用 Angular 和 Vite 来构建和提供 Storybook 应用。这个向导也适用于 _任何_ 集成 Storybook 的 Angular 项目。
+
+## 设置 Storybook
+
+如果你还没有设置 Storybook，运行下面的命令在你的项目里初始化 Storybook：
+
+```sh
+npx storybook@latest init
+```
+
+按照提供的指示继续，并且提交你的变更。
+
+## 安装 Storybook 和 Vite 包
+
+安装 Angular 的 Vite 插件和 Storybook 的 Vite 构建器。按照你使用的包管理器，运行下面的命令：
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install @analogjs/vite-plugin-angular @storybook/builder-vite --save-dev
+```
+
+  </TabItem>
+
+  <TabItem label="yarn" value="yarn">
+
+```shell
+yarn add @analogjs/vite-plugin-angular @storybook/builder-vite --dev
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install @analogjs/vite-plugin-angular @storybook/builder-vite -w --save-dev
+```
+
+  </TabItem>
+
+  <TabItem value="bun">
+
+```shell
+bun install @analogjs/vite-plugin-angular @storybook/builder-vite --save-dev
+```
+
+  </TabItem>  
+</Tabs>
+
+## 配置 Storybook 使用 View 构建器
+
+更新 `.storybook/main.ts` 文件并使用 `@storybook/builder-vite` 并且添加 `viteFinal` 配置函数来配置 Angular 的 Vite 插件。
+
+```ts
+import { StorybookConfig } from '@storybook/angular';
+import { StorybookConfigVite } from '@storybook/builder-vite';
+import { UserConfig } from 'vite';
+
+const config: StorybookConfig & StorybookConfigVite = {
+  // other config, addons, etc.
+  core: {
+    builder: {
+      name: '@storybook/builder-vite',
+      options: {
+        viteConfigPath: undefined,
+      },
+    },
+  },
+  async viteFinal(config: UserConfig) {
+    // Merge custom configuration into the default config
+    const { mergeConfig } = await import('vite');
+    const { default: angular } = await import('@analogjs/vite-plugin-angular');
+
+    return mergeConfig(config, {
+      // Add dependencies to pre-optimization
+      optimizeDeps: {
+        include: [
+          '@storybook/angular',
+          '@storybook/angular/dist/client',
+          '@angular/compiler',
+          '@storybook/blocks',
+          'tslib',
+        ],
+      },
+      plugins: [angular({ jit: true, tsconfig: './.storybook/tsconfig.json' })],
+    });
+  },
+};
+```
+
+移除现有的 `webpackFinal` 配置函数。
+
+然后，更新 `package.json` 来直接运行 Storybook 命令。
+
+```json
+{
+  "name": "my-app",
+  "scripts": {
+    "storybook": "storybook dev --port 4400",
+    "build-storybook": "storybook build"
+  }
+}
+```
+
+> 你还可以删除 angular.json 里的 Storybook 目标
+
+如果你用的是 [Nx](https://nx.dev)，更新你的 `project.json` storybook 目标为运行 Storybook 命令：
+
+```json
+    "storybook": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/my-app",
+        "command": "storybook dev --port 4400"
+      }
+    },
+    "build-storybook": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/my-app",
+        "command": "storybook build --output-dir ../../dist/storybook/my-app"
+      }
+    }
+```
+
+添加 `/storybook-static` 目录到你的 `.gitignore` 文件里。
+
+## 运行 Storybook
+
+直接运行 storybook 命令来启动开发服务器。
+
+```sh
+npm run storybook
+```
+
+## 构建 Storybook
+
+运行以下命令来构建 storybook。
+
+```sh
+npm run build-storybook
+```

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/integrations/storybook/index.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/integrations/storybook/index.md
@@ -63,7 +63,7 @@ bun install @analogjs/vite-plugin-angular @storybook/builder-vite --save-dev
 
 ## 配置 Storybook 使用 Vite 构建器
 
-更新 `.storybook/main.ts` 文件并使用 `@storybook/builder-vite` 并且添加 `viteFinal` 配置函数来配置 Angular 的 Vite 插件。
+更新 `.storybook/main.ts` 文件以使用 `@storybook/builder-vite`，并且添加 `viteFinal` 配置函数来配置 Angular 的 Vite 插件。
 
 ```ts
 import { StorybookConfig } from '@storybook/angular';

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/support.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/support.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 5
+---
+
+# 支持
+
+无论您是独立开发者还是一个大型企业，都可以在这里找到支持！
+
+## Discord
+
+[Discord Server](https://chat.analogjs.org) 提供以下支持：
+
+- 社区支持
+- Q&A
+- 聊天
+
+## GitHub
+
+Analog 的[源码](https://github.com/analogjs/analog)基于 MIT 协议，免费并且是开源的。您可以通过以下形式发起常规的支持：
+
+- Bug 上报
+- 功能需求
+- 合并请求
+- 常规[贡献](/docs/contributing)
+
+## 专属支持
+
+我们通过以下方式提供专属支持：
+
+- 架构咨询
+- 企业支持合同
+- 付费咨询
+- 研讨会/工作坊
+
+- 安排一个 [会议](https://calendly.com/brandontroberts/session) 或者直接 [联系我们](mailto:support@analogjs.org?subject=Dedicated+Support) 来商讨专属支持。

--- a/apps/docs-app/i18n/zh-hans/docusaurus-theme-classic/navbar.json
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-theme-classic/navbar.json
@@ -7,6 +7,10 @@
     "message": "文档",
     "description": "Navbar item with label Docs"
   },
+  "item.label.Support": {
+    "message": "支持",
+    "description": "Navbar item with label Support"
+  },
   "item.label.GitHub": {
     "message": "GitHub",
     "description": "Navbar item with label GitHub"


### PR DESCRIPTION
## PR Checklist

add zh-hans on [support](https://analogjs.org/docs/support), [og image generation](https://analogjs.org/docs/features/api/og-image-generation) and [storybook](https://analogjs.org/docs/integrations/storybook) pages

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->