### PR TITLE
fix(nx-plugin): add marked-mangle to installed dependencies on new app/migration

### DIFF
--- a/packages/nx-plugin/src/generators/app/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/app/generator.spec.ts
@@ -124,8 +124,8 @@ describe('nx-plugin generator', () => {
     dependencies: Record<string, string>,
     devDependencies: Record<string, string>
   ) => {
-    expect(dependencies['@analogjs/content']).toBe('^1.3.0');
-    expect(dependencies['@analogjs/router']).toBe('^1.3.0');
+    expect(dependencies['@analogjs/content']).toBe('^1.7.0');
+    expect(dependencies['@analogjs/router']).toBe('^1.7.0');
     expect(dependencies['@angular/platform-server']).toBe(
       dependencies['@angular/core']
     );
@@ -133,6 +133,7 @@ describe('nx-plugin generator', () => {
     expect(dependencies['marked']).toBe('^5.0.2');
     expect(dependencies['marked-gfm-heading-id']).toBe('^3.1.0');
     expect(dependencies['marked-highlight']).toBe('^2.0.1');
+    expect(dependencies['marked-mangle']).toBe('^1.1.7');
     expect(dependencies['mermaid']).toBe('^10.2.4');
     expect(dependencies['prismjs']).toBe('^1.29.0');
 
@@ -141,8 +142,8 @@ describe('nx-plugin generator', () => {
     // we just check for truthy because @nx/eslint generator
     // will install the correct version based on Nx version
     expect(devDependencies['@nx/eslint']).toBeTruthy();
-    expect(devDependencies['@analogjs/platform']).toBe('^1.3.0');
-    expect(devDependencies['@analogjs/vite-plugin-angular']).toBe('^1.3.0');
+    expect(devDependencies['@analogjs/platform']).toBe('^1.7.0');
+    expect(devDependencies['@analogjs/vite-plugin-angular']).toBe('^1.7.0');
     expect(devDependencies['@nx/vite']).toBe('^19.1.0');
     expect(devDependencies['jsdom']).toBe('^22.1.0');
     expect(devDependencies['vite']).toBe('^5.0.0');

--- a/packages/nx-plugin/src/generators/app/versions/dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/dependencies.ts
@@ -6,6 +6,7 @@ import {
   V16_X_MARKED,
   V16_X_MARKED_GFM_HEADING_ID,
   V16_X_MARKED_HIGHLIGHT,
+  V16_X_MARKED_MANGLE,
   V16_X_MERMAID,
   V16_X_PRISMJS,
 } from './nx_16_X/versions';
@@ -25,6 +26,7 @@ import {
   V17_X_MARKED,
   V17_X_MARKED_GFM_HEADING_ID,
   V17_X_MARKED_HIGHLIGHT,
+  V17_X_MARKED_MANGLE,
   V17_X_MERMAID,
   V17_X_PRISMJS,
 } from './nx_17_X/versions';
@@ -35,6 +37,7 @@ import {
   V18_X_MARKED,
   V18_X_MARKED_GFM_HEADING_ID,
   V18_X_MARKED_HIGHLIGHT,
+  V18_X_MARKED_MANGLE,
   V18_X_MERMAID,
   V18_X_PRISMJS,
 } from './nx_18_X/versions';
@@ -52,6 +55,7 @@ const dependencyKeys15 = [
 const dependencyKeys16 = [
   'marked-gfm-heading-id',
   'marked-highlight',
+  'marked-mangle',
   'mermaid',
 ] as const;
 
@@ -100,6 +104,7 @@ export const getAnalogDependencies = (
       marked: V16_X_MARKED,
       'marked-gfm-heading-id': V16_X_MARKED_GFM_HEADING_ID,
       'marked-highlight': V16_X_MARKED_HIGHLIGHT,
+      'marked-mangle': V16_X_MARKED_MANGLE,
       mermaid: V16_X_MERMAID,
       prismjs: V16_X_PRISMJS,
     };
@@ -115,6 +120,7 @@ export const getAnalogDependencies = (
       marked: V17_X_MARKED,
       'marked-gfm-heading-id': V17_X_MARKED_GFM_HEADING_ID,
       'marked-highlight': V17_X_MARKED_HIGHLIGHT,
+      'marked-mangle': V17_X_MARKED_MANGLE,
       mermaid: V17_X_MERMAID,
       prismjs: V17_X_PRISMJS,
     };
@@ -129,6 +135,7 @@ export const getAnalogDependencies = (
     marked: V18_X_MARKED,
     'marked-gfm-heading-id': V18_X_MARKED_GFM_HEADING_ID,
     'marked-highlight': V18_X_MARKED_HIGHLIGHT,
+    'marked-mangle': V18_X_MARKED_MANGLE,
     mermaid: V18_X_MERMAID,
     prismjs: V18_X_PRISMJS,
   };

--- a/packages/nx-plugin/src/generators/app/versions/nx_16_X/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx_16_X/versions.ts
@@ -14,6 +14,7 @@ export const V16_X_FRONT_MATTER = '^4.0.2';
 export const V16_X_MARKED = '^5.0.2';
 export const V16_X_MARKED_GFM_HEADING_ID = '^3.1.0';
 export const V16_X_MARKED_HIGHLIGHT = '^2.0.1';
+export const V16_X_MARKED_MANGLE = '^1.1.7';
 export const V16_X_MERMAID = '^10.2.4';
 export const V16_X_PRISMJS = '^1.29.0';
 export const V16_X_TAILWINDCSS = '^3.0.2';

--- a/packages/nx-plugin/src/generators/app/versions/nx_17_X/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx_17_X/versions.ts
@@ -14,6 +14,7 @@ export const V17_X_FRONT_MATTER = '^4.0.2';
 export const V17_X_MARKED = '^5.0.2';
 export const V17_X_MARKED_GFM_HEADING_ID = '^3.1.0';
 export const V17_X_MARKED_HIGHLIGHT = '^2.0.1';
+export const V17_X_MARKED_MANGLE = '^1.1.7';
 export const V17_X_MERMAID = '^10.2.4';
 export const V17_X_PRISMJS = '^1.29.0';
 export const V17_X_TAILWINDCSS = '^3.0.2';

--- a/packages/nx-plugin/src/generators/app/versions/nx_18_X/versions.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx_18_X/versions.ts
@@ -2,10 +2,10 @@
 // dependencies
 export const V18_X_NX_DEVKIT = '^19.1.0';
 export const V18_X_NX_ANGULAR = '^19.1.0';
-export const V18_X_ANALOG_JS_CONTENT = '^1.3.0';
-export const V18_X_ANALOG_JS_ROUTER = '^1.3.0';
-export const V18_X_ANALOG_JS_TRPC = '~0.2.45';
-export const V18_X_ANALOG_JS_VITE_PLUGIN_ANGULAR = '^1.3.0';
+export const V18_X_ANALOG_JS_CONTENT = '^1.7.0';
+export const V18_X_ANALOG_JS_ROUTER = '^1.7.0';
+export const V18_X_ANALOG_JS_TRPC = '~0.2.46';
+export const V18_X_ANALOG_JS_VITE_PLUGIN_ANGULAR = '^1.7.0';
 export const V18_X_TRPC_CLIENT = '^10.25.0';
 export const V18_X_TRPC_SERVER = '^10.25.0';
 export const V18_X_ISOMORPHIC_FETCH = '^3.0.0';
@@ -14,6 +14,7 @@ export const V18_X_FRONT_MATTER = '^4.0.2';
 export const V18_X_MARKED = '^5.0.2';
 export const V18_X_MARKED_GFM_HEADING_ID = '^3.1.0';
 export const V18_X_MARKED_HIGHLIGHT = '^2.0.1';
+export const V18_X_MARKED_MANGLE = '^1.1.7';
 export const V18_X_MERMAID = '^10.2.4';
 export const V18_X_PRISMJS = '^1.29.0';
 export const V18_X_TAILWINDCSS = '^3.0.2';
@@ -21,7 +22,7 @@ export const V18_X_POSTCSS = '^8.4.5';
 export const V18_X_AUTOPREFIXER = '^10.4.0';
 
 // devDependencies
-export const V18_X_ANALOG_JS_PLATFORM = '^1.3.0';
+export const V18_X_ANALOG_JS_PLATFORM = '^1.7.0';
 export const V18_X_ANGULAR_DEVKIT_BUILD_ANGULAR = '^18.0.0';
 export const V18_X_NX_VITE = '^19.1.0';
 export const V18_X_NX_LINTER = '^19.1.0';

--- a/packages/nx-plugin/src/utils/versions/dependencies.ts
+++ b/packages/nx-plugin/src/utils/versions/dependencies.ts
@@ -5,6 +5,7 @@ import {
   V16_X_MARKED,
   V16_X_MARKED_GFM_HEADING_ID,
   V16_X_MARKED_HIGHLIGHT,
+  V16_X_MARKED_MANGLE,
   V16_X_NX_ANGULAR,
   V16_X_PRISMJS,
 } from './ng_16_X/versions';
@@ -15,6 +16,7 @@ import {
   V17_X_MARKED,
   V17_X_MARKED_GFM_HEADING_ID,
   V17_X_MARKED_HIGHLIGHT,
+  V17_X_MARKED_MANGLE,
   V17_X_NX_ANGULAR,
   V17_X_PRISMJS,
 } from './ng_17_X/versions';
@@ -24,6 +26,7 @@ import {
   V15_X_MARKED,
   V15_X_MARKED_GFM_HEADING_ID,
   V15_X_MARKED_HIGHLIGHT,
+  V15_X_MARKED_MANGLE,
   V15_X_NX_ANGULAR,
   V15_X_PRISMJS,
 } from './ng_15_X/versions';
@@ -33,6 +36,7 @@ import {
   V18_X_MARKED,
   V18_X_MARKED_GFM_HEADING_ID,
   V18_X_MARKED_HIGHLIGHT,
+  V18_X_MARKED_MANGLE,
   V18_X_NX_ANGULAR,
   V18_X_PRISMJS,
 } from './ng_18_X/versions';
@@ -73,6 +77,7 @@ const getDependencies = (escapedAngularVersion: string) => {
       marked: V15_X_MARKED,
       'marked-gfm-heading-id': V15_X_MARKED_GFM_HEADING_ID,
       'marked-highlight': V15_X_MARKED_HIGHLIGHT,
+      'marked-mangle': V15_X_MARKED_MANGLE,
       prismjs: V15_X_PRISMJS,
     };
   }
@@ -86,6 +91,7 @@ const getDependencies = (escapedAngularVersion: string) => {
       marked: V16_X_MARKED,
       'marked-gfm-heading-id': V16_X_MARKED_GFM_HEADING_ID,
       'marked-highlight': V16_X_MARKED_HIGHLIGHT,
+      'marked-mangle': V16_X_MARKED_MANGLE,
       prismjs: V16_X_PRISMJS,
     };
   }
@@ -99,6 +105,7 @@ const getDependencies = (escapedAngularVersion: string) => {
       marked: V17_X_MARKED,
       'marked-gfm-heading-id': V17_X_MARKED_GFM_HEADING_ID,
       'marked-highlight': V17_X_MARKED_HIGHLIGHT,
+      'marked-mangle': V17_X_MARKED_MANGLE,
       prismjs: V17_X_PRISMJS,
     };
   }
@@ -111,6 +118,7 @@ const getDependencies = (escapedAngularVersion: string) => {
     marked: V18_X_MARKED,
     'marked-gfm-heading-id': V18_X_MARKED_GFM_HEADING_ID,
     'marked-highlight': V18_X_MARKED_HIGHLIGHT,
+    'marked-mangle': V18_X_MARKED_MANGLE,
     prismjs: V18_X_PRISMJS,
   };
 };

--- a/packages/nx-plugin/src/utils/versions/ng_15_X/versions.ts
+++ b/packages/nx-plugin/src/utils/versions/ng_15_X/versions.ts
@@ -4,6 +4,7 @@ export const V15_X_ANALOG_JS_CONTENT = '~1.1.0';
 export const V15_X_MARKED = '^5.0.2';
 export const V15_X_MARKED_GFM_HEADING_ID = '^3.0.4';
 export const V15_X_MARKED_HIGHLIGHT = '^2.0.1';
+export const V15_X_MARKED_MANGLE = '^1.1.7';
 export const V15_X_PRISMJS = '^1.29.0';
 
 // devDependencies

--- a/packages/nx-plugin/src/utils/versions/ng_16_X/versions.ts
+++ b/packages/nx-plugin/src/utils/versions/ng_16_X/versions.ts
@@ -1,15 +1,16 @@
 // V16_X
-export const V16_X_ANALOG_JS_ROUTER = '^1.5.0';
-export const V16_X_ANALOG_JS_CONTENT = '^1.5.0';
+export const V16_X_ANALOG_JS_ROUTER = '^1.7.0';
+export const V16_X_ANALOG_JS_CONTENT = '^1.7.0';
 export const V16_X_MARKED = '^5.0.2';
 export const V16_X_MARKED_GFM_HEADING_ID = '^3.0.4';
 export const V16_X_MARKED_HIGHLIGHT = '^2.0.1';
+export const V16_X_MARKED_MANGLE = '^1.1.7';
 export const V16_X_PRISMJS = '^1.29.0';
 
 // devDependencies
-export const V16_X_ANALOG_JS_PLATFORM = '^1.5.0';
-export const V16_X_ANALOG_JS_VITE_PLUGIN_ANGULAR = '^1.5.0';
-export const V16_X_ANALOG_JS_VITEST_ANGULAR = '^1.5.0';
+export const V16_X_ANALOG_JS_PLATFORM = '^1.7.0';
+export const V16_X_ANALOG_JS_VITE_PLUGIN_ANGULAR = '^1.7.0';
+export const V16_X_ANALOG_JS_VITEST_ANGULAR = '^1.7.0';
 export const V16_X_NX_ANGULAR = '~18.0.0';
 export const V16_X_NX_VITE = '~18.0.0';
 export const V16_X_JSDOM = '^22.0.0';

--- a/packages/nx-plugin/src/utils/versions/ng_17_X/versions.ts
+++ b/packages/nx-plugin/src/utils/versions/ng_17_X/versions.ts
@@ -1,15 +1,16 @@
 // V17_X
-export const V17_X_ANALOG_JS_ROUTER = '^1.5.0';
-export const V17_X_ANALOG_JS_CONTENT = '^1.5.0';
+export const V17_X_ANALOG_JS_ROUTER = '^1.7.0';
+export const V17_X_ANALOG_JS_CONTENT = '^1.7.0';
 export const V17_X_MARKED = '^5.0.2';
 export const V17_X_MARKED_GFM_HEADING_ID = '^3.0.4';
 export const V17_X_MARKED_HIGHLIGHT = '^2.0.1';
+export const V17_X_MARKED_MANGLE = '^1.1.7';
 export const V17_X_PRISMJS = '^1.29.0';
 
 // devDependencies
-export const V17_X_ANALOG_JS_PLATFORM = '^1.5.0';
-export const V17_X_ANALOG_JS_VITE_PLUGIN_ANGULAR = '^1.5.0';
-export const V17_X_ANALOG_JS_VITEST_ANGULAR = '^1.5.0';
+export const V17_X_ANALOG_JS_PLATFORM = '^1.7.0';
+export const V17_X_ANALOG_JS_VITE_PLUGIN_ANGULAR = '^1.7.0';
+export const V17_X_ANALOG_JS_VITEST_ANGULAR = '^1.7.0';
 export const V17_X_NX_ANGULAR = '~18.0.0';
 export const V17_X_NX_VITE = '~18.0.0';
 export const V17_X_JSDOM = '^22.0.0';

--- a/packages/nx-plugin/src/utils/versions/ng_18_X/versions.ts
+++ b/packages/nx-plugin/src/utils/versions/ng_18_X/versions.ts
@@ -4,6 +4,7 @@ export const V18_X_ANALOG_JS_CONTENT = '^1.7.0';
 export const V18_X_MARKED = '^5.0.2';
 export const V18_X_MARKED_GFM_HEADING_ID = '^3.0.4';
 export const V18_X_MARKED_HIGHLIGHT = '^2.0.1';
+export const V18_X_MARKED_MANGLE = '^1.1.7';
 export const V18_X_PRISMJS = '^1.29.0';
 
 // devDependencies


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- When generating a new application, or running a migration to Analog, the `marked-mangle` dependency is added.
- Analog dependencies are also bumped

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
