### PR TITLE
fix(platform): add front-matter for default optimization

### DIFF
--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -29,6 +29,7 @@ export function depsPlugin(options?: Options): Plugin[] {
               ...(Number(VERSION.major) > 15
                 ? ['@angular/core/rxjs-interop']
                 : []),
+              'front-matter',
             ],
             exclude: [
               '@angular/platform-server',


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Adds the `front-matter` package to the default group of optimized packages for content-based applications

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
