### PR TITLE
fix(vite-plugin-angular): add better support for angular/cdk in vitest browser testing

### DIFF
--- a/libs/card/vite.config.ts
+++ b/libs/card/vite.config.ts
@@ -17,15 +17,9 @@ export default defineConfig(({ mode }) => {
       cache: {
         dir: `../../node_modules/.vitest`,
       },
-      deps: {
-        inline: ['@analogjs/vitest-angular', 'zone.js'],
-      },
     },
     define: {
       'import.meta.vitest': mode !== 'production',
-    },
-    ssr: {
-      noExternal: ['@analogjs/vitest-angular', 'zone.js'],
     },
   };
 });

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -1,4 +1,4 @@
-import { Plugin, UserConfig, transformWithEsbuild } from 'vite';
+import { Plugin, transformWithEsbuild } from 'vite';
 
 export function angularVitestPlugin(): Plugin {
   return {
@@ -14,14 +14,20 @@ export function angularVitestPlugin(): Plugin {
           pool: userConfig.test?.pool ?? 'vmThreads',
           server: {
             deps: {
-              inline: ['@analogjs/router'],
+              inline: [
+                '@analogjs/router',
+                '@analogjs/vitest-angular/setup-zone',
+              ],
             },
           },
         },
       };
     },
     async transform(_code, id) {
-      if (/fesm2022/.test(id) && _code.includes('async (')) {
+      if (
+        (/fesm2022/.test(id) && _code.includes('async (')) ||
+        _code.includes('@angular/cdk')
+      ) {
         const { code, map } = await transformWithEsbuild(_code, id, {
           loader: 'js',
           format: 'esm',


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When using Vitest, files containing `@angular/cdk` imports are transformed to downlevel async/await to es2016 when using with zone.js

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
