### PR TITLE
fix(router): inject HttpClient only when page endpoint is configured

### DIFF
--- a/packages/router/src/lib/route-config.ts
+++ b/packages/router/src/lib/route-config.ts
@@ -33,12 +33,12 @@ export function toRouteConfig(routeMeta: RouteMeta | undefined): RouteConfig {
   routeConfig.resolve = {
     ...routeConfig.resolve,
     load: async (route) => {
-      const http = inject(HttpClient);
       const routeConfig = route.routeConfig as Route & {
         [ANALOG_META_KEY]: { endpoint: string; endpointKey: string };
       };
 
       if (ANALOG_PAGE_ENDPOINTS[routeConfig[ANALOG_META_KEY].endpointKey]) {
+        const http = inject(HttpClient);
         const url = injectRouteEndpointURL(route);
 
         if (


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

HttpClient is not injected if page endpoints are not configured

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
