### PR TITLE
docs: add section for copying assets to migration guide

### DIFF
--- a/apps/docs-app/docs/guides/migrating.md
+++ b/apps/docs-app/docs/guides/migrating.md
@@ -141,8 +141,8 @@ export default defineConfig(({ mode }) => ({
     mode === 'production' &&
       replaceFiles([
         {
-          replace: 'src/environments/environment.ts',
-          with: 'src/environments/environment.prod.ts',
+          replace: './src/environments/environment.ts',
+          with: './src/environments/environment.prod.ts',
         },
       ]),
   ],
@@ -171,4 +171,24 @@ Add the environment files to `files` array in the `tsconfig.app.json` may also b
     "src/environments/environment.prod.ts"
   ]
 }
+```
+
+## Copying Assets
+
+Static assets in the `public` directory are copied to the build output directory by default. If you want to copy additional assets outside of that directory, use the `nxCopyAssetsPlugin` Vite plugin.
+
+Import the plugin and set it up:
+
+```ts
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite';
+import analog from '@analogjs/platform';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => ({
+  // ...
+  plugins: [analog(), nxCopyAssetsPlugin(['*.md'])],
+}));
 ```


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1355 
Closes #1372 

## What is the new behavior?

- Adds a section on copying assets from outside the public directory to the migration guide.
- Fixes the path in the file replacements section

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
