### PR TITLE
fix(vite-plugin-angular): allow supplying and exporting vfile data for agx files

### DIFF
--- a/apps/ng-app/src/app/models.ts
+++ b/apps/ng-app/src/app/models.ts
@@ -1,0 +1,6 @@
+export interface PostAttributes {
+  title: string;
+  slug: string;
+  description: string;
+  coverImage: string;
+}

--- a/apps/ng-app/src/app/pages/posts.[slug].page.analog
+++ b/apps/ng-app/src/app/pages/posts.[slug].page.analog
@@ -5,31 +5,25 @@ import {
 } from '@analogjs/content';
 import { MarkdownComponent } from '@analogjs/content' with { analog: 'imports' }
 import { RouteMeta } from '@analogjs/router';
-import { AsyncPipe, JsonPipe, NgFor, NgIf } from '@angular/common' with { analog: 'imports'};
-import { Component, inject } from '@angular/core';
+import { effect, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs';
 
-import { PostAttributes } from './models';
+import { PostAttributes } from '../models';
 
 const renderer = inject(ContentRenderer);
 const post$ = injectContent<PostAttributes>();
 
-const toc$ = post$.pipe(
-  map(() => {
-    return renderer.getContentHeadings();
-  })
-);
+const postSignal = toSignal(post$);
+
+effect(() => {
+  console.log(postSignal());
+})
 </script>
 
-<template><ng-container *ngIf="post$ | async as post">
-  <h1>{{ post.attributes.title }}</h1>
-  <div *ngIf="toc$ | async as toc">
-    <ul>
-      <li *ngFor="let item of toc">
-        <a href="#{{ item.id }}">{{ item.text }}</a>
-      </li>
-    </ul>
-  </div>
-
-  <analog-markdown [content]="post.content"></analog-markdown>
-</ng-container></template>
+<template>
+  @if(postSignal(); as post){
+    <h1>{{ post.attributes.title }}</h1>
+    <analog-markdown [content]="post.content"></analog-markdown>
+  }
+</template>

--- a/apps/ng-app/vite.config.ts
+++ b/apps/ng-app/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig(({ mode }) => ({
       vite: {
         experimental: {
           supportAnalogFormat: true,
-          markdownTemplateTransforms: [],
+          markdownTemplateTransforms: [vFileTemplateTransform],
         },
       },
     }),
@@ -46,7 +46,9 @@ export default defineConfig(({ mode }) => ({
 // adding vfile data in markdown transform
 export const vFileTemplateTransform = async (content: string) => {
   return {
-    content: 'transformed content',
-    vfile: { data: { headings: { title: 'hello' } } },
+    data: { headings: { title: 'hello' } },
+    toString() {
+      return 'this is the content';
+    },
   };
 };

--- a/apps/ng-app/vite.config.ts
+++ b/apps/ng-app/vite.config.ts
@@ -2,6 +2,7 @@
 
 import { defineConfig } from 'vite';
 import analog from '@analogjs/platform';
+import { type VFile } from 'vfile';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -22,7 +23,6 @@ export default defineConfig(({ mode }) => ({
       vite: {
         experimental: {
           supportAnalogFormat: true,
-          markdownTemplateTransforms: [],
         },
       },
     }),
@@ -53,5 +53,5 @@ const vFileTemplateTransform = async (content: string) => {
     toString() {
       return 'this is the transformed content';
     },
-  };
+  } as unknown as VFile;
 };

--- a/apps/ng-app/vite.config.ts
+++ b/apps/ng-app/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig(({ mode }) => ({
       vite: {
         experimental: {
           supportAnalogFormat: true,
+          markdownTemplateTransforms: [],
         },
       },
     }),
@@ -41,3 +42,11 @@ export default defineConfig(({ mode }) => ({
     'import.meta.vitest': mode !== 'production',
   },
 }));
+
+// adding vfile data in markdown transform
+export const vFileTemplateTransform = async (content: string) => {
+  return {
+    content: 'transformed content',
+    vfile: { data: { headings: { title: 'hello' } } },
+  };
+};

--- a/apps/ng-app/vite.config.ts
+++ b/apps/ng-app/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig(({ mode }) => ({
       vite: {
         experimental: {
           supportAnalogFormat: true,
-          markdownTemplateTransforms: [vFileTemplateTransform],
+          markdownTemplateTransforms: [],
         },
       },
     }),
@@ -43,12 +43,15 @@ export default defineConfig(({ mode }) => ({
   },
 }));
 
-// adding vfile data in markdown transform
-export const vFileTemplateTransform = async (content: string) => {
+const standardTemplateTransform = async (content: string) => {
+  return 'this is the transformed content';
+};
+
+const vFileTemplateTransform = async (content: string) => {
   return {
     data: { headings: { title: 'hello' } },
     toString() {
-      return 'this is the content';
+      return 'this is the transformed content';
     },
   };
 };

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "ts-morph": "^21.0.1",
     "ts-node": "10.9.1",
     "typescript": "5.4.3",
+    "vfile": "^6.0.3",
     "vite": "^5.3.0",
     "vite-plugin-eslint": "^1.8.1",
     "vite-tsconfig-paths": "4.2.0",

--- a/packages/vite-plugin-angular/package.json
+++ b/packages/vite-plugin-angular/package.json
@@ -36,7 +36,8 @@
     }
   },
   "dependencies": {
-    "ts-morph": "^21.0.0"
+    "ts-morph": "^21.0.0",
+    "vfile": "^6.0.3"
   },
   "ng-update": {
     "packageGroup": [

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -41,7 +41,6 @@ import {
   defaultMarkdownTemplateTransforms,
   MarkdownTemplateTransform,
 } from './authoring/markdown-transform.js';
-import { type VFile } from 'vfile';
 
 export interface PluginOptions {
   tsconfig?: string;
@@ -387,24 +386,12 @@ export function angular(options?: PluginOptions): Plugin[] {
             data = ngFileResult?.content || '';
 
             if (id.includes('.agx')) {
-              const metadata = await getFrontmatterMetadata(code);
-              let vfile: Partial<VFile> = {};
-              for (const transform of pluginOptions.markdownTemplateTransforms ||
-                []) {
-                const result = await transform(code, id);
-                vfile = typeof result === 'object' ? result : vfile;
-              }
+              const metadata = await getFrontmatterMetadata(
+                code,
+                id,
+                pluginOptions.markdownTemplateTransforms || []
+              );
               data += metadata;
-
-              const stringifiedVFile = JSON.stringify({
-                path: vfile.path,
-                data: vfile.data,
-                messages: vfile.messages,
-                history: vfile.history,
-                cwd: vfile.cwd,
-              });
-
-              data += `\n\nexport const vfile = ${stringifiedVFile}`;
             }
           }
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -387,7 +387,14 @@ export function angular(options?: PluginOptions): Plugin[] {
 
             if (id.includes('.agx')) {
               const metadata = await getFrontmatterMetadata(code);
+              let vfile = {};
+              for (const transform of pluginOptions.markdownTemplateTransforms ||
+                []) {
+                const result = await transform(code, id);
+                vfile = typeof result === 'object' ? result.vfile : vfile;
+              }
               data += metadata;
+              data += `\n\nexport const vfile = ${JSON.stringify(vfile)}`;
             }
           }
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -41,6 +41,7 @@ import {
   defaultMarkdownTemplateTransforms,
   MarkdownTemplateTransform,
 } from './authoring/markdown-transform.js';
+import { type VFile } from 'vfile';
 
 export interface PluginOptions {
   tsconfig?: string;
@@ -387,14 +388,23 @@ export function angular(options?: PluginOptions): Plugin[] {
 
             if (id.includes('.agx')) {
               const metadata = await getFrontmatterMetadata(code);
-              let vfile = {};
+              let vfile: Partial<VFile> = {};
               for (const transform of pluginOptions.markdownTemplateTransforms ||
                 []) {
                 const result = await transform(code, id);
                 vfile = typeof result === 'object' ? result : vfile;
               }
               data += metadata;
-              data += `\n\nexport const vfile = ${JSON.stringify(vfile)}`;
+
+              const stringifiedVFile = JSON.stringify({
+                path: vfile.path,
+                data: vfile.data,
+                messages: vfile.messages,
+                history: vfile.history,
+                cwd: vfile.cwd,
+              });
+
+              data += `\n\nexport const vfile = ${stringifiedVFile}`;
             }
           }
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -391,7 +391,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               for (const transform of pluginOptions.markdownTemplateTransforms ||
                 []) {
                 const result = await transform(code, id);
-                vfile = typeof result === 'object' ? result.vfile : vfile;
+                vfile = typeof result === 'object' ? result : vfile;
               }
               data += metadata;
               data += `\n\nexport const vfile = ${JSON.stringify(vfile)}`;

--- a/packages/vite-plugin-angular/src/lib/authoring/frontmatter.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/frontmatter.ts
@@ -1,4 +1,11 @@
-export async function getFrontmatterMetadata(content: string) {
+import { MarkdownTemplateTransform } from './markdown-transform';
+import { type VFile } from 'vfile';
+
+export async function getFrontmatterMetadata(
+  content: string,
+  id: string,
+  transforms: MarkdownTemplateTransform[]
+) {
   const fm: any = await import('front-matter');
   // The `default` property will be available in CommonJS environment, for instance,
   // when running unit tests. It's safe to retrieve `default` first, since we still
@@ -6,7 +13,26 @@ export async function getFrontmatterMetadata(content: string) {
   const frontmatterFn: (code: string) => { attributes: object } =
     fm.default || fm;
 
+  let vfile: Partial<VFile> = {};
+  for (const transform of transforms) {
+    const result = await transform(content, id);
+    vfile = typeof result === 'object' ? result : vfile;
+  }
+
+  const safeVFile = {
+    path: vfile.path,
+    data: vfile.data,
+    messages: vfile.messages,
+    history: vfile.history,
+    cwd: vfile.cwd,
+  };
+
   const { attributes } = frontmatterFn(content);
 
-  return `\n\nexport const metadata = ${JSON.stringify(attributes)}`;
+  const combinedMetadata = {
+    ...attributes,
+    vfile: safeVFile,
+  };
+
+  return `\n\nexport const metadata = ${JSON.stringify(combinedMetadata)}`;
 }

--- a/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
@@ -1,9 +1,10 @@
 import { FRONTMATTER_REGEX } from './constants.js';
+import { type VFile } from 'vfile';
 
 export type MarkdownTemplateTransform = (
   content: string,
   fileName: string
-) => string | Promise<string> | Promise<{ content: string; vfile: object }>;
+) => string | Promise<string> | Promise<VFile>;
 
 export const defaultMarkdownTemplateTransform: MarkdownTemplateTransform =
   async (content: string) => {

--- a/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
@@ -3,7 +3,7 @@ import { FRONTMATTER_REGEX } from './constants.js';
 export type MarkdownTemplateTransform = (
   content: string,
   fileName: string
-) => string | Promise<string>;
+) => string | Promise<string> | Promise<{ content: string; vfile: object }>;
 
 export const defaultMarkdownTemplateTransform: MarkdownTemplateTransform =
   async (content: string) => {

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -133,7 +133,8 @@ export function augmentHostWithResources(
 
     if (fileName.includes('virtual-analog:')) {
       for (const transform of options.markdownTemplateTransforms || []) {
-        content = await transform(content, fileName);
+        const result = await transform(content, fileName);
+        content = typeof result === 'string' ? result : result.content;
       }
     }
 

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -133,8 +133,7 @@ export function augmentHostWithResources(
 
     if (fileName.includes('virtual-analog:')) {
       for (const transform of options.markdownTemplateTransforms || []) {
-        const result = await transform(content, fileName);
-        content = typeof result === 'string' ? result : String(result);
+        content = String(await transform(content, fileName));
       }
     }
 

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -134,7 +134,7 @@ export function augmentHostWithResources(
     if (fileName.includes('virtual-analog:')) {
       for (const transform of options.markdownTemplateTransforms || []) {
         const result = await transform(content, fileName);
-        content = typeof result === 'string' ? result : result.content;
+        content = typeof result === 'string' ? result : String(result);
       }
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,6 +396,9 @@ importers:
       typescript:
         specifier: 5.4.3
         version: 5.4.3
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^5.3.0
         version: 5.3.4(@types/node@18.19.15)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6)
@@ -11405,7 +11408,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.10.4:
@@ -13352,6 +13354,9 @@ packages:
   vfile@6.0.1:
     resolution: {integrity: sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==}
 
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
   vite-node@1.4.0:
     resolution: {integrity: sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -14013,7 +14018,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1802.4(chokidar@3.6.0)
-      '@angular-devkit/build-webpack': 0.1802.4(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)))(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      '@angular-devkit/build-webpack': 0.1802.4(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)))(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       '@angular-devkit/core': 18.2.4(chokidar@3.6.0)
       '@angular/build': 18.2.4(@angular/compiler-cli@18.2.4(@angular/compiler@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.3))(@angular/platform-server@18.2.4(@angular/animations@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/common@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/compiler@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10))(@angular/platform-browser@18.2.4(@angular/animations@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/common@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10))))(@types/node@18.19.15)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.41)(stylus@0.59.0)(tailwindcss@3.0.2(autoprefixer@10.4.19(postcss@8.4.38))(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.15)(typescript@5.4.3)))(terser@5.31.6)(typescript@5.4.3)
       '@angular/compiler-cli': 18.2.4(@angular/compiler@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.3)
@@ -14027,15 +14032,15 @@ snapshots:
       '@babel/preset-env': 7.25.3(@babel/core@7.25.2)
       '@babel/runtime': 7.25.0
       '@discoveryjs/json-ext': 0.6.1
-      '@ngtools/webpack': 18.2.4(@angular/compiler-cli@18.2.4(@angular/compiler@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.3))(typescript@5.4.3)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      '@ngtools/webpack': 18.2.4(@angular/compiler-cli@18.2.4(@angular/compiler@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.3))(typescript@5.4.3)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.4.0(@types/node@18.19.15)(less@4.2.0)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.20(postcss@8.4.41)
-      babel-loader: 9.1.3(@babel/core@7.25.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      babel-loader: 9.1.3(@babel/core@7.25.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       browserslist: 4.23.3
-      copy-webpack-plugin: 12.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      copy-webpack-plugin: 12.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       critters: 0.0.24
-      css-loader: 7.1.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      css-loader: 7.1.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       esbuild-wasm: 0.23.0
       fast-glob: 3.3.2
       http-proxy-middleware: 3.0.0
@@ -14044,11 +14049,11 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.2.0
-      less-loader: 12.2.0(less@4.2.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
-      license-webpack-plugin: 4.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      less-loader: 12.2.0(less@4.2.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
+      license-webpack-plugin: 4.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       loader-utils: 3.3.1
       magic-string: 0.30.11
-      mini-css-extract-plugin: 2.9.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      mini-css-extract-plugin: 2.9.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       mrmime: 2.0.0
       open: 10.1.0
       ora: 5.4.1
@@ -14056,13 +14061,13 @@ snapshots:
       picomatch: 4.0.2
       piscina: 4.6.1
       postcss: 8.4.41
-      postcss-loader: 8.1.1(postcss@8.4.41)(typescript@5.4.3)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      postcss-loader: 8.1.1(postcss@8.4.41)(typescript@5.4.3)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.77.6
-      sass-loader: 16.0.0(sass@1.77.6)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      sass-loader: 16.0.0(sass@1.77.6)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       semver: 7.6.3
-      source-map-loader: 5.0.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      source-map-loader: 5.0.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       source-map-support: 0.5.21
       terser: 5.31.6
       tree-kill: 1.2.2
@@ -14071,10 +14076,10 @@ snapshots:
       vite: 5.4.0(@types/node@18.19.15)(less@4.2.0)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6)
       watchpack: 2.4.1
       webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
-      webpack-dev-middleware: 7.4.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      webpack-dev-middleware: 7.4.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       webpack-dev-server: 5.0.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)))(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)))(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
     optionalDependencies:
       '@angular/platform-server': 18.2.4(@angular/animations@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/common@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/compiler@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10))(@angular/platform-browser@18.2.4(@angular/animations@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/common@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))
       esbuild: 0.23.0
@@ -14100,11 +14105,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1802.4(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)))(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))':
+  '@angular-devkit/build-webpack@0.1802.4(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)))(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))':
     dependencies:
       '@angular-devkit/architect': 0.1802.4(chokidar@3.6.0)
       rxjs: 7.8.1
-      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
       webpack-dev-server: 5.0.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
     transitivePeerDependencies:
       - chokidar
@@ -14405,7 +14410,7 @@ snapshots:
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.0.0
       unist-util-visit-parents: 6.0.1
-      vfile: 6.0.1
+      vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14426,7 +14431,7 @@ snapshots:
       remark-smartypants: 3.0.1
       source-map: 0.7.4
       unist-util-visit: 5.0.0
-      vfile: 6.0.1
+      vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15890,7 +15895,7 @@ snapshots:
       '@types/node': 18.19.15
       chalk: 4.1.2
       cosmiconfig: 8.1.3
-      cosmiconfig-typescript-loader: 4.3.0(@types/node@18.19.15)(cosmiconfig@8.1.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.15)(typescript@5.4.3))(typescript@4.8.4)
+      cosmiconfig-typescript-loader: 4.3.0(@types/node@18.19.15)(cosmiconfig@8.1.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.15)(typescript@4.8.4))(typescript@4.8.4)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -17688,7 +17693,7 @@ snapshots:
       unist-util-position-from-estree: 2.0.0
       unist-util-stringify-position: 4.0.0
       unist-util-visit: 5.0.0
