### PR TITLE
fix(vite-plugin-nitro): use ssrBuildDir if provided for SSR entry point

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -62,15 +62,12 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
           additionalPagesDirs: options?.additionalPagesDirs,
         });
 
-        const ssrEntry = normalizePath(
-          filePrefix +
-            resolve(
-              workspaceRoot,
-              'dist',
-              rootDir,
-              `ssr/main.server${filePrefix ? '.js' : ''}`
-            )
+        const ssrEntryPath = resolve(
+          options?.ssrBuildDir ||
+            resolve(workspaceRoot, 'dist', rootDir, `ssr`),
+          `main.server${filePrefix ? '.js' : ''}`
         );
+        const ssrEntry = normalizePath(filePrefix + ssrEntryPath);
         const rendererEntry =
           filePrefix +
           normalizePath(


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Applies the `ssrBuildDir` option when building the server

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/NWpTZunsRRaJor5KD1/giphy.gif"/>