### PR TITLE
fix(create-analog): read the doc color scheme in light mode

### DIFF
--- a/packages/create-analog/template-latest/src/app/pages/index.page.ts
+++ b/packages/create-analog/template-latest/src/app/pages/index.page.ts
@@ -37,6 +37,12 @@ import { Component, signal } from '@angular/core';
       .read-the-docs > * {
         color: #fff;
       }
+
+      @media (prefers-color-scheme: light) {
+        .read-the-docs > * {
+          color: #213547;
+        }
+      }
     `,
   ],
 })

--- a/packages/create-analog/template-minimal/src/app/pages/index.page.ts
+++ b/packages/create-analog/template-minimal/src/app/pages/index.page.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
 
     <h3>The fullstack meta-framework for Angular!</h3>
 
-    <p>
+    <p class="read-the-docs">
       <a href="https://analogjs.org" target="_blank">Docs</a> |
       <a href="https://github.com/analogjs/analog" target="_blank">GitHub</a> |
       <a href="https://github.com/sponsors/brandonroberts" target="_blank"
@@ -22,6 +22,15 @@ import { Component } from '@angular/core';
       flex-direction: column;
       justify-content: center;
       align-items: center;
+    }
+    .read-the-docs > * {
+      color: #fff;
+    }
+
+    @media (prefers-color-scheme: light) {
+      .read-the-docs > * {
+        color: #213547;
+      }
     }
   `,
 })


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/analogjs/analog/issues/1351

Closes #1351

## What is the new behavior?
"Read the doc" link is visible in lightmode

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