-      vfile: 6.0.1
+      vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17867,11 +17872,11 @@ snapshots:
       '@netlify/node-cookies': 0.1.0
       urlpattern-polyfill: 8.0.2
 
-  '@ngtools/webpack@18.2.4(@angular/compiler-cli@18.2.4(@angular/compiler@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.3))(typescript@5.4.3)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))':
+  '@ngtools/webpack@18.2.4(@angular/compiler-cli@18.2.4(@angular/compiler@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.3))(typescript@5.4.3)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))':
     dependencies:
       '@angular/compiler-cli': 18.2.4(@angular/compiler@18.2.4(@angular/core@18.2.4(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.3)
       typescript: 5.4.3
-      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -20329,9 +20334,9 @@ snapshots:
       strip-ansi: 7.1.0
       tsconfck: 3.0.3(typescript@5.4.3)
       unist-util-visit: 5.0.0
-      vfile: 6.0.1
-      vite: 5.3.4(@types/node@18.19.15)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6)
-      vitefu: 0.2.5(vite@5.3.4(@types/node@18.19.15)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6))
+      vfile: 6.0.3
+      vite: 5.4.0(@types/node@18.19.15)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6)
+      vitefu: 0.2.5(vite@5.4.0(@types/node@18.19.15)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6))
       which-pm: 2.1.1
       yargs-parser: 21.1.1
       zod: 3.23.8
