### PR TITLE
feat(router): introduce support for Analog Server Components

### DIFF
--- a/apps/analog-app/src/app/app.config.server.ts
+++ b/apps/analog-app/src/app/app.config.server.ts
@@ -1,15 +1,10 @@
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
-import {
-  provideServerRendering,
-  ɵSERVER_CONTEXT as SERVER_CONTEXT,
-} from '@angular/platform-server';
+import { provideServerRendering } from '@angular/platform-server';
+
 import { appConfig } from './app.config';
 
 const serverConfig: ApplicationConfig = {
-  providers: [
-    provideServerRendering(),
-    { provide: SERVER_CONTEXT, useValue: 'ssr-analog' },
-  ],
+  providers: [provideServerRendering()],
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/apps/analog-app/src/app/pages/client/(client).page.ts
+++ b/apps/analog-app/src/app/pages/client/(client).page.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ServerOnly } from '@analogjs/router';
+
+@Component({
+  standalone: true,
+  imports: [ServerOnly],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <h2>Client Component</h2>
+
+    <ServerOnly component="hello" [props]="props()" (outputs)="log($event)" />
+
+    <ServerOnly component="hello" [props]="props2()" (outputs)="log($event)" />
+
+    <p>
+      <button (click)="update()">Update</button>
+    </p>
+  `,
+})
+export default class ClientComponent {
+  props = signal({ name: 'Brandon', count: 0 });
+  props2 = signal({ name: 'Brandon', count: 4 });
+
+  update() {
+    this.props.update((data) => ({ ...data, count: ++data.count }));
+  }
+
+  log($event: object) {
+    console.log({ outputs: $event });
+  }
+}

--- a/apps/analog-app/src/app/pages/goodbye.page.analog
+++ b/apps/analog-app/src/app/pages/goodbye.page.analog
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { ServerOnly } from '@analogjs/router' with { analog: 'imports' };
+</script>
+
+<template>
+  Goodbye on the client
+
+  <ServerOnly component="goodbye" />
+</template>

--- a/apps/analog-app/src/app/pages/server/(server).page.ts
+++ b/apps/analog-app/src/app/pages/server/(server).page.ts
@@ -1,0 +1,11 @@
+import { RouteMeta } from '@analogjs/router';
+
+import { ServerOnly } from '@analogjs/router';
+
+export const routeMeta: RouteMeta = {
+  data: {
+    component: 'hello',
+  },
+};
+
+export default ServerOnly;

--- a/apps/analog-app/src/main.server.ts
+++ b/apps/analog-app/src/main.server.ts
@@ -1,31 +1,8 @@
 import 'zone.js/node';
-import { enableProdMode } from '@angular/core';
-import { bootstrapApplication } from '@angular/platform-browser';
-import { renderApplication } from '@angular/platform-server';
-import { provideServerContext } from '@analogjs/router/server';
-import type { ServerContext } from '@analogjs/router/tokens';
+import '@angular/platform-server/init';
+import { render } from '@analogjs/router/server';
 
 import { config } from './app/app.config.server';
 import { AppComponent } from './app/app.component';
 
-if (import.meta.env.PROD) {
-  enableProdMode();
-}
-
-export function bootstrap() {
-  return bootstrapApplication(AppComponent, config);
-}
-
-export default async function render(
-  url: string,
-  document: string,
-  serverContext: ServerContext
-) {
-  const html = await renderApplication(bootstrap, {
-    document,
-    url,
-    platformProviders: [provideServerContext(serverContext)],
-  });
-
-  return html;
-}
+export default render(AppComponent, config);

--- a/apps/analog-app/src/server/components/goodbye.ag
+++ b/apps/analog-app/src/server/components/goodbye.ag
@@ -1,0 +1,3 @@
+<template>
+  Goodbye from the server
+</template>

--- a/apps/analog-app/src/server/components/hello.ts
+++ b/apps/analog-app/src/server/components/hello.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+
+import {
+  injectStaticOutputs,
+  injectStaticProps,
+} from '@analogjs/router/server';
+
+@Component({
+  selector: 'app-hello',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <h3>Hello From the Server</h3>
+
+    <p>Props: {{ json() }}</p>
+
+    <p>Time: {{ Date.now().toString() }}</p>
+  `,
+  styles: `
+    h3 {
+      color: blue;
+    }
+  `,
+})
+export default class HelloComponent {
+  Date = Date;
+  props = injectStaticProps();
+  outputs = injectStaticOutputs<{ loaded: boolean }>();
+  json = computed(() => JSON.stringify(this.props));
+
+  ngOnInit() {
+    this.outputs.set({ loaded: true });
+  }
+}

