### PR TITLE
fix(nx-plugin): typo that causes Nx graph to crash

### DIFF
--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/.eslintrc.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/.eslintrc.json__template__
@@ -29,7 +29,7 @@
     },
     {
       "files": ["*.html"],
-      "extends": ["plugin:<%= nxPackageNamespace %>/nx/angular-template"],
+      "extends": ["plugin:<%= nxPackageNamespace %>/angular-template"],
       "rules": {}
     }
   ]

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/.eslintrc.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/.eslintrc.json__template__
@@ -5,7 +5,7 @@
     {
       "files": ["*.ts"],
       "extends": [
-        "plugin:<%= nxPackageNamespace %>/nx/angular",
+        "plugin:<%= nxPackageNamespace %>/angular",
         "plugin:@angular-eslint/template/process-inline-templates"
       ],
       "rules": {

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/.eslintrc.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/.eslintrc.json__template__
@@ -5,7 +5,7 @@
     {
       "files": ["*.ts"],
       "extends": [
-        "plugin:<%= nxPackageNamespace %>/nx/angular",
+        "plugin:<%= nxPackageNamespace %>/angular",
         "plugin:@angular-eslint/template/process-inline-templates"
       ],
       "rules": {
@@ -29,7 +29,7 @@
     },
     {
       "files": ["*.html"],
-      "extends": ["plugin:<%= nxPackageNamespace %>/nx/angular-template"],
+      "extends": ["plugin:<%= nxPackageNamespace %>/angular-template"],
       "rules": {}
     }
   ]

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v17/.eslintrc.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v17/.eslintrc.json__template__
@@ -5,7 +5,7 @@
     {
       "files": ["*.ts"],
       "extends": [
-        "plugin:<%= nxPackageNamespace %>/nx/angular",
+        "plugin:<%= nxPackageNamespace %>/angular",
         "plugin:@angular-eslint/template/process-inline-templates"
       ],
       "rules": {
@@ -29,7 +29,7 @@
     },
     {
       "files": ["*.html"],
-      "extends": ["plugin:<%= nxPackageNamespace %>/nx/angular-template"],
+      "extends": ["plugin:<%= nxPackageNamespace %>/angular-template"],
       "rules": {}
     }
   ]

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v18/.eslintrc.json__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v18/.eslintrc.json__template__
@@ -5,7 +5,7 @@
     {
       "files": ["*.ts"],
       "extends": [
-        "plugin:<%= nxPackageNamespace %>/nx/angular",
+        "plugin:<%= nxPackageNamespace %>/angular",
         "plugin:@angular-eslint/template/process-inline-templates"
       ],
       "rules": {
@@ -29,7 +29,7 @@
     },
     {
       "files": ["*.html"],
-      "extends": ["plugin:<%= nxPackageNamespace %>/nx/angular-template"],
+      "extends": ["plugin:<%= nxPackageNamespace %>/angular-template"],
       "rules": {}
     }
   ]


### PR DESCRIPTION


## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I've been having this error when I create an app with Nx 
```
Failed to process project graph. Run "nx reset" to fix this. Please report the issue if you keep seeing it.
  An error occurred while processing files for the @nx/eslint/plugin plugin.
    - apps/blog/.eslintrc.json: Failed to load plugin '@nx/nx' declared in '.eslintrc.json#overrides[0]': Cannot find module '@nx/eslint-plugin-nx'
  Require stack:
  - /Users/ngilyass/projects/confs/findRally/apps/blog/__placeholder__.js
  Referenced from: /Users/ngilyass/projects/confs/findRally/apps/blog/.eslintrc.json
      Error: Failed to load plugin '@nx/nx' declared in '.eslintrc.json#overrides[0]': Cannot find module '@nx/eslint-plugin-nx'
      Require stack:
      - /Users/ngilyass/projects/confs/findRally/apps/blog/__placeholder__.js
      Referenced from: /Users/ngilyass/projects/confs/findRally/apps/blog/.eslintrc.json
          at Module._resolveFilename (node:internal/modules/cjs/loader:1152:15)
          at Function.resolve (node:internal/modules/helpers:190:19)
          at Object.resolve (/Users/ngilyass/projects/confs/findRally/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2346:46)
          at ConfigArrayFactory._loadPlugin (/Users/ngilyass/projects/confs/findRally/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3414:33)
          at ConfigArrayFactory._loadExtendedPluginConfig (/Users/ngilyass/projects/confs/findRally/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3233:29)
          at ConfigArrayFactory._loadExtends (/Users/ngilyass/projects/confs/findRally/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3154:29)
          at ConfigArrayFactory._normalizeObjectConfigDataBody (/Users/ngilyass/projects/confs/findRally/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3095:25)
          at _normalizeObjectConfigDataBody.next (<anonymous>)
          at ConfigArrayFactory._normalizeObjectConfigData (/Users/ngilyass/projects/confs/findRally/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3040:20)
          at _normalizeObjectConfigData.next (<anonymous>)
```

when changed the correct eslint plugin to extends it works
Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

https://giphy.com/gifs/shrempin-vibin-shremp-shremps-mxmlZQOcN5FapMUrq6
