### PR TITLE
fix(vitest-angular): reuse vitest server in watch mode for build-test

### DIFF
--- a/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
+++ b/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
@@ -31,7 +31,7 @@ async function vitestBuilder(
 
   const server = await startVitest('test', options.testFiles ?? [], config, {
     test: { watch },
-  });
+  } as any);
 
   let hasErrors = false;
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The `build-test` executor was respawning a new server on each change in watch mode. Now it will reuse the same Vitest server to run the tests after changes are made.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
