### PR TITLE
fix(vite-plugin-angular): fix optimization bug with bundles w/o side effects

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -52,6 +52,7 @@ export function buildOptimizerPlugin({
         const result: Uint8Array = await javascriptTransformer.transformData(
           id,
           code,
+          false,
           false
         );
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Noticed a bug where a minimal build using Zoneless/Vite was 222kb vs Angular CLI build was 99kb. Packages with no side effects were being processed correctly. This ensures the same optimization happens and reduces the bundle size.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/h7A2h9cMFdJhTgNHaX/giphy.gif"/>