### PR TITLE
fix(vitest-angular): set watch mode flag when passed from CLI args

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -215,9 +215,9 @@ export function angular(options?: PluginOptions): Plugin[] {
       configResolved(config) {
         resolvedConfig = config;
 
-        // set watch mode
+        // set test watch mode
         // - environment variable from vitest-angular
-        // - @nx/vite executor set server.watch explicitly to undefined/null
+        // - @nx/vite executor set server.watch explicitly to undefined (watch)/null (watch=false)
         // - vite config for test.watch variable
         testWatchMode =
           testWatchMode ||

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -135,7 +135,7 @@ export function angular(options?: PluginOptions): Plugin[] {
   let nextProgram: NgtscProgram | undefined | ts.Program;
   let builderProgram: ts.EmitAndSemanticDiagnosticsBuilderProgram;
   let watchMode = false;
-  let testWatchMode = false;
+  let testWatchMode = process.env['ANALOG_VITEST_WATCH'] === 'true';
   const sourceFileCache = new SourceFileCache();
   const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
   const isStackBlitz = !!process.versions['webcontainer'];
@@ -214,7 +214,15 @@ export function angular(options?: PluginOptions): Plugin[] {
       },
       configResolved(config) {
         resolvedConfig = config;
-        testWatchMode = !(config.server.watch === null);
+
+        // set watch mode
+        // - environment variable from vitest-angular
+        // - @nx/vite executor set server.watch explicitly to undefined/null
+        // - vite config for test.watch variable
+        testWatchMode =
+          testWatchMode ||
+          !(config.server.watch === null) ||
+          config.test?.watch === true;
       },
       configureServer(server) {
         viteServer = server;

--- a/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
+++ b/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
@@ -12,6 +12,7 @@ async function vitestBuilder(
 ): Promise<BuilderOutput> {
   process.env['TEST'] = 'true';
   process.env['VITEST'] = 'true';
+  process.env['ANALOG_VITEST_WATCH'] = `${options.watch === true}`;
 
   const { startVitest } = await (Function(
     'return import("vitest/node")'


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1507

## What is the new behavior?

Adds additional checks for watch mode during testing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
