### PR TITLE
fix(platform): add better cache invalidation for changes to route page files

### DIFF
--- a/packages/platform/src/lib/router-plugin.ts
+++ b/packages/platform/src/lib/router-plugin.ts
@@ -23,15 +23,13 @@ export function routerPlugin(options?: Options): Plugin[] {
       configureServer(server) {
         function invalidateRoutes(path: string) {
           if (
-            path.includes(normalizePath(`/app/routes/`)) ||
-            path.includes(normalizePath(`/pages/`))
+            path.includes(`routes`) ||
+            path.includes(`pages`) ||
+            path.includes('content')
           ) {
             server.moduleGraph.fileToModulesMap.forEach((mods) => {
               mods.forEach((mod) => {
-                if (
-                  mod.id?.includes('analogjs') &&
-                  mod.id?.includes('router')
-                ) {
+                if (mod.id?.includes('analogjs') && mod.id?.includes('fesm')) {
                   server.moduleGraph.invalidateModule(mod);
 
                   mod.importers.forEach((imp) => {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1384

## What is the new behavior?

Whenever files in the `pages` or `content` directory are added/deleted, all the analogjs dependencies cached in the Vite Module Graph (router, content) along with any files that import them are invalidated,  so they can be refreshed to detect new routes/pages/content.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/jow0Rzk2rJ3yyGJAjN/giphy.gif"/>