### PR TITLE
fix(vite-plugin-angular): return undefined when not resolving id

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -284,7 +284,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           )}?raw`;
         }
 
-        return id;
+        return undefined;
       },
       async transform(code, id) {
         // Skip transforming node_modules


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Instead of returning the id, return undefined to let the resolveId pass through

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
