### PR TITLE
fix(vite-plugin-angular): add NODE_ENV check as fallback for production

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -23,7 +23,9 @@ export function buildOptimizerPlugin({
     name: '@analogjs/vite-plugin-angular-optimizer',
     apply: 'build',
     config(userConfig) {
-      isProd = userConfig.mode === 'production';
+      isProd =
+        userConfig.mode === 'production' ||
+        process.env['NODE_ENV'] === 'production';
 
       return {
         define: isProd

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -161,7 +161,9 @@ export function angular(options?: PluginOptions): Plugin[] {
       name: '@analogjs/vite-plugin-angular',
       async config(config, { command }) {
         watchMode = command === 'serve';
-        isProd = config.mode === 'production';
+        isProd =
+          config.mode === 'production' ||
+          process.env['NODE_ENV'] === 'production';
         pluginOptions.tsconfig =
           options?.tsconfig ??
           resolve(


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Related to: https://github.com/storybookjs/storybook/issues/22544#issuecomment-2455088246

## What is the new behavior?

`process.env['NODE_ENV'] === 'production'` is used as a fallback check for production mode so the correct flags are set for prod optimizations and tree-shaking.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