@@ -20343,6 +20348,7 @@ snapshots:
       - less
       - lightningcss
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -20441,6 +20447,13 @@ snapshots:
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
       webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+
+  babel-loader@9.1.3(@babel/core@7.25.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
+    dependencies:
+      '@babel/core': 7.25.2
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
 
   babel-plugin-const-enum@1.2.0(@babel/core@7.25.2):
     dependencies:
@@ -21398,7 +21411,7 @@ snapshots:
       serialize-javascript: 6.0.2
       webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
 
-  copy-webpack-plugin@12.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)):
+  copy-webpack-plugin@12.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -21406,7 +21419,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
 
   core-js-compat@3.38.1:
     dependencies:
@@ -21430,11 +21443,11 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  cosmiconfig-typescript-loader@4.3.0(@types/node@18.19.15)(cosmiconfig@8.1.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.15)(typescript@5.4.3))(typescript@4.8.4):
+  cosmiconfig-typescript-loader@4.3.0(@types/node@18.19.15)(cosmiconfig@8.1.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.15)(typescript@4.8.4))(typescript@4.8.4):
     dependencies:
       '@types/node': 18.19.15
       cosmiconfig: 8.1.3
-      ts-node: 10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.15)(typescript@5.4.3)
+      ts-node: 10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.15)(typescript@4.8.4)
       typescript: 4.8.4
 
   cosmiconfig@6.0.0:
