### PR TITLE
fix(vitest-angular): pass custom config file path to runner

### DIFF
--- a/packages/vitest-angular/src/lib/vitest.impl.ts
+++ b/packages/vitest-angular/src/lib/vitest.impl.ts
@@ -24,6 +24,7 @@ async function vitestBuilder(
   const config = {
     root: `${projectConfig['root'] || '.'}`,
     watch: options.watch === true,
+    config: options.configFile,
     ...extraArgs,
   };
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1331 

## What is the new behavior?

Passing the `--config` option on the command line is processed correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/Zp3dDTwtkKKU8/giphy.gif"/>
