### PR TITLE
fix(platform): exclude Nx package from Vite optimizations

### DIFF
--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -48,6 +48,7 @@ export function depsPlugin(options?: Options): Plugin[] {
               '@nx/eslint',
               'webpack',
               'fsevents',
+              'nx',
             ],
           },
         };


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Adds `nx` to the `optimizeDependencies.exclude` array to prevent it from being optimized through esbuild.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
