### PR TITLE
fix(vite-plugin-angular): add define option for ngServerMode

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -31,6 +31,7 @@ export function buildOptimizerPlugin({
               ngJitMode: 'false',
               ngI18nClosureMode: 'false',
               ngDevMode: 'false',
+              ngServerMode: `${!!userConfig.build?.ssr}`,
             }
           : {},
         esbuild: {
@@ -39,6 +40,7 @@ export function buildOptimizerPlugin({
                 ngDevMode: 'false',
                 ngJitMode: 'false',
                 ngI18nClosureMode: 'false',
+                ngServerMode: `${!!userConfig.build?.ssr}`,
               }
             : undefined,
         },


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Angular v19 introduces a new `ngServerMode` variable that is used internally to tree-shake framework server code. This allows the Vite plugin to mimic the same behavior.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/h7A2h9cMFdJhTgNHaX/giphy.gif"/>