### PR TITLE
fix(vite-plugin-angular): mark @angular/compiler with sideEffects during jit build

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -4,9 +4,11 @@ import { JavaScriptTransformer } from './utils/devkit.js';
 
 export function buildOptimizerPlugin({
   isProd,
+  jit,
 }: {
   isProd: boolean;
   supportedBrowsers: string[];
+  jit: boolean;
 }): Plugin {
   const javascriptTransformer = new JavaScriptTransformer(
     {
@@ -49,11 +51,13 @@ export function buildOptimizerPlugin({
           };
         }
 
+        const sideEffects =
+          jit && id.includes('@angular/compiler') ? true : false;
         const result: Uint8Array = await javascriptTransformer.transformData(
           id,
           code,
           false,
-          false
+          sideEffects
         );
 
         return {

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -412,6 +412,7 @@ export function angular(options?: PluginOptions): Plugin[] {
     buildOptimizerPlugin({
       isProd,
       supportedBrowsers: pluginOptions.supportedBrowsers,
+      jit,
     }),
     (isStorybook && angularStorybookPlugin()) as Plugin,
   ].filter(Boolean) as Plugin[];


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When doing a JIT build, the angular compiler should not be marked as side-effect free.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