@@ -21607,7 +21620,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
 
-  css-loader@7.1.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)):
+  css-loader@7.1.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.41)
       postcss: 8.4.41
@@ -21618,7 +21631,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
 
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.19.5)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)):
     dependencies:
@@ -23630,7 +23643,7 @@ snapshots:
       devlop: 1.1.0
       hast-util-from-parse5: 8.0.1
       parse5: 7.1.2
-      vfile: 6.0.1
+      vfile: 6.0.3
       vfile-message: 4.0.2
 
   hast-util-from-parse5@8.0.1:
@@ -23640,7 +23653,7 @@ snapshots:
       devlop: 1.1.0
       hastscript: 8.0.0
       property-information: 6.1.1
-      vfile: 6.0.1
+      vfile: 6.0.3
       vfile-location: 5.0.2
       web-namespaces: 2.0.1
 
@@ -23664,7 +23677,7 @@ snapshots:
       parse5: 7.1.2
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
-      vfile: 6.0.1
+      vfile: 6.0.3
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
@@ -25003,11 +25016,11 @@ snapshots:
       less: 4.1.3
       webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
 
-  less-loader@12.2.0(less@4.2.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)):
+  less-loader@12.2.0(less@4.2.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
     dependencies:
       less: 4.2.0
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
 
   less@4.1.3:
     dependencies:
@@ -25058,6 +25071,12 @@ snapshots:
       webpack-sources: 3.2.3
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+
+  license-webpack-plugin@4.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
+    dependencies:
+      webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
 
   lilconfig@2.0.6: {}
 
@@ -25618,7 +25637,7 @@ snapshots:
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
-      vfile: 6.0.1
+      vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.0:
     dependencies:
@@ -26183,6 +26202,12 @@ snapshots:
       schema-utils: 4.2.0
       tapable: 2.2.1
       webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+
+  mini-css-extract-plugin@2.9.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
+    dependencies:
+      schema-utils: 4.2.0
+      tapable: 2.2.1
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
 
   minimalistic-assert@1.0.1: {}
 
@@ -27074,7 +27099,7 @@ snapshots:
       nlcst-to-string: 4.0.0
       unist-util-modify-children: 4.0.0
       unist-util-visit-children: 3.0.0
-      vfile: 6.0.1
+      vfile: 6.0.3
 
   parse-node-version@1.0.1: {}
 
@@ -27464,14 +27489,14 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.1.1(postcss@8.4.41)(typescript@5.4.3)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)):
+  postcss-loader@8.1.1(postcss@8.4.41)(typescript@5.4.3)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.4.3)
       jiti: 1.21.0
       postcss: 8.4.41
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
     transitivePeerDependencies:
       - typescript
 
