### PR TITLE
fix(vitest-angular): set correct type in package.json based on output format

### DIFF
--- a/packages/vitest-angular/package.json
+++ b/packages/vitest-angular/package.json
@@ -2,7 +2,7 @@
   "name": "@analogjs/vitest-angular",
   "version": "1.9.2",
   "description": "Vitest Builder for Angular",
-  "type": "module",
+  "type": "commonjs",
   "author": "Brandon Roberts <robertsbt@gmail.com>",
   "exports": {
     ".": "./src/index.js",
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@analogjs/vite-plugin-angular": "*",
-    "@angular-devkit/architect": "^0.1500.0 || ^0.1600.0 || ^0.1700.0 || ^0.1800.0 || ^0.1900.0-rc.0",
+    "@angular-devkit/architect": "^0.1500.0 || ^0.1600.0 || ^0.1700.0 || ^0.1800.0 || next",
     "vitest": "^1.3.1 || ^2.0.0"
   },
   "ng-update": {

--- a/packages/vitest-angular/tsconfig.json
+++ b/packages/vitest-angular/tsconfig.json
@@ -7,7 +7,10 @@
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": false,
+    "inlineSourceMap": true,
+    "inlineSources": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1436 
Closes #1437

## What is the new behavior?

- Sets the `type` is set to `commonjs` for the `vitest-angular` package to be fully compatible with Angular builders and native Vitest.
- Fixes console warning about sourcemaps

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
