### PR TITLE
fix(create-analog): add npm overrides for @nx/angular

### DIFF
--- a/packages/create-analog/template-blog/package.json
+++ b/packages/create-analog/template-blog/package.json
@@ -18,7 +18,6 @@
     "@analogjs/content": "^1.10.1-beta.1",
     "@analogjs/router": "^1.10.1-beta.1",
     "@angular/animations": "^19.0.0",
-    "@angular/build": "^19.0.0",
     "@angular/common": "^19.0.0",
     "@angular/compiler": "^19.0.0",
     "@angular/core": "^19.0.0",
@@ -40,6 +39,8 @@
     "@analogjs/platform": "^1.10.1-beta.1",
     "@analogjs/vite-plugin-angular": "^1.10.1-beta.1",
     "@analogjs/vitest-angular": "^1.10.1-beta.1",
+    "@angular-devkit/build-angular": "^19.0.0",
+    "@angular/build": "^19.0.0",
     "@angular/cli": "^19.0.0",
     "@angular/compiler-cli": "^19.0.0",
     "jsdom": "^22.0.0",
@@ -47,5 +48,10 @@
     "vite": "^5.0.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^2.0.0"
+  },
+  "overrides": {
+    "@nx/angular": {
+      "@angular-devkit/build-angular": "$@angular-devkit/build-angular"
+    }
   }
 }

--- a/packages/create-analog/template-latest/package.json
+++ b/packages/create-analog/template-latest/package.json
@@ -18,7 +18,6 @@
     "@analogjs/content": "^1.10.1-beta.1",
     "@analogjs/router": "^1.10.1-beta.1",
     "@angular/animations": "^19.0.0",
-    "@angular/build": "^19.0.0",
     "@angular/common": "^19.0.0",
     "@angular/compiler": "^19.0.0",
     "@angular/core": "^19.0.0",
@@ -41,6 +40,8 @@
     "@analogjs/platform": "^1.10.1-beta.1",
     "@analogjs/vite-plugin-angular": "^1.10.1-beta.1",
     "@analogjs/vitest-angular": "^1.10.1-beta.1",
+    "@angular-devkit/build-angular": "^19.0.0",
+    "@angular/build": "^19.0.0",
     "@angular/cli": "^19.0.0",
     "@angular/compiler-cli": "^19.0.0",
     "jsdom": "^22.0.0",
@@ -48,5 +49,10 @@
     "vite": "^5.0.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^2.0.0"
+  },
+  "overrides": {
+    "@nx/angular": {
+      "@angular-devkit/build-angular": "$@angular-devkit/build-angular"
+    }
   }
 }

--- a/packages/create-analog/template-minimal/package.json
+++ b/packages/create-analog/template-minimal/package.json
@@ -18,7 +18,6 @@
     "@analogjs/content": "^1.10.1-beta.1",
     "@analogjs/router": "^1.10.1-beta.1",
     "@angular/animations": "^19.0.0",
-    "@angular/build": "^19.0.0",
     "@angular/common": "^19.0.0",
     "@angular/compiler": "^19.0.0",
     "@angular/core": "^19.0.0",
@@ -41,6 +40,8 @@
     "@analogjs/platform": "^1.10.1-beta.1",
     "@analogjs/vite-plugin-angular": "^1.10.1-beta.1",
     "@analogjs/vitest-angular": "^1.10.1-beta.1",
+    "@angular-devkit/build-angular": "^19.0.0",
+    "@angular/build": "^19.0.0",
     "@angular/cli": "^19.0.0",
     "@angular/compiler-cli": "^19.0.0",
     "jsdom": "^22.0.0",
@@ -48,5 +49,10 @@
     "vite": "^5.0.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^2.0.0"
+  },
+  "overrides": {
+    "@nx/angular": {
+      "@angular-devkit/build-angular": "$@angular-devkit/build-angular"
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Adds temporary npm overrides to support installation without peer dependency errors until Nx 20.2 is released with support for Angular v19.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/Z9zo37ooUzwNwzmw4w/giphy.gif"/>