### PR TITLE
fix(vite-plugin-angular): set ngDevMode in during build optimization

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -25,6 +25,13 @@ export function buildOptimizerPlugin({
     apply: 'build',
     config() {
       return {
+        define: isProd
+          ? {
+              ngJitMode: 'false',
+              ngI18nClosureMode: 'false',
+              ngDevMode: 'false',
+            }
+          : {},
         esbuild: {
           define: isProd
             ? {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

`ngDevMode` is applied to the `define` object so dev-mode only code is tree-shaken in production

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
