### PR TITLE
fix(router): retrieve initial server page load from transfer state

### DIFF
--- a/packages/router/src/lib/cookie-interceptor.ts
+++ b/packages/router/src/lib/cookie-interceptor.ts
@@ -9,7 +9,7 @@ export function cookieInterceptor(
   location = inject(PLATFORM_ID),
   serverRequest = injectRequest()
 ) {
-  if (isPlatformServer(location) && req.url.includes('/api/_analog/')) {
+  if (isPlatformServer(location) && req.url.includes('/_analog/')) {
     let headers = new HttpHeaders();
     const cookies = serverRequest?.headers.cookie;
     headers = headers.set('cookie', cookies ?? '');

--- a/packages/router/src/lib/request-context.ts
+++ b/packages/router/src/lib/request-context.ts
@@ -72,7 +72,10 @@ export function requestContextInterceptor(
   }
 
   // on the client
-  if (!import.meta.env.SSR && req.url.startsWith('/')) {
+  if (
+    !import.meta.env.SSR &&
+    (req.url.startsWith('/') || req.url.includes('/_analog/'))
+  ) {
     const cacheRestoreResponse = transferState.get(storeKey, null);
 
     if (cacheRestoreResponse) {
@@ -80,9 +83,14 @@ export function requestContextInterceptor(
       return of(new HttpResponse(cacheRestoreResponse));
     }
 
+    // /_analog/ requests are full URLs
+    const url = req.url.includes('/_analog/')
+      ? req.url
+      : `${window.location.origin}${req.url}`;
+
     return next(
       req.clone({
-        url: `${window.location.origin}${req.url}`,
+        url,
       })
     );
   }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1383

## What is the new behavior?

When prerendering pages that use server-side data fetching, get the initial request from the transfer state to prevent data fetching on the initial page load.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/WmXRlTbjhPOqh1MRlK/giphy.gif"/>