### PR TITLE
fix(vite-plugin-angular): use esbuild to postprocess sourcemaps during testing

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -31,7 +31,7 @@ import {
   createJitResourceTransformer,
   SourceFileCache,
 } from './utils/devkit.js';
-import { angularVitestPlugin } from './angular-vitest-plugin.js';
+import { angularVitestPlugins } from './angular-vitest-plugin.js';
 import { angularStorybookPlugin } from './angular-storybook-plugin.js';
 
 const require = createRequire(import.meta.url);
@@ -409,7 +409,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
   return [
     angularPlugin(),
-    (isTest && !isStackBlitz && angularVitestPlugin()) as Plugin,
+    ...(isTest && !isStackBlitz ? angularVitestPlugins() : []),
     (jit &&
       jitPlugin({
         inlineStylesExtension: pluginOptions.inlineStylesExtension,

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -1,4 +1,4 @@
-import { Plugin, transformWithEsbuild } from 'vite';
+import { Plugin, transformWithEsbuild, UserConfig } from 'vite';
 
 export function angularVitestPlugin(): Plugin {
   return {
@@ -45,4 +45,48 @@ export function angularVitestPlugin(): Plugin {
       return undefined;
     },
   };
+}
+
+/**
+ * This eagerly disables esbuild so Vitest
+ * disables it when its internal plugin
+ * is configured.
+ */
+export function angularVitestEsbuildPlugin(): Plugin {
+  return {
+    name: '@analogjs/vitest-angular-esbuild-plugin',
+    enforce: 'pre',
+    config(userConfig: UserConfig) {
+      return {
+        esbuild: userConfig.esbuild ?? false,
+      };
+    },
+  };
+}
+
+/**
+ * This plugin does post-processing with esbuild
+ * instead of preprocessing to re-align
+ * the sourcemaps so breakpoints and coverage reports
+ * work correctly.
+ */
+export function angularVitestSourcemapPlugin(): Plugin {
+  return {
+    name: '@analogjs/vitest-angular-sourcemap-plugin',
+    async transform(code: string, id: string) {
+      const result = await transformWithEsbuild(code, id, {
+        loader: 'js',
+      });
+
+      return result;
+    },
+  };
+}
+
+export function angularVitestPlugins() {
+  return [
+    angularVitestPlugin(),
+    angularVitestEsbuildPlugin(),
+    angularVitestSourcemapPlugin(),
+  ];
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1211
Closes #1212

## What is the new behavior?

When running tests
- esbuild is disabled eagerly for Vitest.
- esbuild is used in postprocessing the files that have gone through Angular compilation to realign the sourcemaps.
- IDE breakpoints work correctly.
- Coverage reports are accurate.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/DqNeh0L4NdPX28pWdO/giphy.gif"/>
