### PR TITLE
fix(vitest-angular): use vite overrides to pass test watch mode

### DIFF
--- a/libs/card/project.json
+++ b/libs/card/project.json
@@ -5,7 +5,6 @@
   "prefix": "lib",
   "projectType": "library",
   "tags": [],
-  "implicitDependencies": ["vitest-angular"],
   "targets": {
     "test": {
       "executor": "@nx/vite:test"

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -135,7 +135,7 @@ export function angular(options?: PluginOptions): Plugin[] {
   let nextProgram: NgtscProgram | undefined | ts.Program;
   let builderProgram: ts.EmitAndSemanticDiagnosticsBuilderProgram;
   let watchMode = false;
-  let testWatchMode = process.env['ANALOG_VITEST_WATCH'] === 'true';
+  let testWatchMode = false;
   const sourceFileCache = new SourceFileCache();
   const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
   const isStackBlitz = !!process.versions['webcontainer'];
@@ -216,13 +216,11 @@ export function angular(options?: PluginOptions): Plugin[] {
         resolvedConfig = config;
 
         // set test watch mode
-        // - environment variable from vitest-angular
+        // - vite override from vitest-angular
         // - @nx/vite executor set server.watch explicitly to undefined (watch)/null (watch=false)
         // - vite config for test.watch variable
         testWatchMode =
-          testWatchMode ||
-          !(config.server.watch === null) ||
-          config.test?.watch === true;
+          !(config.server.watch === null) || config.test?.watch === true;
       },
       configureServer(server) {
         viteServer = server;

--- a/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
+++ b/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
@@ -12,7 +12,6 @@ async function vitestBuilder(
 ): Promise<BuilderOutput> {
   process.env['TEST'] = 'true';
   process.env['VITEST'] = 'true';
-  process.env['ANALOG_VITEST_WATCH'] = `${options.watch === true}`;
 
   const { startVitest } = await (Function(
     'return import("vitest/node")'
@@ -22,14 +21,17 @@ async function vitestBuilder(
     context.target as unknown as string
   );
   const extraArgs = await getExtraArgs(options);
+  const watch = options.watch === true;
   const config = {
     root: `${projectConfig['root'] || '.'}`,
-    watch: options.watch === true,
+    watch,
     config: options.configFile,
     ...extraArgs,
   };
 
-  const server = await startVitest('test', options.testFiles ?? [], config);
+  const server = await startVitest('test', options.testFiles ?? [], config, {
+    test: { watch },
+  });
 
   let hasErrors = false;
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Related to #1507 

## What is the new behavior?

Use the vite overrides through Vitest to set the `test.watch` flag for detecting watch mode.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
