### PR TITLE
fix(router): support transfer state/prerendering for static assets

### DIFF
--- a/apps/analog-app/vite.config.ts
+++ b/apps/analog-app/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig(({ mode }) => {
         additionalPagesDirs: ['/libs/shared/feature'],
         additionalAPIDirs: ['/libs/shared/feature/src/api'],
         prerender: {
-          routes: ['/', '/cart'],
+          routes: ['/', '/cart', '/shipping'],
           sitemap: {
             host: base,
           },

--- a/packages/router/src/lib/request-context.ts
+++ b/packages/router/src/lib/request-context.ts
@@ -34,14 +34,15 @@ export function requestContextInterceptor(
     typeof global !== 'undefined' &&
     global.$fetch &&
     baseUrl &&
-    (req.url.startsWith('/') || req.url.startsWith(baseUrl))
+    (req.url.startsWith('/') ||
+      req.url.startsWith(baseUrl) ||
+      req.url.startsWith(`/${apiPrefix}`))
   ) {
     const requestUrl = new URL(req.url, baseUrl);
     const cacheKey = makeCacheKey(req, new URL(requestUrl).pathname);
     const storeKey = makeStateKey<unknown>(`analog_${cacheKey}`);
-    const fetchUrl = req.url.includes(`/${apiPrefix}/`)
-      ? requestUrl.pathname
-      : requestUrl.href;
+    const fetchUrl = requestUrl.pathname;
+
     const responseType =
       req.responseType === 'arraybuffer' ? 'arrayBuffer' : req.responseType;
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1421

## What is the new behavior?

HttpClient requests for static assets are handled correctly during prerendering with transfer state.

For example, a public asset may be stored in `public/assets/shipping.json` and referenced as `http.get('/assets/shipping.json')`. The asset will be cached/transferred correctly with no double request on initial load.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
