### PR TITLE
fix(vite-plugin-angular): infer production build from config mode instead of NODE_ENV

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -3,10 +3,8 @@ import { Plugin } from 'vite';
 import { JavaScriptTransformer } from './utils/devkit.js';
 
 export function buildOptimizerPlugin({
-  isProd,
   jit,
 }: {
-  isProd: boolean;
   supportedBrowsers: string[];
   jit: boolean;
 }): Plugin {
@@ -19,11 +17,14 @@ export function buildOptimizerPlugin({
     },
     1
   );
+  let isProd = false;
 
   return {
     name: '@analogjs/vite-plugin-angular-optimizer',
     apply: 'build',
-    config() {
+    config(userConfig) {
+      isProd = userConfig.mode === 'production';
+
       return {
         define: isProd
           ? {

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -134,7 +134,6 @@ export function angular(options?: PluginOptions): Plugin[] {
   let builderProgram: ts.EmitAndSemanticDiagnosticsBuilderProgram;
   let watchMode = false;
   const sourceFileCache = new SourceFileCache();
-  const isProd = process.env['NODE_ENV'] === 'production';
   const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
   const isStackBlitz = !!process.versions['webcontainer'];
   const isAstroIntegration = process.env['ANALOG_ASTRO'] === 'true';
@@ -156,11 +155,13 @@ export function angular(options?: PluginOptions): Plugin[] {
   const templateUrlsResolver = new TemplateUrlsResolver();
 
   function angularPlugin(): Plugin {
+    let isProd = false;
+
     return {
       name: '@analogjs/vite-plugin-angular',
       async config(config, { command }) {
         watchMode = command === 'serve';
-
+        isProd = config.mode === 'production';
         pluginOptions.tsconfig =
           options?.tsconfig ??
           resolve(
@@ -421,7 +422,6 @@ export function angular(options?: PluginOptions): Plugin[] {
         inlineStylesExtension: pluginOptions.inlineStylesExtension,
       })) as Plugin,
     buildOptimizerPlugin({
-      isProd,
       supportedBrowsers: pluginOptions.supportedBrowsers,
       jit,
     }),
@@ -481,6 +481,7 @@ export function angular(options?: PluginOptions): Plugin[] {
   }
 
   function setupCompilation(config: ResolvedConfig, context?: unknown) {
+    const isProd = config.mode === 'production';
     const analogFiles = findAnalogFiles(config);
     const includeFiles = findIncludes();
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Fixes an issue potentially in Nx 20 where NODE_ENV is no longer set to `production` because of a change in the `@nx/vite` package on how the Vite config is loaded. Now the `production` flag is inferred from the `mode` in the vite config during the build.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/VeSvZhPrqgZxx2KpOA/giphy.gif"/>
