### PR TITLE
fix(router): expose inject function for page endpoint URL

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -13,3 +13,4 @@ export { PageServerLoad, LoadResult } from './lib/route-types';
 export { injectLoad } from './lib/inject-load';
 export { getLoadResolver } from './lib/get-load-resolver';
 export { requestContextInterceptor } from './lib/request-context';
+export { injectRouteEndpointURL } from './lib/inject-route-endpoint-url';

--- a/packages/router/src/lib/inject-route-endpoint-url.ts
+++ b/packages/router/src/lib/inject-route-endpoint-url.ts
@@ -1,0 +1,35 @@
+import type { ActivatedRouteSnapshot, Route } from '@angular/router';
+import { injectBaseURL } from '@analogjs/router/tokens';
+
+import { ANALOG_META_KEY } from './endpoints';
+
+export function injectRouteEndpointURL(route: ActivatedRouteSnapshot) {
+  const routeConfig = route.routeConfig as Route & {
+    [ANALOG_META_KEY]: { endpoint: string; endpointKey: string };
+  };
+
+  const baseUrl = injectBaseURL();
+  const { queryParams, fragment: hash, params, parent } = route;
+  const segment = parent?.url.map((segment) => segment.path).join('/') || '';
+  const url = new URL(
+    '',
+    import.meta.env['VITE_ANALOG_PUBLIC_BASE_URL'] ||
+      baseUrl ||
+      (typeof window !== 'undefined' && window.location.origin
+        ? window.location.origin
+        : '')
+  );
+
+  url.pathname = `${
+    url.pathname.endsWith('/') ? url.pathname : url.pathname + '/'
+  }api/_analog${routeConfig[ANALOG_META_KEY].endpoint}`;
+  url.search = `${new URLSearchParams(queryParams).toString()}`;
+  url.hash = hash ?? '';
+
+  Object.keys(params).forEach((param) => {
+    url.pathname = url.pathname.replace(`[${param}]`, params[param]);
+  });
+  url.pathname = url.pathname.replace('**', segment);
+
+  return url;
+}

--- a/packages/router/src/lib/provide-file-router.ts
+++ b/packages/router/src/lib/provide-file-router.ts
@@ -3,13 +3,7 @@ import {
   EnvironmentProviders,
   makeEnvironmentProviders,
 } from '@angular/core';
-import {
-  provideRouter,
-  RouterFeature,
-  RouterFeatures,
-  ROUTES,
-  Routes,
-} from '@angular/router';
+import { provideRouter, RouterFeatures, ROUTES, Routes } from '@angular/router';
 import { ɵHTTP_ROOT_INTERCEPTOR_FNS as HTTP_ROOT_INTERCEPTOR_FNS } from '@angular/common/http';
 
 import { routes } from './routes';

--- a/packages/router/src/lib/route-config.ts
+++ b/packages/router/src/lib/route-config.ts
@@ -1,12 +1,12 @@
 import { inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import type { Route } from '@angular/router';
-import { injectBaseURL } from '@analogjs/router/tokens';
 import { firstValueFrom } from 'rxjs';
 
 import { RedirectRouteMeta, RouteConfig, RouteMeta } from './models';
 import { ROUTE_META_TAGS_KEY } from './meta-tags';
 import { ANALOG_PAGE_ENDPOINTS, ANALOG_META_KEY } from './endpoints';
+import { injectRouteEndpointURL } from './inject-route-endpoint-url';
 
 export function toRouteConfig(routeMeta: RouteMeta | undefined): RouteConfig {
   if (routeMeta && isRedirectRouteMeta(routeMeta)) {
@@ -33,34 +33,13 @@ export function toRouteConfig(routeMeta: RouteMeta | undefined): RouteConfig {
   routeConfig.resolve = {
     ...routeConfig.resolve,
     load: async (route) => {
-      const baseUrl = injectBaseURL();
+      const http = inject(HttpClient);
       const routeConfig = route.routeConfig as Route & {
         [ANALOG_META_KEY]: { endpoint: string; endpointKey: string };
       };
 
       if (ANALOG_PAGE_ENDPOINTS[routeConfig[ANALOG_META_KEY].endpointKey]) {
-        const { queryParams, fragment: hash, params, parent } = route;
-        const segment =
-          parent?.url.map((segment) => segment.path).join('/') || '';
-        const url = new URL(
-          '',
-          import.meta.env['VITE_ANALOG_PUBLIC_BASE_URL'] ||
-            baseUrl ||
-            (typeof window !== 'undefined' && window.location.origin
-              ? window.location.origin
-              : '')
-        );
-
-        url.pathname = `${
-          url.pathname.endsWith('/') ? url.pathname : url.pathname + '/'
-        }api/_analog${routeConfig[ANALOG_META_KEY].endpoint}`;
-        url.search = `${new URLSearchParams(queryParams).toString()}`;
-        url.hash = hash ?? '';
-
-        Object.keys(params).forEach((param) => {
-          url.pathname = url.pathname.replace(`[${param}]`, params[param]);
-        });
-        url.pathname = url.pathname.replace('**', segment);
+        const url = injectRouteEndpointURL(route);
 
         if (
           !!import.meta.env['VITE_ANALOG_PUBLIC_BASE_URL'] &&
@@ -69,7 +48,6 @@ export function toRouteConfig(routeMeta: RouteMeta | undefined): RouteConfig {
           return (globalThis as any).$fetch(url.pathname);
         }
 
-        const http = inject(HttpClient);
         return firstValueFrom(http.get(`${url.href}`));
       }
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Exposes the `injectRouteEndpointURL` function to get the page endpoint for a given page. Meant to be used to the form action directive and will not remain public.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
