### PR TITLE
fix(vite-plugin-angular): skip double transform in JIT mode

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -311,6 +311,14 @@ export function angular(options?: PluginOptions): Plugin[] {
           return;
         }
 
+        /**
+         * Skip re-transforming files already JIT compiled
+         * with external styles or templates.
+         */
+        if (jit && code.includes('angular:jit:')) {
+          return;
+        }
+
         if (TS_EXT_REGEX.test(id)) {
           if (id.includes('.ts?')) {
             // Strip the query string off the ID


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1288

## What is the new behavior?

In JIT mode, files already transformed containing external styles and template are excluded from being re-transformed in case the plugin is included multiple times through a combination of tools like Vitest and Storybook.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/lqCbIYwLMWDLLJdByS/giphy.gif"/>