### PR TITLE
fix(vite-plugin-angular): only apply sourcemap transform to TS files

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -81,6 +81,10 @@ export function angularVitestSourcemapPlugin(): Plugin {
   return {
     name: '@analogjs/vitest-angular-sourcemap-plugin',
     async transform(code: string, id: string) {
+      if (!/\.ts/.test(id)) {
+        return;
+      }
+
       const [, query] = id.split('?');
 
       if (query && query.includes('inline')) {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1488 

## What is the new behavior?

When apply the sourcemap transform during testing, only apply the transform to TypeScript files.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/VeSvZhPrqgZxx2KpOA/giphy.gif"/>