### PR TITLE
feat(create-analog): optionally generate new projects with Analog SFCs

### DIFF
--- a/packages/create-analog/__tests__/cli.spec.ts
+++ b/packages/create-analog/__tests__/cli.spec.ts
@@ -79,10 +79,15 @@ test('asks to overwrite non-empty current directory', () => {
 
 test('successfully scaffolds a project based on angular starter template', () => {
   const { stdout } = run(
-    [projectName, '--template', 'latest', '--skipTailwind'],
-    {
-      cwd: __dirname,
-    }
+    [
+      projectName,
+      '--template',
+      'latest',
+      '--skipTailwind',
+      '--analogSFC',
+      'false',
+    ],
+    { cwd: __dirname }
   );
   const generatedFiles = readdirSync(genPath).sort();
 
@@ -92,9 +97,10 @@ test('successfully scaffolds a project based on angular starter template', () =>
 });
 
 test('works with the -t alias', () => {
-  const { stdout } = run([projectName, '-t', 'latest', '--skipTailwind'], {
-    cwd: __dirname,
-  });
+  const { stdout } = run(
+    [projectName, '-t', 'latest', '--skipTailwind', '--analogSFC', 'false'],
+    { cwd: __dirname }
+  );
   const generatedFiles = readdirSync(genPath).sort();
 
   // Assertions

--- a/packages/create-analog/files/analog-env.d.ts
+++ b/packages/create-analog/files/analog-env.d.ts
@@ -1,0 +1,9 @@
+declare module '*.analog' {
+  const cmp: any;
+  export default cmp;
+}
+
+declare module '*.ag' {
+  const cmp: any;
+  export default cmp;
+}

--- a/packages/create-analog/files/styles.css
+++ b/packages/create-analog/files/styles.css
@@ -26,6 +26,7 @@ a {
   color: #646cff;
   text-decoration: inherit;
 }
+
 a:hover {
   color: #535bf2;
 }
@@ -54,9 +55,11 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
+
 button:hover {
   border-color: #646cff;
 }
+
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
@@ -75,9 +78,11 @@ button:focus-visible {
     color: #213547;
     background-color: #ffffff;
   }
+
   a:hover {
     color: #747bff;
   }
+
   button {
     background-color: #f9f9f9;
   }

--- a/packages/create-analog/index.js
+++ b/packages/create-analog/index.js
@@ -64,7 +64,8 @@ const renameFiles = {
 async function init() {
   let targetDir = formatTargetDir(argv._[0]);
   let template = argv.template || argv.t;
-  let skipTailwind = argv.skipTailwind || false;
+  let skipTailwind = fromBoolArg(argv.skipTailwind);
+  let useAnalogSFC = fromBoolArg(argv.analogSFC);
 
   const defaultTargetDir = 'analog-project';
   const getProjectName = () =>
@@ -135,12 +136,12 @@ async function init() {
           initial: 1,
         },
         {
-          type: 'confirm',
-          name: 'useAnalogSFC',
+          type: useAnalogSFC === undefined ? 'confirm' : null,
+          name: 'analogSFC',
           message: 'Would you like to use Analog SFCs?',
         },
         {
-          type: skipTailwind ? null : 'confirm',
+          type: skipTailwind === undefined ? 'confirm' : null,
           name: 'tailwind',
           message: 'Would you like to add Tailwind to your project?',
         },
@@ -162,7 +163,7 @@ async function init() {
     overwrite,
     packageName,
     variant,
-    useAnalogSFC,
+    analogSFC,
     tailwind,
     syntaxHighlighter,
   } = result;
@@ -179,7 +180,8 @@ async function init() {
   template = variant || framework || template;
   // determine syntax highlighter
   let highlighter = syntaxHighlighter ?? (template === 'blog' ? 'prism' : null);
-  skipTailwind = !tailwind || skipTailwind;
+  skipTailwind = skipTailwind ?? !tailwind;
+  useAnalogSFC = useAnalogSFC ?? analogSFC;
 
   console.log(`\nScaffolding project in ${root}...`);
 
@@ -496,6 +498,12 @@ function deleteFiles(root, files) {
 
 function toFlatArray(value) {
   return (Array.isArray(value) ? value : [value]).filter(Boolean).flat();
+}
+
+function fromBoolArg(arg) {
+  return ['boolean', 'undefined'].includes(typeof arg)
+    ? arg
+    : ['', 'true'].includes(arg);
 }
 
 init().catch((e) => {

--- a/packages/create-analog/template-blog/src/app/app-root.ag
+++ b/packages/create-analog/template-blog/src/app/app-root.ag
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { RouterLink, RouterOutlet } from '@angular/router' with { analog: 'imports' };
+</script>
+
+<template>
+  <nav>
+    <a routerLink="/">Home</a>
+  </nav>
+
+  <router-outlet />
+</template>
+
+<style>
+  :host {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 2rem;
+    text-align: center;
+  }
+
+  nav {
+    text-align: left;
+    padding: 0 0 2rem 0;
+  }
+</style>

--- a/packages/create-analog/template-blog/src/app/app-root.spec.ts
+++ b/packages/create-analog/template-blog/src/app/app-root.spec.ts
@@ -2,18 +2,18 @@ import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { provideLocationMocks } from '@angular/common/testing';
 
-import { AppComponent } from './app.component';
+import App from './app-root.ag';
 
-describe('AppComponent', () => {
+describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
+      imports: [App],
       providers: [provideRouter([]), provideLocationMocks()],
     }).compileComponents();
   });
 
   it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
+    const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });

--- a/packages/create-analog/template-blog/src/app/app.component.ts
+++ b/packages/create-analog/template-blog/src/app/app.component.ts
@@ -1,30 +1,29 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterLink, RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [RouterLink, RouterOutlet],
   template: `
     <nav>
-      <a href="/">Home</a>
+      <a routerLink="/">Home</a>
     </nav>
+
     <router-outlet />
   `,
-  styles: [
-    `
-      :host {
-        max-width: 1280px;
-        margin: 0 auto;
-        padding: 2rem;
-        text-align: center;
-      }
+  styles: `
+    :host {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 2rem;
+      text-align: center;
+    }
 
-      nav {
-        text-align: left;
-        padding: 0 0 2rem 0;
-      }
-    `,
-  ],
+    nav {
+      text-align: left;
+      padding: 0 0 2rem 0;
+    }
+  `,
 })
 export class AppComponent {}

--- a/packages/create-analog/template-blog/src/app/pages/blog/[slug].page.ag
+++ b/packages/create-analog/template-blog/src/app/pages/blog/[slug].page.ag
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { AsyncPipe } from '@angular/common' with { analog: 'imports' };
+  import { MarkdownComponent } from '@analogjs/content' with { analog: 'imports' };
+  import { injectContent } from '@analogjs/content';
+
+  import PostAttributes from '../../post-attributes';
+
+  const post$ = injectContent<PostAttributes>('slug');
+</script>
+
+<template>
+  @if (post$ | async; as post) {
+  <article>
+    <img class="post__image" [src]="post.attributes.coverImage" />
+    <analog-markdown [content]="post.content" />
+  </article>
+  }
+</template>
+
+<style>
+  .post__image {
+    max-height: 40vh;
+  }
+</style>

--- a/packages/create-analog/template-blog/src/app/pages/blog/[slug].page.ts
+++ b/packages/create-analog/template-blog/src/app/pages/blog/[slug].page.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
-import { injectContent, MarkdownComponent } from '@analogjs/content';
 import { AsyncPipe } from '@angular/common';
+import { injectContent, MarkdownComponent } from '@analogjs/content';
 
 import PostAttributes from '../../post-attributes';
 
@@ -16,13 +16,11 @@ import PostAttributes from '../../post-attributes';
     </article>
     }
   `,
-  styles: [
-    `
-      .post__image {
-        max-height: 40vh;
-      }
-    `,
-  ],
+  styles: `
+    .post__image {
+      max-height: 40vh;
+    }
+  `,
 })
 export default class BlogPostComponent {
   readonly post$ = injectContent<PostAttributes>('slug');

--- a/packages/create-analog/template-blog/src/app/pages/blog/index.page.ag
+++ b/packages/create-analog/template-blog/src/app/pages/blog/index.page.ag
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { RouterLink } from '@angular/router' with { analog: 'imports' };
+  import { injectContentFiles } from '@analogjs/content';
+
+  import PostAttributes from '../../post-attributes';
+
+  const posts = injectContentFiles<PostAttributes>();
+</script>
+
+<template>
+  <h1>Blog Archive</h1>
+
+  @for (post of posts; track post.attributes.slug) {
+  <a [routerLink]="['/blog/', post.attributes.slug]">
+    <h2 class="post__title">{{ post.attributes.title }}</h2>
+    <p class="post__desc">{{ post.attributes.description }}</p>
+  </a>
+  }
+</template>
+
+<style>
+  a {
+    text-align: left;
+    display: block;
+    margin-bottom: 2rem;
+  }
+
+  .post__title,
+  .post__desc {
+    margin: 0;
+  }
+</style>

--- a/packages/create-analog/template-blog/src/app/pages/blog/index.page.ts
+++ b/packages/create-analog/template-blog/src/app/pages/blog/index.page.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
-import { injectContentFiles } from '@analogjs/content';
-import PostAttributes from '../../post-attributes';
 import { RouterLink } from '@angular/router';
+import { injectContentFiles } from '@analogjs/content';
+
+import PostAttributes from '../../post-attributes';
 
 @Component({
   selector: 'app-blog',
@@ -9,27 +10,26 @@ import { RouterLink } from '@angular/router';
   imports: [RouterLink],
   template: `
     <h1>Blog Archive</h1>
-    @for (post of posts;track post.attributes.slug) {
+
+    @for (post of posts; track post.attributes.slug) {
     <a [routerLink]="['/blog/', post.attributes.slug]">
       <h2 class="post__title">{{ post.attributes.title }}</h2>
       <p class="post__desc">{{ post.attributes.description }}</p>
     </a>
     }
   `,
-  styles: [
-    `
-      a {
-        text-align: left;
-        display: block;
-        margin-bottom: 2rem;
-      }
+  styles: `
+    a {
+      text-align: left;
+      display: block;
+      margin-bottom: 2rem;
+    }
 
-      .post__title,
-      .post__desc {
-        margin: 0;
-      }
-    `,
-  ],
+    .post__title,
+    .post__desc {
+      margin: 0;
+    }
+  `,
 })
 export default class BlogComponent {
   readonly posts = injectContentFiles<PostAttributes>();

--- a/packages/create-analog/template-blog/src/main.server.ts
+++ b/packages/create-analog/template-blog/src/main.server.ts
@@ -6,15 +6,15 @@ import { renderApplication } from '@angular/platform-server';
 import { provideServerContext } from '@analogjs/router/server';
 import { ServerContext } from '@analogjs/router/tokens';
 
+__APP_COMPONENT_IMPORT__
 import { config } from './app/app.config.server';
-import { AppComponent } from './app/app.component';
 
 if (import.meta.env.PROD) {
   enableProdMode();
 }
 
 export function bootstrap() {
-  return bootstrapApplication(AppComponent, config);
+  return bootstrapApplication(__APP_COMPONENT__, config);
 }
 
 export default async function render(

--- a/packages/create-analog/template-blog/src/main.ts
+++ b/packages/create-analog/template-blog/src/main.ts
@@ -1,7 +1,7 @@
 import 'zone.js';
 import { bootstrapApplication } from '@angular/platform-browser';
 
-import { AppComponent } from './app/app.component';
+__APP_COMPONENT_IMPORT__
 import { appConfig } from './app/app.config';
 
-bootstrapApplication(AppComponent, appConfig);
+bootstrapApplication(__APP_COMPONENT__, appConfig);

--- a/packages/create-analog/template-blog/vite.config.ts
+++ b/packages/create-analog/template-blog/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig(({ mode }) => ({
       },
       prerender: {
         routes: ['/blog', '/blog/2022-12-27-my-first-post'],
-      },
+      },__ANALOG_SFC_CONFIG__
     }),
   ],
   test: {

--- a/packages/create-analog/template-latest/src/app/app-root.ag
+++ b/packages/create-analog/template-latest/src/app/app-root.ag
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { RouterOutlet } from '@angular/router' with { analog: 'imports' };
+</script>
+
+<template>
+  <router-outlet />
+</template>
+
+<style>
+  :host {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 2rem;
+    text-align: center;
+  }
+</style>

--- a/packages/create-analog/template-latest/src/app/app-root.spec.ts
+++ b/packages/create-analog/template-latest/src/app/app-root.spec.ts
@@ -2,18 +2,18 @@ import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { provideLocationMocks } from '@angular/common/testing';
 
-import { AppComponent } from './app.component';
+import App from './app-root.ag';
 
-describe('AppComponent', () => {
+describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
+      imports: [App],
       providers: [provideRouter([]), provideLocationMocks()],
     }).compileComponents();
   });
 
   it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
+    const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });

--- a/packages/create-analog/template-latest/src/app/app.component.ts
+++ b/packages/create-analog/template-latest/src/app/app.component.ts
@@ -6,15 +6,13 @@ import { RouterOutlet } from '@angular/router';
   standalone: true,
   imports: [RouterOutlet],
   template: `<router-outlet />`,
-  styles: [
-    `
-      :host {
-        max-width: 1280px;
-        margin: 0 auto;
-        padding: 2rem;
-        text-align: center;
-      }
-    `,
-  ],
+  styles: `
+    :host {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 2rem;
+      text-align: center;
+    }
+  `,
 })
 export class AppComponent {}

--- a/packages/create-analog/template-latest/src/app/pages/index.page.ag
+++ b/packages/create-analog/template-latest/src/app/pages/index.page.ag
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { signal } from '@angular/core';
+
+  const count = signal(0);
+
+  function increment() {
+    this.count.update((count) => count + 1);
+  }
+</script>
+
+<template>
+  <div>
+    <a href="https://analogjs.org/" target="_blank">
+      <img alt="Analog Logo" class="logo analog" src="/analog.svg" />
+    </a>
+  </div>
+
+  <h2>Analog</h2>
+
+  <h3>The fullstack meta-framework for Angular!</h3>
+
+  <div class="card">
+    <button type="button" (click)="increment()">Count {{ count() }}</button>
+  </div>
+
+  <p class="read-the-docs">
+    <a href="https://analogjs.org" target="_blank">Docs</a> |
+    <a href="https://github.com/analogjs/analog" target="_blank">GitHub</a> |
+    <a href="https://github.com/sponsors/brandonroberts" target="_blank">
+      Sponsor
+    </a>
+  </p>
+</template>
+
+<style>
+  .logo {
+    will-change: filter;
+  }
+
+  .logo:hover {
+    filter: drop-shadow(0 0 2em #646cffaa);
+  }
+
+  .read-the-docs > * {
+    color: #fff;
+  }
+
+  @media (prefers-color-scheme: light) {
+    .read-the-docs > * {
+      color: #213547;
+    }
+  }
+</style>

--- a/packages/create-analog/template-latest/src/app/pages/index.page.ts
+++ b/packages/create-analog/template-latest/src/app/pages/index.page.ts
@@ -21,30 +21,30 @@ import { Component, signal } from '@angular/core';
     <p class="read-the-docs">
       <a href="https://analogjs.org" target="_blank">Docs</a> |
       <a href="https://github.com/analogjs/analog" target="_blank">GitHub</a> |
-      <a href="https://github.com/sponsors/brandonroberts" target="_blank"
-        >Sponsor</a
-      >
+      <a href="https://github.com/sponsors/brandonroberts" target="_blank">
+        Sponsor
+      </a>
     </p>
   `,
-  styles: [
-    `
-      .logo {
-        will-change: filter;
-      }
-      .logo:hover {
-        filter: drop-shadow(0 0 2em #646cffaa);
-      }
-      .read-the-docs > * {
-        color: #fff;
-      }
+  styles: `
+    .logo {
+      will-change: filter;
+    }
 
-      @media (prefers-color-scheme: light) {
-        .read-the-docs > * {
-          color: #213547;
-        }
+    .logo:hover {
+      filter: drop-shadow(0 0 2em #646cffaa);
+    }
+
+    .read-the-docs > * {
+      color: #fff;
+    }
+
+    @media (prefers-color-scheme: light) {
+      .read-the-docs > * {
+        color: #213547;
       }
-    `,
-  ],
+    }
+  `,
 })
 export default class HomeComponent {
   count = signal(0);

--- a/packages/create-analog/template-latest/src/main.server.ts
+++ b/packages/create-analog/template-latest/src/main.server.ts
@@ -6,15 +6,15 @@ import { renderApplication } from '@angular/platform-server';
 import { provideServerContext } from '@analogjs/router/server';
 import { ServerContext } from '@analogjs/router/tokens';
 
+__APP_COMPONENT_IMPORT__
 import { config } from './app/app.config.server';
-import { AppComponent } from './app/app.component';
 
 if (import.meta.env.PROD) {
   enableProdMode();
 }
 
 export function bootstrap() {
-  return bootstrapApplication(AppComponent, config);
+  return bootstrapApplication(__APP_COMPONENT__, config);
 }
 
 export default async function render(

--- a/packages/create-analog/template-latest/src/main.ts
+++ b/packages/create-analog/template-latest/src/main.ts
@@ -1,7 +1,7 @@
 import 'zone.js';
 import { bootstrapApplication } from '@angular/platform-browser';
 
-import { AppComponent } from './app/app.component';
+__APP_COMPONENT_IMPORT__
 import { appConfig } from './app/app.config';
 
-bootstrapApplication(AppComponent, appConfig);
+bootstrapApplication(__APP_COMPONENT__, appConfig);

--- a/packages/create-analog/template-latest/src/styles.css
+++ b/packages/create-analog/template-latest/src/styles.css
@@ -21,6 +21,7 @@ a {
   color: #646cff;
   text-decoration: inherit;
 }
+
 a:hover {
   color: #535bf2;
 }
@@ -49,9 +50,11 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
+
 button:hover {
   border-color: #646cff;
 }
+
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
@@ -66,9 +69,11 @@ button:focus-visible {
     color: #213547;
     background-color: #ffffff;
   }
+
   a:hover {
     color: #747bff;
   }
+
   button {
     background-color: #f9f9f9;
   }

--- a/packages/create-analog/template-latest/vite.config.ts
+++ b/packages/create-analog/template-latest/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig(({ mode }) => ({
   resolve: {
     mainFields: ['module'],
   },
-  plugins: [analog()],
+  plugins: [analog(__ANALOG_SFC_CONFIG__)],
   test: {
     globals: true,
     environment: 'jsdom',

--- a/packages/create-analog/template-minimal/src/app/app-root.ag
+++ b/packages/create-analog/template-minimal/src/app/app-root.ag
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { RouterOutlet } from '@angular/router' with { analog: 'imports' };
+</script>
+
+<template>
+  <router-outlet />
+</template>

--- a/packages/create-analog/template-minimal/src/app/pages/index.page.ag
+++ b/packages/create-analog/template-minimal/src/app/pages/index.page.ag
@@ -1,0 +1,32 @@
+<template>
+  <h2>Analog</h2>
+
+  <h3>The fullstack meta-framework for Angular!</h3>
+
+  <p class="read-the-docs">
+    <a href="https://analogjs.org" target="_blank">Docs</a> |
+    <a href="https://github.com/analogjs/analog" target="_blank">GitHub</a> |
+    <a href="https://github.com/sponsors/brandonroberts" target="_blank">
+      Sponsor
+    </a>
+  </p>
+</template>
+
+<style>
+  :host {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .read-the-docs > * {
+    color: #fff;
+  }
+
+  @media (prefers-color-scheme: light) {
+    .read-the-docs > * {
+      color: #213547;
+    }
+  }
+</style>

--- a/packages/create-analog/template-minimal/src/app/pages/index.page.ts
+++ b/packages/create-analog/template-minimal/src/app/pages/index.page.ts
@@ -11,9 +11,9 @@ import { Component } from '@angular/core';
     <p class="read-the-docs">
       <a href="https://analogjs.org" target="_blank">Docs</a> |
       <a href="https://github.com/analogjs/analog" target="_blank">GitHub</a> |
-      <a href="https://github.com/sponsors/brandonroberts" target="_blank"
-        >Sponsor</a
-      >
+      <a href="https://github.com/sponsors/brandonroberts" target="_blank">
+        Sponsor
+      </a>
     </p>
   `,
   styles: `
@@ -23,6 +23,7 @@ import { Component } from '@angular/core';
       justify-content: center;
       align-items: center;
     }
+
     .read-the-docs > * {
       color: #fff;
     }

--- a/packages/create-analog/template-minimal/src/main.server.ts
+++ b/packages/create-analog/template-minimal/src/main.server.ts
@@ -6,15 +6,15 @@ import { renderApplication } from '@angular/platform-server';
 import { provideServerContext } from '@analogjs/router/server';
 import { ServerContext } from '@analogjs/router/tokens';
 
+__APP_COMPONENT_IMPORT__
 import { config } from './app/app.config.server';
-import { AppComponent } from './app/app.component';
 
 if (import.meta.env.PROD) {
   enableProdMode();
 }
 
 export function bootstrap() {
-  return bootstrapApplication(AppComponent, config);
+  return bootstrapApplication(__APP_COMPONENT__, config);
 }
 
 export default async function render(

--- a/packages/create-analog/template-minimal/src/main.ts
+++ b/packages/create-analog/template-minimal/src/main.ts
@@ -1,7 +1,7 @@
 import 'zone.js';
 import { bootstrapApplication } from '@angular/platform-browser';
 
-import { AppComponent } from './app/app.component';
+__APP_COMPONENT_IMPORT__
 import { appConfig } from './app/app.config';
 
-bootstrapApplication(AppComponent, appConfig);
+bootstrapApplication(__APP_COMPONENT__, appConfig);

--- a/packages/create-analog/template-minimal/vite.config.ts
+++ b/packages/create-analog/template-minimal/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(({ mode }) => ({
       static: true,
       prerender: {
         routes: [],
-      },
+      },__ANALOG_SFC_CONFIG__
     }),
   ],
 }));


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1369

## What is the new behavior?

When creating a new Analog app (latest/blog/minimal) there is an option to select Analog SFC as a preferred component authoring format. When selected, all components and pages in a created project will be Analog SFCs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


