### PR TITLE
fix(create-analog): set root property to empty on angular.json

### DIFF
--- a/packages/create-analog/template-blog/angular.json
+++ b/packages/create-analog/template-blog/angular.json
@@ -5,7 +5,7 @@
   "projects": {
     "blog": {
       "projectType": "application",
-      "root": ".",
+      "root": "",
       "sourceRoot": "src",
       "prefix": "blog",
       "architect": {

--- a/packages/create-analog/template-latest/angular.json
+++ b/packages/create-analog/template-latest/angular.json
@@ -5,7 +5,7 @@
   "projects": {
     "my-app": {
       "projectType": "application",
-      "root": ".",
+      "root": "",
       "sourceRoot": "src",
       "prefix": "app",
       "architect": {

--- a/packages/create-analog/template-minimal/angular.json
+++ b/packages/create-analog/template-minimal/angular.json
@@ -5,7 +5,7 @@
   "projects": {
     "my-app": {
       "projectType": "application",
-      "root": ".",
+      "root": "",
       "sourceRoot": "src",
       "prefix": "app",
       "architect": {


### PR DESCRIPTION
## PR Checklist

Remove useless property on angular.json templates

Closes #1474 

## What is the new behavior?

Generate angular.json without root property

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
