### PR TITLE
fix(create-analog): remove override for @nx/angular package

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -10,7 +10,7 @@ on:
         type: choice
         options:
           - latest
-          - beta    
+          - beta
       angular_build_tag:
         description: 'Angular Build Tag'
         required: true

--- a/packages/create-analog/template-blog/package.json
+++ b/packages/create-analog/template-blog/package.json
@@ -48,10 +48,5 @@
     "vite": "^5.0.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^2.0.0"
-  },
-  "overrides": {
-    "@nx/angular": {
-      "@angular-devkit/build-angular": "$@angular-devkit/build-angular"
-    }
   }
 }

--- a/packages/create-analog/template-latest/package.json
+++ b/packages/create-analog/template-latest/package.json
@@ -49,10 +49,5 @@
     "vite": "^5.0.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^2.0.0"
-  },
-  "overrides": {
-    "@nx/angular": {
-      "@angular-devkit/build-angular": "$@angular-devkit/build-angular"
-    }
   }
 }

--- a/packages/create-analog/template-minimal/package.json
+++ b/packages/create-analog/template-minimal/package.json
@@ -49,10 +49,5 @@
     "vite": "^5.0.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^2.0.0"
-  },
-  "overrides": {
-    "@nx/angular": {
-      "@angular-devkit/build-angular": "$@angular-devkit/build-angular"
-    }
   }
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Nx 20.2 is released with support for Angular v19 in the `@nx/angular` package.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?