### PR TITLE
feat(vite-plugin-angular): include frontmatter in markdown transform content

### DIFF
--- a/packages/vite-plugin-angular/src/lib/authoring/constants.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/constants.ts
@@ -11,6 +11,7 @@ export const SCRIPT_TAG_REGEX = /<script lang="ts">([\s\S]*?)<\/script>/i;
 export const TEMPLATE_TAG_REGEX =
   /(<template(?:\s+([^>]*?))?>)([\s\S]*?)<\/template>/i;
 export const STYLE_TAG_REGEX = /<style>([\s\S]*?)<\/style>/i;
+export const FRONTMATTER_REGEX = /^\s*---[\s\S]*?---/;
 
 export const ON_INIT = 'onInit';
 export const ON_DESTROY = 'onDestroy';

--- a/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
@@ -1,3 +1,5 @@
+import { FRONTMATTER_REGEX } from './constants.js';
+
 export type MarkdownTemplateTransform = (
   content: string,
   fileName: string
@@ -11,7 +13,9 @@ export const defaultMarkdownTemplateTransform: MarkdownTemplateTransform =
     const markedSetupService = new MarkedSetupService();
     const mdContent = markedSetupService
       .getMarkedInstance()
-      .parse(content) as unknown as Promise<string>;
+      .parse(
+        content.replace(FRONTMATTER_REGEX, '')
+      ) as unknown as Promise<string>;
 
     return mdContent;
   };

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -4,7 +4,10 @@ import { normalizePath } from 'vite';
 import { readFileSync } from 'node:fs';
 import * as ts from 'typescript';
 import { compileAnalogFile } from './authoring/analog.js';
-import { TEMPLATE_TAG_REGEX } from './authoring/constants.js';
+import {
+  FRONTMATTER_REGEX,
+  TEMPLATE_TAG_REGEX,
+} from './authoring/constants.js';
 import { MarkdownTemplateTransform } from './authoring/markdown-transform.js';
 
 import { createRequire } from 'node:module';
@@ -89,7 +92,10 @@ export function augmentHostWithResources(
         const templateContent =
           TEMPLATE_TAG_REGEX.exec(fileContent)?.pop()?.trim() || '';
 
-        return templateContent;
+        const frontmatterContent =
+          FRONTMATTER_REGEX.exec(fileContent)?.pop()?.trim() || '';
+
+        return frontmatterContent + '\n\n' + templateContent;
       }
 
       return baseReadFile.call(resourceHost, fileName);

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -92,10 +92,15 @@ export function augmentHostWithResources(
         const templateContent =
           TEMPLATE_TAG_REGEX.exec(fileContent)?.pop()?.trim() || '';
 
-        const frontmatterContent =
-          FRONTMATTER_REGEX.exec(fileContent)?.pop()?.trim() || '';
+        const frontmatterContent = FRONTMATTER_REGEX.exec(fileContent)
+          ?.pop()
+          ?.trim();
 
-        return frontmatterContent + '\n\n' + templateContent;
+        if (frontmatterContent) {
+          return frontmatterContent + '\n\n' + templateContent;
+        }
+
+        return templateContent;
       }
 
       return baseReadFile.call(resourceHost, fileName);


### PR DESCRIPTION
## PR Checklist

Markdown template transforms may want to perform some transformation based on some information in the front matter of a file, but currently only the content of the `<template>` tag is passed to the transform:

```ts
    if (fileName.includes('virtual-analog:')) {
      for (const transform of options.markdownTemplateTransforms || []) {
        content = await transform(content, fileName);
      }
    }
```

In the code above, `content` is the contents of the `<template>`, but front matter is placed outside of the template tag.

## What is the new behavior?

The `content` passed to the transform will now have the front matter added to the beginning if it exists, such that is has the structure of a standard markdown file with front matter, e.g:

```
---
title: hello
---

## My post
```

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This will be breaking for anyone using custom markdown transforms as the value being passed to the transform will change if front matter exists on the file. However, this is still listed under experimental vite settings and all that is required for migration is for the transform to be updated to handle the front matter in some way (which could be to just strip the front matter from the file as is being done for the default transform in this PR)

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/NTtoU4hkyq8W48re2f/giphy.gif"/>