@@ -28339,7 +28364,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.3
       hast-util-raw: 9.0.1
-      vfile: 6.0.1
+      vfile: 6.0.3
 
   rehype-stringify@10.0.0:
     dependencies:
@@ -28415,7 +28440,7 @@ snapshots:
       '@types/mdast': 4.0.1
       mdast-util-to-hast: 13.1.0
       unified: 11.0.4
-      vfile: 6.0.1
+      vfile: 6.0.3
 
   remark-smartypants@2.0.0:
     dependencies:
@@ -28722,12 +28747,12 @@ snapshots:
     optionalDependencies:
       sass: 1.77.6
 
-  sass-loader@16.0.0(sass@1.77.6)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)):
+  sass-loader@16.0.0(sass@1.77.6)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.77.6
-      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
 
   sass@1.77.6:
     dependencies:
@@ -29161,6 +29186,12 @@ snapshots:
       source-map-js: 1.2.0
       webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
 
+  source-map-loader@5.0.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
+    dependencies:
+      iconv-lite: 0.6.3
+      source-map-js: 1.2.0
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
+
   source-map-support@0.5.13:
     dependencies:
       buffer-from: 1.1.2
@@ -29585,14 +29616,14 @@ snapshots:
       '@swc/core': 1.5.7(@swc/helpers@0.5.11)
       esbuild: 0.19.5
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.31.6
-      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
     optionalDependencies:
       '@swc/core': 1.5.7(@swc/helpers@0.5.11)
       esbuild: 0.23.0
