### PR TITLE
fix(platform): load content highlighter on first content request

### DIFF
--- a/packages/platform/src/lib/content-plugin.ts
+++ b/packages/platform/src/lib/content-plugin.ts
@@ -77,42 +77,43 @@ export function contentPlugin(
     {
       name: 'analogjs-content-file',
       enforce: 'post',
-      async config() {
-        if (highlighter === 'shiki') {
-          const { getShikiHighlighter } = await import(
-            './content/shiki/index.js'
-          );
-          markedHighlighter = getShikiHighlighter(shikiOptions);
-        } else {
-          const { getPrismHighlighter } = await import(
-            './content/prism/index.js'
-          );
-          markedHighlighter = getPrismHighlighter();
-
-          const langs = [
-            'bash',
-            'css',
-            'javascript',
-            'json',
-            'markup',
-            'typescript',
-          ];
-
-          if (
-            Array.isArray(prismOptions?.additionalLangs) &&
-            prismOptions?.additionalLangs?.length > 0
-          ) {
-            langs.push(...prismOptions.additionalLangs);
-          }
-
-          const loadLanguages = await import('prismjs/components/index.js');
-
-          (loadLanguages as unknown as { default: Function }).default(langs);
-        }
-      },
       async load(id) {
         if (!id.includes('analog-content-file=true')) {
           return;
+        }
+
+        if (!markedHighlighter) {
+          if (highlighter === 'shiki') {
+            const { getShikiHighlighter } = await import(
+              './content/shiki/index.js'
+            );
+            markedHighlighter = getShikiHighlighter(shikiOptions);
+          } else {
+            const { getPrismHighlighter } = await import(
+              './content/prism/index.js'
+            );
+            markedHighlighter = getPrismHighlighter();
+
+            const langs = [
+              'bash',
+              'css',
+              'javascript',
+              'json',
+              'markup',
+              'typescript',
+            ];
+
+            if (
+              Array.isArray(prismOptions?.additionalLangs) &&
+              prismOptions?.additionalLangs?.length > 0
+            ) {
+              langs.push(...prismOptions.additionalLangs);
+            }
+
+            const loadLanguages = await import('prismjs/components/index.js');
+
+            (loadLanguages as unknown as { default: Function }).default(langs);
+          }
         }
 
         const fm: any = await import('front-matter');


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The `prism`, `marked`, and `marked-highlight` dependencies aren't loaded until a content file request is made.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
