### PR TITLE
fix(vite-plugin-angular): improve support for Angular Material and testing using harnesses

### DIFF
--- a/apps/analog-app/project.json
+++ b/apps/analog-app/project.json
@@ -4,6 +4,7 @@
   "projectType": "application",
   "sourceRoot": "apps/analog-app/src",
   "prefix": "analogjs",
+  "implicitDependencies": ["vitest-angular"],
   "tags": [],
   "targets": {
     "build": {

--- a/apps/analog-app/project.json
+++ b/apps/analog-app/project.json
@@ -65,7 +65,7 @@
       "executor": "@nx/eslint:lint"
     },
     "test": {
-      "executor": "@analogjs/vitest-angular:test",
+      "executor": "@nx/vite:test",
       "outputs": ["{projectRoot}/coverage"]
     }
   }

--- a/apps/analog-app/project.json
+++ b/apps/analog-app/project.json
@@ -64,7 +64,7 @@
       "executor": "@nx/eslint:lint"
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@analogjs/vitest-angular:test",
       "outputs": ["{projectRoot}/coverage"]
     }
   }

--- a/libs/card/project.json
+++ b/libs/card/project.json
@@ -8,7 +8,7 @@
   "implicitDependencies": ["vitest-angular"],
   "targets": {
     "test": {
-      "executor": "@analogjs/vitest-angular:test"
+      "executor": "@nx/vite:test"
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/libs/card/project.json
+++ b/libs/card/project.json
@@ -8,7 +8,7 @@
   "implicitDependencies": ["vitest-angular"],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test"
+      "executor": "@analogjs/vitest-angular:test"
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -7,6 +7,10 @@ export function angularVitestPlugin(): Plugin {
     enforce: 'post',
     config(userConfig) {
       return {
+        optimizeDeps: {
+          include: ['tslib', '@angular/cdk/testing/testbed'],
+          exclude: ['@angular/cdk/testing'],
+        },
         ssr: {
           noExternal: [/cdk\/fesm2022/],
         },
@@ -15,6 +19,7 @@ export function angularVitestPlugin(): Plugin {
           server: {
             deps: {
               inline: [
+                '@angular/material',
                 '@analogjs/router',
                 '@analogjs/vitest-angular/setup-zone',
               ],
@@ -74,6 +79,12 @@ export function angularVitestSourcemapPlugin(): Plugin {
   return {
     name: '@analogjs/vitest-angular-sourcemap-plugin',
     async transform(code: string, id: string) {
+      const [, query] = id.split('?');
+
+      if (query && query.includes('inline')) {
+        return;
+      }
+
       const result = await transformWithEsbuild(code, id, {
         loader: 'js',
       });


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1440 

## What is the new behavior?

Angular Material and using Material Harnesses for testing is supported without additional vite configuration. 

- The `@angular/material` package wasn't being transformed when only using the `@analogjs/vite-plugin-angular` package.
- The `@angular/cdk/testing/testbed` package as not being properly optimized for testing with zone.js
- Also fixed a bug where inline styles were being processed by the internal sourcemap plugin.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/l0K4mdQxWIFn9Lr4A/giphy.gif"/>