@@ -29965,7 +29996,7 @@ snapshots:
       extend: 3.0.2
       is-plain-obj: 4.1.0
       trough: 2.1.0
-      vfile: 6.0.1
+      vfile: 6.0.3
 
   unimport@3.12.0(rollup@4.20.0)(webpack-sources@3.2.3):
     dependencies:
@@ -30243,7 +30274,7 @@ snapshots:
   vfile-location@5.0.2:
     dependencies:
       '@types/unist': 3.0.0
-      vfile: 6.0.1
+      vfile: 6.0.3
 
   vfile-message@3.1.2:
     dependencies:
@@ -30266,6 +30297,11 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.0
       unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.2
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.0
       vfile-message: 4.0.2
 
   vite-node@1.4.0(@types/node@18.19.15)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6):
@@ -30347,6 +30383,10 @@ snapshots:
   vitefu@0.2.5(vite@5.3.4(@types/node@18.19.15)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6)):
     optionalDependencies:
       vite: 5.3.4(@types/node@18.19.15)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6)
+
+  vitefu@0.2.5(vite@5.4.0(@types/node@18.19.15)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6)):
+    optionalDependencies:
+      vite: 5.4.0(@types/node@18.19.15)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6)
 
   vitest@1.4.0(@types/node@18.19.15)(happy-dom@12.10.3)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.6)(stylus@0.59.0)(terser@5.31.6):
     dependencies:
