### PR TITLE
fix(vite-plugin-nitro): inline std-env package for Windows build

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -246,11 +246,16 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
               });                    
               `
               );
+
+              nitroConfig.externals = {
+                inline: ['std-env'],
+              };
             }
 
             nitroConfig = {
               ...nitroConfig,
               externals: {
+                ...nitroConfig.externals,
                 external: ['rxjs', 'node-fetch-native/dist/polyfill'],
               },
               moduleSideEffects: ['zone.js/node', 'zone.js/fesm2015/zone-node'],


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1359

## What is the new behavior?

Removes the false positive during a Windows build where its unable to resolve `std-env` package. The error didn't have any impact on the running application.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/cLwkKm4BN2C8AkPvzu/giphy.gif"/>
