### PR TITLE
fix(vite-plugin-angular): use defaultMarkdownTemplateTransform if none supplied

### DIFF
--- a/apps/ng-app/vite.config.ts
+++ b/apps/ng-app/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig(({ mode }) => ({
       vite: {
         experimental: {
           supportAnalogFormat: true,
+          markdownTemplateTransforms: [],
         },
       },
     }),

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -114,9 +114,10 @@ export function angular(options?: PluginOptions): Plugin[] {
     supportedBrowsers: options?.supportedBrowsers ?? ['safari 15'],
     jit: options?.experimental?.supportAnalogFormat ? false : options?.jit,
     supportAnalogFormat: options?.experimental?.supportAnalogFormat ?? false,
-    markdownTemplateTransforms:
-      options?.experimental?.markdownTemplateTransforms ??
-      defaultMarkdownTemplateTransforms,
+    markdownTemplateTransforms: options?.experimental
+      ?.markdownTemplateTransforms?.length
+      ? options.experimental.markdownTemplateTransforms
+      : defaultMarkdownTemplateTransforms,
     include: options?.include ?? [],
     additionalContentDirs: options?.additionalContentDirs ?? [],
   };


### PR DESCRIPTION
## PR Checklist

If the `markdownTemplateTransforms` option is defined, but no transforms are supplied, it will result in broken templates.

## What is the new behavior?

If an empty array is supplied for `markdownTemplateTransforms` it will still use the default transform.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/aX3XejBK7Cc7Z9pReu/giphy.gif"/>