--- a/apps/analog-app/tsconfig.app.json
+++ b/apps/analog-app/tsconfig.app.json
@@ -10,6 +10,7 @@
   "include": [
     "src/**/*.d.ts",
     "src/app/pages/**/*.page.ts",
+    "src/server/components/**/*.ts",
     "src/server/middleware/**/*.ts"
   ],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"]

--- a/apps/analog-app/vite.config.ts
+++ b/apps/analog-app/vite.config.ts
@@ -32,13 +32,16 @@ export default defineConfig(({ mode }) => {
         additionalPagesDirs: ['/libs/shared/feature'],
         additionalAPIDirs: ['/libs/shared/feature/src/api'],
         prerender: {
-          routes: ['/', '/cart', '/shipping'],
+          routes: ['/', '/cart', '/shipping', '/client'],
           sitemap: {
             host: base,
           },
         },
         vite: {
           inlineStylesExtension: 'scss',
+          experimental: {
+            supportAnalogFormat: true,
+          },
         },
       }),
       nxViteTsPaths(),

--- a/apps/blog-app/src/main.server.ts
+++ b/apps/blog-app/src/main.server.ts
@@ -1,31 +1,8 @@
 import 'zone.js/node';
-import { enableProdMode } from '@angular/core';
-import { bootstrapApplication } from '@angular/platform-browser';
-import { renderApplication } from '@angular/platform-server';
-import { provideServerContext } from '@analogjs/router/server';
-import { ServerContext } from '@analogjs/router/tokens';
+import '@angular/platform-server/init';
+import { render } from '@analogjs/router/server';
 
 import { config } from './app/app.config.server';
 import { AppComponent } from './app/app.component';
 
-if (import.meta.env.PROD) {
-  enableProdMode();
-}
-
-export function bootstrap() {
-  return bootstrapApplication(AppComponent, config);
-}
-
-export default async function render(
-  url: string,
-  document: string,
-  serverContext: ServerContext
-) {
-  const html = await renderApplication(bootstrap, {
-    document,
-    url,
-    platformProviders: [provideServerContext(serverContext)],
-  });
-
-  return html;
-}
+export default render(AppComponent, config);

--- a/apps/trpc-app/src/main.server.ts
+++ b/apps/trpc-app/src/main.server.ts
@@ -1,20 +1,8 @@
 import 'zone.js/node';
-import { enableProdMode } from '@angular/core';
-import { renderApplication } from '@angular/platform-server';
-import { AppComponent } from './app/app.component';
-import { bootstrapApplication } from '@angular/platform-browser';
+import '@angular/platform-server/init';
+import { render } from '@analogjs/router/server';
+
 import { config } from './app.config.server';
+import { AppComponent } from './app/app.component';
 
-if (import.meta.env.PROD) {
-  enableProdMode();
-}
-
-const bootstrap = () => bootstrapApplication(AppComponent, config);
-
-export default async function render(url: string, document: string) {
-  const html = await renderApplication(bootstrap, {
-    document,
-    url,
-  });
-  return html;
-}
+export default render(AppComponent, config);

--- a/packages/create-analog/template-blog/src/main.server.ts
+++ b/packages/create-analog/template-blog/src/main.server.ts
@@ -1,32 +1,8 @@
 import 'zone.js/node';
 import '@angular/platform-server/init';
