### PR TITLE
feat(vitest-angular): add UI and coverage options to test

### DIFF
--- a/packages/vitest-angular/src/lib/builders/test/schema.d.ts
+++ b/packages/vitest-angular/src/lib/builders/test/schema.d.ts
@@ -4,4 +4,6 @@ export interface VitestSchema {
   reportsDirectory?: string;
   testFiles?: string[];
   watch?: boolean;
+  ui?: boolean;
+  coverage?: boolean;
 }

--- a/packages/vitest-angular/src/lib/builders/test/schema.json
+++ b/packages/vitest-angular/src/lib/builders/test/schema.json
@@ -28,6 +28,14 @@
     "watch": {
       "description": "Watch files for changes and rerun tests related to changed files.",
       "type": "boolean"
+    },
+    "ui": {
+      "description": "Run tests using Vitest UI Mode.",
+      "type": "boolean"
+    },
+    "coverage": {
+      "description": "Enable code coverage analysis.",
+      "type": "boolean"
     }
   },
   "required": []

--- a/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
+++ b/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
@@ -20,10 +20,7 @@ async function vitestBuilder(
   const projectConfig = await context.getProjectMetadata(
     context.target as unknown as string
   );
-  const {
-    coverageArgs,
-    ...extraArgs
-  } = await getExtraArgs(options);
+  const { coverageArgs, ...extraArgs } = await getExtraArgs(options);
   const watch = options.watch === true;
   const ui = options.ui === true;
   const coverageEnabled = options.coverage === true;

--- a/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
+++ b/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
@@ -20,12 +20,22 @@ async function vitestBuilder(
   const projectConfig = await context.getProjectMetadata(
     context.target as unknown as string
   );
-  const extraArgs = await getExtraArgs(options);
+  const {
+    coverageArgs,
+    ...extraArgs
+  } = await getExtraArgs(options);
   const watch = options.watch === true;
+  const ui = options.ui === true;
+  const coverageEnabled = options.coverage === true;
   const config = {
     root: `${projectConfig['root'] || '.'}`,
     watch,
+    ui,
     config: options.configFile,
+    coverage: {
+      enabled: coverageEnabled,
+      ...coverageArgs,
+    },
     ...extraArgs,
   };
 


### PR DESCRIPTION
## PR Checklist

Closes #1520 

## What is the new behavior?

This PR adds support for the `--coverage` and `--ui` flags in the `@analogjs/vitest-angular` builder CLI. Users can now dynamically enable these options without manually configuring them in `angular.json`.

Example usage:

```bash
ng test --coverage   # Display test coverage  
ng test --ui         # Enable UI mode  
```

This simplifies testing workflows by reducing unnecessary `angular.json` complexity.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
