### PR TITLE
fix(platform): add support for @ng-web-apis and @taiga-ui deps w/SSR

### DIFF
--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -18,6 +18,8 @@ export function depsPlugin(options?: Options): Plugin[] {
               'firebase/**',
               'firebase-admin/**',
               'rxfire',
+              '@ng-web-apis/**',
+              '@taiga-ui/**',
             ],
           },
           optimizeDeps: {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Related to https://github.com/taiga-family/taiga-ui/issues/9085

## What is the new behavior?

When using `@ng-web-apis` or `@taiga-ui` packages, no errors are thrown when using SSR. Our dependency crawler plugin doesn't account for peer dependencies inside top-level packages, so some of the packages were not being transformed for Angular compilation. 

Manually this was fixed by adding those orgs to the `ssr.noExternal` array in the `vite.config.ts`

```ts
    ssr: {
      noExternal: [
        '@analogjs/trpc',
        '@trpc/server',
        '@ng-web-apis/**', // <-- transform all `@ng-web-apis` sub-packages
        '@taiga-ui/**',  // <-- transform all `@taiga-ui` sub-packages
      ],
    },
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/VeSvZhPrqgZxx2KpOA/giphy.gif"/>