-import { enableProdMode } from '@angular/core';
-import { bootstrapApplication } from '@angular/platform-browser';
-import { renderApplication } from '@angular/platform-server';
-import { provideServerContext } from '@analogjs/router/server';
-import { ServerContext } from '@analogjs/router/tokens';
+import { render } from '@analogjs/router/server';
 
 __APP_COMPONENT_IMPORT__
 import { config } from './app/app.config.server';
 
-if (import.meta.env.PROD) {
-  enableProdMode();
-}
-
-export function bootstrap() {
-  return bootstrapApplication(__APP_COMPONENT__, config);
-}
-
-export default async function render(
-  url: string,
-  document: string,
-  serverContext: ServerContext
-) {
-  const html = await renderApplication(bootstrap, {
-    document,
-    url,
-    platformProviders: [provideServerContext(serverContext)],
-  });
-
-  return html;
-}
+export default render(__APP_COMPONENT__, config);

--- a/packages/create-analog/template-latest/src/main.server.ts
+++ b/packages/create-analog/template-latest/src/main.server.ts
@@ -1,32 +1,8 @@
 import 'zone.js/node';
 import '@angular/platform-server/init';
-import { enableProdMode } from '@angular/core';
-import { bootstrapApplication } from '@angular/platform-browser';
-import { renderApplication } from '@angular/platform-server';
-import { provideServerContext } from '@analogjs/router/server';
-import { ServerContext } from '@analogjs/router/tokens';
+import { render } from '@analogjs/router/server';
 
 __APP_COMPONENT_IMPORT__
 import { config } from './app/app.config.server';
 
-if (import.meta.env.PROD) {
-  enableProdMode();
-}
-
-export function bootstrap() {
-  return bootstrapApplication(__APP_COMPONENT__, config);
-}
-
-export default async function render(
-  url: string,
-  document: string,
-  serverContext: ServerContext
-) {
-  const html = await renderApplication(bootstrap, {
-    document,
-    url,
-    platformProviders: [provideServerContext(serverContext)],
-  });
-
-  return html;
-}
+export default render(__APP_COMPONENT__, config);

--- a/packages/create-analog/template-minimal/src/main.server.ts
+++ b/packages/create-analog/template-minimal/src/main.server.ts
@@ -1,32 +1,8 @@
 import 'zone.js/node';
 import '@angular/platform-server/init';
-import { enableProdMode } from '@angular/core';
-import { bootstrapApplication } from '@angular/platform-browser';
-import { renderApplication } from '@angular/platform-server';
-import { provideServerContext } from '@analogjs/router/server';
-import { ServerContext } from '@analogjs/router/tokens';
+import { render } from '@analogjs/router/server';
 
 __APP_COMPONENT_IMPORT__
 import { config } from './app/app.config.server';
 
-if (import.meta.env.PROD) {
-  enableProdMode();
-}
-
-export function bootstrap() {
-  return bootstrapApplication(__APP_COMPONENT__, config);
-}
-
-export default async function render(
-  url: string,
-  document: string,
-  serverContext: ServerContext
-) {
-  const html = await renderApplication(bootstrap, {
-    document,
-    url,
-    platformProviders: [provideServerContext(serverContext)],
-  });
-
-  return html;
-}
+export default render(__APP_COMPONENT__, config);

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v18/src/main.server.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v18/src/main.server.ts__template__
@@ -1,32 +1,8 @@
 import 'zone.js/node';
 import '@angular/platform-server/init';
-import { enableProdMode } from '@angular/core';
-import { bootstrapApplication } from '@angular/platform-browser';
-import { renderApplication } from '@angular/platform-server';
-import { provideServerContext } from '@analogjs/router/server';
-import { ServerContext } from '@analogjs/router/tokens';
+import { render } from '@analogjs/router/server';
 
 import { config } from './app/app.config.server';
 import { AppComponent } from './app/app.component';
 