@@ -30478,6 +30518,17 @@ snapshots:
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)
 
+  webpack-dev-middleware@7.4.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
+    dependencies:
+      colorette: 2.0.20
+      memfs: 4.9.2
+      mime-types: 2.1.35
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      schema-utils: 4.2.0
+    optionalDependencies:
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
+
   webpack-dev-server@4.15.1(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)):
     dependencies:
       '@types/bonjour': 3.5.13
@@ -30581,6 +30632,13 @@ snapshots:
     optionalDependencies:
       html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
 
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5)))(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)):
+    dependencies:
+      typed-assert: 1.0.9
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)
+    optionalDependencies:
+      html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+
   webpack-virtual-modules@0.6.1: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -30637,7 +30695,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.5))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.23.0))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,15 @@ importers:
         specifier: ~5.5.4
         version: 5.5.4
 
+  packages/vite-plugin-angular:
+    dependencies:
+      ts-morph:
+        specifier: ^21.0.0
+        version: 21.0.1
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+
 packages:
 
   '@aashutoshrathi/word-wrap@1.2.6':
@@ -19330,7 +19339,7 @@ snapshots:
   '@ts-morph/common@0.22.0':
     dependencies:
       fast-glob: 3.3.2
-      minimatch: 9.0.3
+      minimatch: 9.0.4
       mkdirp: 3.0.1
       path-browserify: 1.0.1
 


