### PR TITLE
fix(vitest-angular): setup separate import for configuring snapshots

### DIFF
--- a/apps/docs-app/docs/features/testing/vitest.md
+++ b/apps/docs-app/docs/features/testing/vitest.md
@@ -1,11 +1,11 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Adding Vitest To An Existing Project
+# Using Vitest with An Angular Project
 
-[Vitest](https://vitest.dev) can be added to existing Angular workspaces with a few steps.
+[Vitest](https://vitest.dev) can be added to **_any_** existing Angular project with a few steps.
 
-## Using a Schematic/Generator
+## Automated Setup Using a Schematic/Generator
 
 Vitest can be installed and setup using a schematic/generator for Angular CLI or Nx workspaces.
 
@@ -102,8 +102,31 @@ export default defineConfig(({ mode }) => ({
 
 Next, define a `src/test-setup.ts` file to setup the `TestBed`:
 
+### Zone.js setup
+
+If you are using `Zone.js` for change detection, import the `setup-zone` script. This script automatically includes support for setting up snapshot tests.
+
 ```ts
 import '@analogjs/vitest-angular/setup-zone';
+
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+import { getTestBed } from '@angular/core/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+```
+
+### Zoneless setup
+
+If you are using `Zoneless` change detection, only import the `setup-snapshots` script.
+
+```ts
+import '@analogjs/vitest-angular/setup-snapshots';
 
 import {
   BrowserDynamicTestingModule,
@@ -226,6 +249,24 @@ export default defineConfig(({ mode }) => ({
 }));
 ```
 
+Next, add the `@angular/compiler` import to the `src/test-setup.ts` file.
+
+```ts
+import '@angular/compiler';
+import '@analogjs/vitest-angular/setup-zone';
+
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+import { getTestBed } from '@angular/core/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+```
+
 ## Running Tests
 
 To run unit tests, use the `test` command:
@@ -255,6 +296,8 @@ pnpm test
 
   </TabItem>
 </Tabs>
+
+> The `npx vitest` command can also be used directly.
 
 ## Snapshot Testing
 

--- a/packages/vitest-angular/README.md
+++ b/packages/vitest-angular/README.md
@@ -2,6 +2,13 @@
 
 A standalone builder for running tests with Vitest and Angular.
 
+## Supporting Analog
+
+- Star the [GitHub Repo](https://github.com/analogjs/analog)
+- Join the [Discord](https://chat.analogjs.org)
+- Follow us on [Twitter](https://twitter.com/analogjs)
+- Become a [Sponsor](https://analogjs.org/docs/sponsoring)
+
 ## Installation
 
 Use your package manager of choice to install the necessary packages.
@@ -79,6 +86,23 @@ Next, define a `src/test-setup.ts` file to setup the `TestBed`:
 
 ```ts
 import '@analogjs/vitest-angular/setup-zone';
+
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+import { getTestBed } from '@angular/core/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+```
+
+If you are using `Zoneless` change detection, only import the `setup-snapshots` script.
+
+```ts
+import '@analogjs/vitest-angular/setup-snapshots';
 
 import {
   BrowserDynamicTestingModule,
@@ -230,9 +254,18 @@ export default defineConfig(({ mode }) => ({
 }));
 ```
 
-## Supporting Analog
+### With Nx
 
-- Star the [GitHub Repo](https://github.com/analogjs/analog)
-- Join the [Discord](https://chat.analogjs.org)
-- Follow us on [Twitter](https://twitter.com/analogjs)
-- Become a [Sponsor](https://analogjs.org/docs/sponsoring)
+For Nx workspaces, import and use the `nxViteTsPaths` plugin from the `@nx/vite` package.
+
+```ts
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+import angular from '@analogjs/vite-plugin-angular';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig(({ mode }) => ({
+  plugins: [angular(), nxViteTsPaths()],
+}));
+```

--- a/packages/vitest-angular/project.json
+++ b/packages/vitest-angular/project.json
@@ -17,7 +17,10 @@
           "packages/vitest-angular/builders.json"
         ],
         "updateBuildableProjectDepsInPackageJson": false,
-        "additionalEntryPoints": ["packages/vitest-angular/setup-zone.ts"],
+        "additionalEntryPoints": [
+          "packages/vitest-angular/setup-zone.ts",
+          "packages/vitest-angular/setup-snapshots.ts"
+        ],
         "generateExportsField": true
       }
     }

--- a/packages/vitest-angular/setup-snapshots.ts
+++ b/packages/vitest-angular/setup-snapshots.ts
@@ -1,0 +1,141 @@
+const env = globalThis as any;
+
+/**
+ * Allows Vitest to handle Angular test fixtures
+ *
+ * Vitest Snapshot guide ==> https://vitest.dev/guide/snapshot.html
+ *
+ * @returns customSnapshotSerializer for Angular Fixture Component
+ */
+const customSnapshotSerializer = () => {
+  function serialize(
+    val: any,
+    config: any,
+    indentation: any,
+    depth: any,
+    refs: any,
+    printer: any
+  ): string {
+    // `printer` is a function that serializes a value using existing plugins.
+    return `${printer(
+      fixtureVitestSerializer(val),
+      config,
+      indentation,
+      depth,
+      refs
+    )}`;
+  }
+  function test(val: any): boolean {
+    // * If it's a ComponentFixture we apply the transformation rules
+    return val && isAngularFixture(val);
+  }
+  return {
+    serialize,
+    test,
+  };
+};
+
+/**
+ * Check if is an Angular fixture
+ *
+ * @param val Angular fixture
+ * @returns boolean who check if is an angular fixture
+ */
+function isAngularFixture(val: any): boolean {
+  if (typeof val !== 'object') {
+    return false;
+  }
+
+  if (val['componentRef'] || val['componentInstance']) {
+    return true;
+  }
+
+  if (val['componentType']) {
+    return true;
+  }
+
+  // * Angular fixture keys in Fixture component Object
+  const fixtureKeys = [
+    'componentRef',
+    'ngZone',
+    'effectRunner',
+    '_autoDetect',
+    '_isStable',
+    '_isDestroyed',
+    '_resolve',
+    '_promise',
+    '_onUnstableSubscription',
+    '_onStableSubscription',
+    '_onMicrotaskEmptySubscription',
+    '_onErrorSubscription',
+    'changeDetectorRef',
+    'elementRef',
+    'debugElement',
+    'componentInstance',
+    'nativeElement',
+  ];
+
+  // * Angular fixture keys in Fixture componentRef Object
+  const fixtureComponentRefKeys = [
+    'location',
+    '_rootLView',
+    '_tNode',
+    'previousInputValues',
+    'instance',
+    'changeDetectorRef',
+    'hostView',
+    'componentType',
+  ];
+
+  return (
+    JSON.stringify(Object.keys(val)) === JSON.stringify(fixtureKeys) ||
+    JSON.stringify(Object.keys(val)) === JSON.stringify(fixtureComponentRefKeys)
+  );
+}
+
+/**
+ * Serialize Angular fixture for Vitest
+ *
+ * @param fixture Angular Fixture Component
+ * @returns HTML Child Node
+ */
+function fixtureVitestSerializer(fixture: any) {
+  // * Get Component meta data
+  const componentType = (
+    fixture && fixture.componentType
+      ? fixture.componentType
+      : fixture.componentRef.componentType
+  ) as any;
+
+  let inputsData: string = '';
+
+  const selector = Reflect.getOwnPropertyDescriptor(
+    componentType,
+    '__annotations__'
+  )?.value[0].selector;
+
+  if (componentType && componentType.propDecorators) {
+    inputsData = Object.entries(componentType.propDecorators)
+      .map(([key, value]) => `${key}="${value}"`)
+      .join('');
+  }
+
+  // * Get DOM Elements
+  const divElement =
+    fixture && fixture.nativeElement
+      ? fixture.nativeElement
+      : fixture.location.nativeElement;
+
+  // * Convert string data to HTML data
+  const doc = new DOMParser().parseFromString(
+    `<${selector} ${inputsData}>${divElement.innerHTML}</${selector}>`,
+    'text/html'
+  );
+
+  return doc.body.childNodes[0];
+}
+
+['expect'].forEach((methodName) => {
+  const originalvitestFn = env[methodName];
+  return originalvitestFn.addSnapshotSerializer(customSnapshotSerializer());
+});

--- a/packages/vitest-angular/setup-zone.ts
+++ b/packages/vitest-angular/setup-zone.ts
@@ -3,6 +3,7 @@ import 'zone.js/plugins/sync-test';
 import 'zone.js/plugins/proxy';
 import 'zone.js/testing';
 
+import './setup-snapshots.js';
 /**
  * Patch Vitest's describe/test/beforeEach/afterEach functions so test code
  * always runs in a testZone (ProxyZone).
@@ -67,141 +68,6 @@ function wrapTestInZone(testBody: string | any[] | undefined) {
   }
 
   return wrappedFunc;
-}
-
-/**
- * Allows Vitest to handle Angular test fixtures
- *
- * Vitest Snapshot guide ==> https://vitest.dev/guide/snapshot.html
- *
- * @returns customSnapshotSerializer for Angular Fixture Component
- */
-const customSnapshotSerializer = () => {
-  function serialize(
-    val: any,
-    config: any,
-    indentation: any,
-    depth: any,
-    refs: any,
-    printer: any
-  ): string {
-    // `printer` is a function that serializes a value using existing plugins.
-    return `${printer(
-      fixtureVitestSerializer(val),
-      config,
-      indentation,
-      depth,
-      refs
-    )}`;
-  }
-  function test(val: any): boolean {
-    // * If it's a ComponentFixture we apply the transformation rules
-    return val && isAngularFixture(val);
-  }
-  return {
-    serialize,
-    test,
-  };
-};
-
-/**
- * Check if is an Angular fixture
- *
- * @param val Angular fixture
- * @returns boolean who check if is an angular fixture
- */
-function isAngularFixture(val: any): boolean {
-  if (typeof val !== 'object') {
-    return false;
-  }
-
-  if (val['componentRef'] || val['componentInstance']) {
-    return true;
-  }
-
-  if (val['componentType']) {
-    return true;
-  }
-
-  // * Angular fixture keys in Fixture component Object
-  const fixtureKeys = [
-    'componentRef',
-    'ngZone',
-    'effectRunner',
-    '_autoDetect',
-    '_isStable',
-    '_isDestroyed',
-    '_resolve',
-    '_promise',
-    '_onUnstableSubscription',
-    '_onStableSubscription',
-    '_onMicrotaskEmptySubscription',
-    '_onErrorSubscription',
-    'changeDetectorRef',
-    'elementRef',
-    'debugElement',
-    'componentInstance',
-    'nativeElement',
-  ];
-
-  // * Angular fixture keys in Fixture componentRef Object
-  const fixtureComponentRefKeys = [
-    'location',
-    '_rootLView',
-    '_tNode',
-    'previousInputValues',
-    'instance',
-    'changeDetectorRef',
-    'hostView',
-    'componentType',
-  ];
-
-  return (
-    JSON.stringify(Object.keys(val)) === JSON.stringify(fixtureKeys) ||
-    JSON.stringify(Object.keys(val)) === JSON.stringify(fixtureComponentRefKeys)
-  );
-}
-
-/**
- * Serialize Angular fixture for Vitest
- *
- * @param fixture Angular Fixture Component
- * @returns HTML Child Node
- */
-function fixtureVitestSerializer(fixture: any) {
-  // * Get Component meta data
-  const componentType = (
-    fixture && fixture.componentType
-      ? fixture.componentType
-      : fixture.componentRef.componentType
-  ) as any;
-
-  let inputsData: string = '';
-
-  const selector = Reflect.getOwnPropertyDescriptor(
-    componentType,
-    '__annotations__'
-  )?.value[0].selector;
-
-  if (componentType && componentType.propDecorators) {
-    inputsData = Object.entries(componentType.propDecorators)
-      .map(([key, value]) => `${key}="${value}"`)
-      .join('');
-  }
-
-  // * Get DOM Elements
-  const divElement =
-    fixture && fixture.nativeElement
-      ? fixture.nativeElement
-      : fixture.location.nativeElement;
-
-  // * Convert string data to HTML data
-  const doc = new DOMParser().parseFromString(
-    `<${selector} ${inputsData}>${divElement.innerHTML}</${selector}>`,
-    'text/html'
-  );
-
-  return doc.body.childNodes[0];
 }
 
 /**
@@ -300,9 +166,4 @@ const bindTest = (
 
     return originalvitestFn.apply(this, args);
   };
-});
-
-['expect'].forEach((methodName) => {
-  const originalvitestFn = env[methodName];
-  return originalvitestFn.addSnapshotSerializer(customSnapshotSerializer());
 });

--- a/packages/vitest-angular/tsconfig.lib.json
+++ b/packages/vitest-angular/tsconfig.lib.json
@@ -5,6 +5,6 @@
     "declaration": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "setup-zone.ts"],
+  "include": ["src/**/*.ts", "setup-zone.ts", "setup-snapshots.ts"],
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- The `@analogjs/vitest-angular/setup-snapshots` import can be used with Zoneless testing.
- Updates docs for Zoneless applications

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/l0ErCHMBw3zJ2WyDm/giphy.gif"/>