-if (import.meta.env.PROD) {
-  enableProdMode();
-}
-
-export function bootstrap() {
-  return bootstrapApplication(AppComponent, config);
-}
-
-export default async function render(
-  url: string,
-  document: string,
-  serverContext: ServerContext
-) {
-  const html = await renderApplication(bootstrap, {
-    document,
-    url,
-    platformProviders: [provideServerContext(serverContext)],
-  });
-
-  return html;
-}
+export default render(AppComponent, config);

--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -69,7 +69,6 @@ export function depsPlugin(options?: Options): Plugin[] {
             return pkgJson['module'] && pkgJson['module'].includes('fesm');
           },
         });
-
         return pkgConfig;
       },
     },

--- a/packages/platform/src/lib/router-plugin.ts
+++ b/packages/platform/src/lib/router-plugin.ts
@@ -87,9 +87,9 @@ export function routerPlugin(options?: Options): Plugin[] {
           );
 
           let result = code.replace(
-            'let ANALOG_ROUTE_FILES = {};',
+            'ANALOG_ROUTE_FILES = {};',
             `
-            let ANALOG_ROUTE_FILES = {${routeFiles.map(
+            ANALOG_ROUTE_FILES = {${routeFiles.map(
               (module) =>
                 `"${module.replace(root, '')}": () => import('${module}')`
             )}};
@@ -97,9 +97,9 @@ export function routerPlugin(options?: Options): Plugin[] {
           );
 
           result = result.replace(
-            'let ANALOG_CONTENT_ROUTE_FILES = {};',
+            'ANALOG_CONTENT_ROUTE_FILES = {};',
             `
-          let ANALOG_CONTENT_ROUTE_FILES = {${contentRouteFiles.map(
+          ANALOG_CONTENT_ROUTE_FILES = {${contentRouteFiles.map(
             (module) =>
               `"${module.replace(
                 root,
@@ -133,9 +133,9 @@ export function routerPlugin(options?: Options): Plugin[] {
           );
 
           const result = code.replace(
-            'let ANALOG_PAGE_ENDPOINTS = {};',
+            'ANALOG_PAGE_ENDPOINTS = {};',
             `
-            let ANALOG_PAGE_ENDPOINTS = {${endpointFiles.map(
+            ANALOG_PAGE_ENDPOINTS = {${endpointFiles.map(
               (module) =>
                 `"${module.replace(root, '')}": () => import('${module}')`
             )}};

--- a/packages/router/server/src/index.ts
+++ b/packages/router/server/src/index.ts
@@ -1,1 +1,7 @@
 export { provideServerContext } from './provide-server-context';
+export { injectStaticProps, injectStaticOutputs } from './tokens';
+export {
+  serverComponentRequest,
+  renderServerComponent,
+} from './server-component-render';
+export { render } from './render';

--- a/packages/router/server/src/render.ts
+++ b/packages/router/server/src/render.ts
@@ -1,0 +1,59 @@
+import {
+  ApplicationConfig,
+  Provider,
+  Type,
+  enableProdMode,
+} from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { renderApplication } from '@angular/platform-server';
+import type { ServerContext } from '@analogjs/router/tokens';
+
+import { provideServerContext } from './provide-server-context';
+import {
+  serverComponentRequest,
+  renderServerComponent,
+} from './server-component-render';
+
+if (import.meta.env.PROD) {
+  enableProdMode();
+}
+
+/**
+ * Returns a function that accepts the navigation URL,
+ * the root HTML, and server context.
+ *
+ * @param rootComponent
+ * @param config
+ * @param platformProviders
+ * @returns Promise<string | Reponse>
+ */
+export function render(
+  rootComponent: Type<unknown>,
+  config: ApplicationConfig,
+  platformProviders: Provider[] = []
+) {
+  function bootstrap() {
+    return bootstrapApplication(rootComponent, config);
+  }
+
+  return async function render(
+    url: string,
+    document: string,
+    serverContext: ServerContext
+  ) {
+    if (serverComponentRequest(serverContext)) {
+      return await renderServerComponent(url, serverContext);
+    }
+
+    const html = await renderApplication(bootstrap, {
+      document,
+      url,
+      platformProviders: [
+        provideServerContext(serverContext),
+        platformProviders,
+      ],
+    });
+
+    return html;
+  };
+}

--- a/packages/router/server/src/server-component-render.ts
+++ b/packages/router/server/src/server-component-render.ts
@@ -1,0 +1,167 @@
+import { ApplicationConfig, Type } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import {
+  reflectComponentType,
+  ɵConsole as Console,
+  APP_ID,
+} from '@angular/core';
+import {
+  provideServerRendering,
+  renderApplication,
+  ɵSERVER_CONTEXT as SERVER_CONTEXT,
+} from '@angular/platform-server';
+import { ServerContext } from '@analogjs/router/tokens';
+import { createEvent, readBody, getHeader } from 'h3';
+
+import { provideStaticProps } from './tokens';
+
+type ComponentLoader = () => Promise<Type<unknown>>;
+
+export function serverComponentRequest(serverContext: ServerContext) {
+  const serverComponentId = getHeader(
+    createEvent(serverContext.req, serverContext.res),
+    'X-Analog-Component'
+  );
+
+  if (
+    !serverComponentId &&
+    serverContext.req.url &&
+    serverContext.req.url.startsWith('/_analog/components')
+  ) {
+    const componentId = serverContext.req.url.split('/')?.[3];
+
+    return componentId;
+  }
+
+  return serverComponentId;
+}
+
+const components = import.meta.glob([
+  '/src/server/components/**/*.{ts,analog,ag}',
+]);
+
+export async function renderServerComponent(
+  url: string,
+  serverContext: ServerContext,
+  config?: ApplicationConfig
+) {
+  const componentReqId = serverComponentRequest(serverContext) as string;
+  const { componentLoader, componentId } = getComponentLoader(componentReqId);
+
+  if (!componentLoader) {
+    return new Response(`Server Component Not Found ${componentId}`, {
+      status: 404,
+    });
+  }
+
+  const component = ((await componentLoader()) as any)[
+    'default'
+  ] as Type<unknown>;
+
+  if (!component) {
+    return new Response(`No default export for ${componentId}`, {
+      status: 422,
+    });
+  }
+
+  const mirror = reflectComponentType(component);
+  const selector = mirror?.selector.split(',')?.[0] || 'server-component';
+  const event = createEvent(serverContext.req, serverContext.res);
+  const body = (await readBody(event)) || {};
+  const appId = `analog-server-${selector.toLowerCase()}-${new Date().getTime()}`;
+
+  const bootstrap = () =>
+    bootstrapApplication(component, {
+      providers: [
+        provideServerRendering(),
+        provideStaticProps(body),
+        { provide: SERVER_CONTEXT, useValue: 'analog-server-component' },
+        {
+          provide: APP_ID,
+          useFactory() {
+            return appId;
+          },
+        },
+        ...(config?.providers || []),
+      ],
+    });
+
+  const html = await renderApplication(bootstrap, {
+    url,
+    document: `<${selector}></${selector}>`,
+    platformProviders: [
+      {
+        provide: Console,
+        useFactory() {
+          return {
+            warn: () => {},
+            log: () => {},
+          };
+        },
+      },
+    ],
+  });
+
+  const outputs = retrieveTransferredState(html, appId);
+  const responseData: { html: string; outputs: Record<string, any> } = {
+    html,
+    outputs,
+  };
+
+  return new Response(JSON.stringify(responseData), {
+    headers: {
+      'X-Analog-Component': 'true',
+    },
+  });
+}
+
+function getComponentLoader(componentReqId: string): {
+  componentLoader: ComponentLoader | undefined;
+  componentId: string;
+} {
+  let _componentId = `/src/server/components/${componentReqId.toLowerCase()}`;
+  let componentLoader: ComponentLoader | undefined = undefined;
+  let componentId = _componentId;
+
+  if (components[`${_componentId}.ts`]) {
+    componentId = `${_componentId}.ts`;
+    componentLoader = components[componentId] as ComponentLoader;
+  } else if (components[`${componentId}.analog`]) {
+    componentId = `${_componentId}.analog`;
+    componentLoader = components[componentId] as ComponentLoader;
+  } else if (components[`${componentId}.ag`]) {
+    componentId = `${_componentId}.ag`;
+    componentLoader = components[componentId] as ComponentLoader;
+  }
+
+  return { componentLoader, componentId };
+}
+
+function retrieveTransferredState(
+  html: string,
+  appId: string
+): Record<string, unknown | undefined> {
+  const regex = new RegExp(
+    `<script id="${appId}-state" type="application/json">(.*?)<\/script>`
+  );
+  const match = html.match(regex);
+
+  if (match) {
+    const scriptContent = match[1];
+
+    if (scriptContent) {
+      try {
+        const parsedContent: {
+          _analog_output: Record<string, unknown | undefined>;
+        } = JSON.parse(scriptContent);
+        return parsedContent._analog_output || {};
+      } catch (e) {
+        console.warn('Exception while parsing static outputs for ' + appId, e);
+      }
+    }
+
+    return {};
+  } else {
+    return {};
+  }
+}

--- a/packages/router/server/src/tokens.ts
+++ b/packages/router/server/src/tokens.ts
@@ -1,0 +1,40 @@
+import {
+  assertInInjectionContext,
+  inject,
+  InjectionToken,
+  makeStateKey,
+  Provider,
+  TransferState,
+} from '@angular/core';
+
+export const STATIC_PROPS = new InjectionToken<Record<string, any>>(
+  'Static Props'
+);
+
+export function provideStaticProps<T = Record<string, any>>(
+  props: T
+): Provider {
+  return {
+    provide: STATIC_PROPS,
+    useFactory() {
+      return props;
+    },
+  };
+}
+
+export function injectStaticProps() {
+  assertInInjectionContext(injectStaticProps);
+
+  return inject(STATIC_PROPS);
+}
+
+export function injectStaticOutputs<T>() {
+  const transferState = inject(TransferState);
+  const outputsKey = makeStateKey<T>('_analog_output');
+
+  return {
+    set(data: T) {
+      transferState.set(outputsKey, data);
+    },
+  };
+}

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -17,3 +17,4 @@ export { injectRouteEndpointURL } from './lib/inject-route-endpoint-url';
 export { FormAction } from './lib/form-action.directive';
 export { injectDebugRoutes } from './lib/debug/routes';
 export { withDebugRoutes } from './lib/debug';
+export { ServerOnly } from './lib/server.component';

--- a/packages/router/src/lib/cache-key.ts
+++ b/packages/router/src/lib/cache-key.ts
@@ -1,0 +1,47 @@
+import { HttpParams, HttpRequest } from '@angular/common/http';
+import { StateKey, makeStateKey } from '@angular/core';
+
+function sortAndConcatParams(params: HttpParams | URLSearchParams): string {
+  return [...params.keys()]
+    .sort()
+    .map((k) => `${k}=${params.getAll(k)}`)
+    .join('&');
+}
+
+export function makeCacheKey(
+  request: HttpRequest<any>,
+  mappedRequestUrl: string
+): StateKey<unknown> {
+  // make the params encoded same as a url so it's easy to identify
+  const { params, method, responseType } = request;
+  const encodedParams = sortAndConcatParams(params);
+
+  let serializedBody = request.serializeBody();
+  if (serializedBody instanceof URLSearchParams) {
+    serializedBody = sortAndConcatParams(serializedBody);
+  } else if (typeof serializedBody !== 'string') {
+    serializedBody = '';
+  }
+
+  const key = [
+    method,
+    responseType,
+    mappedRequestUrl,
+    serializedBody,
+    encodedParams,
+  ].join('|');
+
+  const hash = generateHash(key);
+
+  return makeStateKey(hash);
+}
+
+function generateHash(str: string) {
+  let hash = 0;
+  for (let i = 0, len = str.length; i < len; i++) {
+    let chr = str.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return `${hash}`;
+}

--- a/packages/router/src/lib/server.component.ts
+++ b/packages/router/src/lib/server.component.ts
@@ -1,0 +1,135 @@
+import {
+  HttpClient,
+  HttpHeaders,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  input,
+  makeStateKey,
+  output,
+  signal,
+  TransferState,
+} from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+import { injectBaseURL } from '@analogjs/router/tokens';
+import { catchError, map, of, throwError } from 'rxjs';
+
+import { makeCacheKey } from './cache-key';
+
+type ServerProps = Record<string, any>;
+type ServerOutputs = Record<string, any>;
+
+/**
+ * @description
+ * Component that defines the bridge between the client and server-only
+ * components. The component passes the component ID and props to the server
+ * and retrieves the rendered HTML and outputs from the server-only component.
+ *
+ * Status: experimental
+ */
+@Component({
+  selector: 'server-only,ServerOnly,Server',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: ` <div [innerHTML]="content()"></div> `,
+})
+export class ServerOnly {
+  component = input.required<string>();
+  props = input<ServerProps>();
+  outputs = output<ServerOutputs>();
+  private http = inject(HttpClient);
+  private sanitizer = inject(DomSanitizer);
+  protected content = signal<SafeHtml>('');
+  private route = inject(ActivatedRoute, { optional: true });
+  private baseURL = injectBaseURL();
+  private transferState = inject(TransferState);
+
+  constructor() {
+    effect(() => {
+      const routeComponentId: string | undefined =
+        this.route?.snapshot.data['component'];
+      const props = this.props() || {};
+      const componentId = routeComponentId || this.component();
+
+      const headers = new HttpHeaders(
+        new Headers({
+          'Content-type': 'application/json',
+          'X-Analog-Component': componentId,
+        })
+      );
+
+      const componentUrl = this.getComponentUrl(componentId);
+      const httpRequest = new HttpRequest('POST', componentUrl, props, {
+        headers,
+      });
+      const cacheKey = makeCacheKey(
+        httpRequest,
+        new URL(componentUrl).pathname
+      );
+      const storeKey = makeStateKey<{ html: string; outputs: ServerOutputs }>(
+        cacheKey
+      );
+      const componentState = this.transferState.get<{
+        html: string;
+        outputs: ServerOutputs;
+      } | null>(storeKey, null);
+
+      if (componentState) {
+        this.updateContent(componentState);
+        this.transferState.remove(storeKey);
+      } else {
+        this.http
+          .request(httpRequest)
+          .pipe(
+            map((response) => {
+              if (response instanceof HttpResponse) {
+                if (import.meta.env.SSR) {
+                  this.transferState.set(storeKey, response.body);
+                }
+
+                return response.body as {
+                  html: string;
+                  outputs: ServerOutputs;
+                };
+              }
+              return throwError(
+                () => ({} as { html: string; outputs: ServerOutputs })
+              );
+            }),
+            catchError((error: unknown) => {
+              console.log(error);
+              return of({
+                html: '',
+                outputs: {} as ServerOutputs,
+              });
+            })
+          )
+          .subscribe((content) =>
+            this.updateContent(
+              content as { html: string; outputs: ServerOutputs }
+            )
+          );
+      }
+    });
+  }
+
+  updateContent(content: { html: string; outputs: ServerOutputs }) {
+    this.content.set(this.sanitizer.bypassSecurityTrustHtml(content.html));
+    this.outputs.emit(content.outputs);
+  }
+
+  getComponentUrl(componentId: string) {
+    let baseURL = this.baseURL;
+
+    if (!baseURL && typeof window !== 'undefined') {
+      baseURL = window.location.origin;
+    }
+
+    return `${baseURL}/_analog/components/${componentId}`;
+  }
+}


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #989 

## What is the new behavior?

Introduces `Analog Server Components` which are inspired by/similar to `Nuxt Server Components` and `Astro Islands` in that the component is **only** rendered on the server, with its HTML output being sent back to the client. 

This is not the same as Incremental Hydration in Angular, where the client-side JS is loaded for the component(s) after the hydration trigger happens. The JS for these components is _never_ sent to the client.

- NOTES
  - No client-side interactivity: Rendered links will cause a page to reload upon clicking. We do have a directive that can be used to intercept these clicks and perform navigation, but that's not part of this initial effort. These components render heavy HTML content on the server without sending the JavaScript to the client.
  - Angular components and Analog SFCs are supported
  - Styles are supported

**Examples**

The server components are placed in the `src/server/components` directory without any trailing names like `.component.ts`:

```ts
// src/server/components/hello.ts
import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
import { readFileSync } from 'node:fs';

import {
  injectStaticOutputs,
  injectStaticProps,
} from '@analogjs/router/server';

@Component({
  selector: 'app-hello',
  template: `
    <h3>Hello From the Server</h3>

    <p>Props: {{ json() }}</p>

    <p>Time: {{ Date.now().toString() }}</p>

    <p>readFileSync: {{ readFileSync }}</p>  
  `,
  styles: `
    h3 {
      color: blue;
    }
  `,
})
export default class HelloComponent {
  Date = Date;
  props = injectStaticProps();
  outputs = injectStaticOutputs<{ loaded: boolean }>();
  json = computed(() => JSON.stringify(this.props));
  readFileSync = !!readFileSync;

  ngOnInit() {
    this.outputs.set({ loaded: true });
  }
}
```

- The `injectStaticProps` function provides the props sent from the client
- The `injectStaticOutputs` provides a way to communicate "outputs" back to the client. They must be serializable as JSON.

For usage on the client-side, a `ServerOnly` component import is provided:

```ts
import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
import { ServerOnly } from '@analogjs/router';

@Component({
  imports: [ServerOnly],
  template: `
    <h2>Client Component</h2>

    <ServerOnly component="hello" [props]="props()" (outputs)="log($event)" />

    <p>
      <button (click)="update()">Update</button>
    </p>
  `,
})
export default class ClientComponent {
  props = signal({ name: 'Brandon', count: 0 });

  update() {
    this.props.update((data) => ({ ...data, count: ++data.count }));
  }

  log($event: object) {
    console.log({ outputs: $event });
  }
}
```

- The `component` input points to the server-only component path, minus the file extension.
- The `props` input should be JSON serializable data.
- The `outputs` are received from the server-only component.

Server-only components can also be used as top-level routes:

```ts
import { RouteMeta } from '@analogjs/router';

import { ServerOnly } from '@analogjs/router';

export const routeMeta: RouteMeta = {
  data: {
    component: 'hello',
  },
};

export default ServerOnly;
```

**Setup**

Add the server components path to the `tsconfig.app.json`

```json
{
  "extends": "./tsconfig.json",
  "compilerOptions": {
    "outDir": "../../dist/out-tsc",
    "types": [],
    "target": "ES2022",
    "useDefineForClassFields": false
  },
  "files": ["src/main.ts", "src/main.server.ts"],
  "include": [
    "src/**/*.d.ts",
    "src/app/pages/**/*.page.ts",
    "src/server/components/**/*.ts",
    "src/server/middleware/**/*.ts"
  ],
  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
}
```

Use the new `render` function in the `main.server.ts`:

```ts
import 'zone.js/node';
import '@angular/platform-server/init';
import { render } from '@analogjs/router/server';

import { config } from './app/app.config.server';
import { AppComponent } from './app/app.component';

export default render(AppComponent, config);
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Demo links: 

https://deploy-preview-1518--analog-app.netlify.app/client - Client w/server component

https://deploy-preview-1518--analog-app.netlify.app/server - Server component as route

https://deploy-preview-1518--analog-app.netlify.app/goodbye - Analog SFCs

Additional uses cases and feedback can be provided here: https://github.com/analogjs/analog/discussions/1517

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/2SPBeZjRQMjCw/giphy.gif"/>