### PR TITLE
fix(platform): exclude Nx Module Federation package from optimization

### DIFF
--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -46,6 +46,8 @@ export function depsPlugin(options?: Options): Plugin[] {
               '@nx/web',
               '@nx/workspace',
               '@nx/eslint',
+              '@nx/module-federation',
+              '@nx/rspack',
               'webpack',
               'fsevents',
               'nx',


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Adds `@nx/module-federation` and `@nx/rspack` to be excluded from esbuild optimization

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/555x0gFF89OhVWPkvb/giphy-downsized-medium.gif"/>