### PR TITLE
fix(vite-plugin-angular): remove deprecated parameter from marked

### DIFF
--- a/packages/vite-plugin-angular/src/lib/authoring/marked-setup.service.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/marked-setup.service.ts
@@ -106,10 +106,6 @@ export class MarkedSetupService {
         pedantic: false,
         gfm: true,
         breaks: false,
-        sanitize: false,
-        smartypants: false,
-        xhtml: false,
-        mangle: false,
       }
     );
 


### PR DESCRIPTION
these parameters are now enabled via separate npm packages. They're set to `false` here which means we don't need to do anything extra

## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
