### PR TITLE
fix(vite-plugin-angular): add inline deps for angular testing library

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -25,6 +25,7 @@ export function angularVitestPlugin(): Plugin {
           server: {
             deps: {
               inline: [
+                '@angular/common',
                 '@angular/core',
                 '@angular/router',
                 '@angular/platform-browser',

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -1,5 +1,11 @@
 import { Plugin, transformWithEsbuild, UserConfig } from 'vite';
 
+/**
+ * Sets up test config for Vitest
+ * and downlevels any dependencies that use
+ * async/await to support zone.js testing
+ * and tests w/fakeAsync
+ */
 export function angularVitestPlugin(): Plugin {
   return {
     name: '@analogjs/vitest-angular-esm-plugin',
@@ -19,9 +25,13 @@ export function angularVitestPlugin(): Plugin {
           server: {
             deps: {
               inline: [
+                '@angular/core',
+                '@angular/router',
+                '@angular/platform-browser',
                 '@angular/material',
                 '@analogjs/router',
                 '@analogjs/vitest-angular/setup-zone',
+                '@testing-library/angular',
               ],
             },
           },


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Reproduction: https://github.com/zargham-leanix/vitest-fake-async

Closes # https://github.com/testing-library/angular-testing-library/issues/505

## What is the new behavior?

Allows `@testing-library/angular` to be used out of the box with `fakeAsync` tests without errors. The packages need to be downleveled from async/await in order to support `zone.js` and `fakeAsync`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