### PR DESCRIPTION
I've taken the liberty of experimenting with a solution for this, so of course feel free to disregard if the approach/API isn't appropriate. Happy to make changes as required too.

Currently with `agx` files the frontmatter export is created before the markdown template transforms run, which is fine, but when the transform functions run they might want to add `vfile` data (as is the case with some remark/rehype plugins e.g. I have created some plugins that track word count/headings through vfile data)

At the moment when a markdown template transform is run it might return all the data as a vfile, e.g:

```ts
VFile {
  cwd: '/Users/joshuamorony/Dev/projects/oss/analog-stuff',
  data: {},
  history: [],
  messages: [],
  value: '<h2>Test</h2>\n' +
    '<p>Hello</p>\n' +
    '<ul>\n' +
    '<li>one</li>\n' +
    '<li>two</li>\n' +
    '<li>three</li>\n' +
    '</ul>\n' +
    '<ul>\n' +
    '<li>one</li>\n' +
    '<li>two</li>\n' +
    '<li>three</li>\n' +
    '</ul>'
}
```

But then the rest of the data needs to be dropped to be compatible with the markdown template transform format, and just the value as the content string is returned, e.g:

```ts
export const agxRemarkRehype =
  (options: RemarkRehypeOptions = {}): MarkdownTemplateTransform =>
  async (content: string) => {
    const processor = setupUnified(options);

    // Contains all the vFile data
    const mdContent = await processor.process(content);

    // Contains only the value string from the vFile data
    return String(mdContent);
  };
```

So all of the vfile data, including any data plugins might have added, will be lost. Currently there is no way to add metadata to the resulting content (e.g. through markdown transform/plugins), only the original frontmatter defined in the file will make it through when actually using the agx component.

e.g. given this plugin set up:

```ts
markdownTemplateTransforms: [
  agxRemarkRehype({
    remarkPlugins: [
      [preview, { percentage: 0.4 }],
      getHeadings,
      getWordCount,
    ],
    rehypePlugins: [rehypeSlug, rehypePrettyCode],
  }),
],
```

Everything works just as it does in the svx ecosystem, except `getHeadings` and `getWordCount` because they don't actually transform the AST, they just create metadata about the tree via the VFile.

## What is the new behavior?

This PR allows the markdown template transforms to optionally return a `vfile` instead of a content string. A `vfile` defines its own internal `toString` method that can be used to retrieve the normal content string, but now we also have a way to make any additional metadata available.

The existing markdown transform loop will now use the content string directly as normal if just a string is supplied, but if a vfile is supplied it will invoke the vfiles `toString` method to get the transformed content.

But the markdown template transforms are now also being run a second time, in order to generate the vfile data at the same time that the `metadata` export is created for the agx file. If any vfile data is returned it is added to an additional `vfile` export.

This way you would be able to access any `vfile` metadata data along with the frontmatter `metadata` when using `agx` files.

UPDATE: To make the vfile data easier to access with the existing `injectContent` approach, I modified this to instead merge the vfile data into the metadata export instead of making it its own export. This means with the existing `injectContent` functionality you can just access the vfile data through `attributes.vfile`.

### Example attributes for standard transform that returns a string

<img width="984" alt="Screenshot 2024-09-16 at 12 07 06 pm" src="https://github.com/user-attachments/assets/6f4ab4d6-0591-46db-863e-be10fdab29c6">

### Example attributes for transform that returns a vfile

<img width="973" alt="Screenshot 2024-09-16 at 12 09 36 pm" src="https://github.com/user-attachments/assets/9433d8fa-3da6-46b3-8ac1-2d63431494bf">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

No, although technically on the off chance that someone happened to already be naming one of their front matter properties `vfile` this update would cause that property to be overwritten

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/NTtoU4hkyq8W48re2f/giphy.gif"/>