### PR TITLE
feat(vite-plugin-angular): introduce support for Angular v19 HMR/live reload

### DIFF
--- a/apps/analog-app/vite.config.ts
+++ b/apps/analog-app/vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig(({ mode }) => {
             supportAnalogFormat: true,
           },
         },
+        liveReload: true,
       }),
       nxViteTsPaths(),
       visualizer() as Plugin,

--- a/apps/ng-app/vite.config.ts
+++ b/apps/ng-app/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig(({ mode }) => ({
     analog({
       ssr: false,
       static: true,
+      liveReload: true,
       vite: {
         experimental: {
           supportAnalogFormat: true,

--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -37,6 +37,12 @@ export interface Options {
   index?: string;
   workspaceRoot?: string;
   content?: ContentPluginOptions;
+
+  /**
+   * Enables Angular's HMR during development
+   */
+  liveReload?: boolean;
+
   /**
    * Additional page paths to include
    */

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -36,6 +36,7 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
         ),
       ],
       additionalContentDirs: platformOptions.additionalContentDirs,
+      liveReload: platformOptions.liveReload,
       ...(opts?.vite ?? {}),
     }),
     serverModePlugin(),

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -46,6 +46,7 @@ import {
 } from './authoring/markdown-transform.js';
 import { routerPlugin } from './router-plugin.js';
 import { pendingTasksPlugin } from './angular-pending-tasks.plugin.js';
+import { analyzeFileUpdates } from './utils/hmr-candidates.js';
 
 export interface PluginOptions {
   tsconfig?: string;
@@ -84,11 +85,15 @@ interface EmitFileResult {
   map?: string;
   dependencies: readonly string[];
   hash?: Uint8Array;
-  errors: (string | ts.DiagnosticMessageChain)[];
-  warnings: (string | ts.DiagnosticMessageChain)[];
+  errors?: (string | ts.DiagnosticMessageChain)[];
+  warnings?: (string | ts.DiagnosticMessageChain)[];
   hmrUpdateCode?: string | null;
+  hmrEligible?: boolean;
 }
-type FileEmitter = (file: string) => Promise<EmitFileResult | undefined>;
+type FileEmitter = (
+  file: string,
+  source?: ts.SourceFile
+) => Promise<EmitFileResult | undefined>;
 
 /**
  * TypeScript file extension regex
@@ -305,17 +310,26 @@ export function angular(options?: PluginOptions): Plugin[] {
           const fileId =
             ctx.file.split('?')[0] +
             (pluginOptions.supportAnalogFormat ? '.ts' : '');
+          const stale = sourceFileCache.get(fileId);
           sourceFileCache.invalidate([fileId]);
           await buildAndAnalyze();
 
-          if (pluginOptions.liveReload && classNames.get(fileId)) {
+          const result = await fileEmitter?.(fileId, stale);
+
+          if (
+            pluginOptions.liveReload &&
+            !!result?.hmrEligible &&
+            classNames.get(fileId)
+          ) {
             const relativeFileId = `${relative(
               process.cwd(),
               fileId
             )}@${classNames.get(fileId)}`;
 
             sendHMRComponentUpdate(ctx.server, relativeFileId);
-
+            ctx.server.config.logger.info(
+              `[HMR Update]: ${relativeFileId.split('@')[0]}`
+            );
             return [];
           }
         }
@@ -359,7 +373,16 @@ export function angular(options?: PluginOptions): Plugin[] {
               sendHMRComponentUpdate(ctx.server, impRelativeFileId);
             });
 
-            return ctx.modules;
+            return ctx.modules.map((mod) => {
+              if (mod.id === ctx.file) {
+                return {
+                  ...mod,
+                  isSelfAccepting: true,
+                } as ModuleNode;
+              }
+
+              return mod;
+            });
           }
 
           return mods;
@@ -769,10 +792,19 @@ export function createFileEmitter(
   angularCompiler?: NgtscProgram['compiler'],
   liveReload?: boolean
 ): FileEmitter {
-  return async (file: string) => {
+  return async (file: string, stale?: ts.SourceFile) => {
     const sourceFile = program.getSourceFile(file);
     if (!sourceFile) {
       return undefined;
+    }
+
+    if (stale) {
+      const hmrEligible = !!analyzeFileUpdates(
+        stale,
+        sourceFile,
+        angularCompiler!
+      );
+      return { dependencies: [], hmrEligible };
     }
 
     const diagnostics = angularCompiler

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -675,6 +675,9 @@ export function angular(options?: PluginOptions): Plugin[] {
 
     if (pluginOptions.liveReload) {
       tsCompilerOptions['_enableHmr'] = true;
+      // Workaround for https://github.com/angular/angular/issues/59310
+      // Force extra instructions to be generated for HMR w/defer
+      tsCompilerOptions['supportTestBed'] = true;
     }
 
     rootNames = rn.concat(analogFiles, includeFiles);

--- a/packages/vite-plugin-angular/src/lib/utils/hmr-candidates.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/hmr-candidates.ts
@@ -1,0 +1,367 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type ng from '@angular/compiler-cli';
+import assert from 'node:assert';
+import ts from 'typescript';
+
+/**
+ * Analyzes one or more modified files for changes to determine if any
+ * class declarations for Angular components are candidates for hot
+ * module replacement (HMR). If any source files are also modified but
+ * are not candidates then all candidates become invalid. This invalidation
+ * ensures that a full rebuild occurs and the running application stays
+ * synchronized with the code.
+ * @param modifiedFiles A set of modified files to analyze.
+ * @param param1 An Angular compiler instance
+ * @param staleSourceFiles A map of paths to previous source file instances.
+ * @returns A set of HMR candidate component class declarations.
+ */
+export function collectHmrCandidates(
+  modifiedFiles: Set<string>,
+  { compiler }: ng.NgtscProgram,
+  staleSourceFiles: Map<string, ts.SourceFile> | undefined
+): Set<ts.ClassDeclaration> {
+  const candidates = new Set<ts.ClassDeclaration>();
+
+  for (const file of modifiedFiles) {
+    // If the file is a template for component(s), add component classes as candidates
+    const templateFileNodes = compiler.getComponentsWithTemplateFile(file);
+    if (templateFileNodes.size) {
+      templateFileNodes.forEach((node) =>
+        candidates.add(node as ts.ClassDeclaration)
+      );
+      continue;
+    }
+
+    // If the file is a style for component(s), add component classes as candidates
+    const styleFileNodes = compiler.getComponentsWithStyleFile(file);
+    if (styleFileNodes.size) {
+      styleFileNodes.forEach((node) =>
+        candidates.add(node as ts.ClassDeclaration)
+      );
+      continue;
+    }
+
+    const staleSource = staleSourceFiles?.get(file);
+    if (staleSource === undefined) {
+      // Unknown file requires a rebuild so clear out the candidates and stop collecting
+      candidates.clear();
+      break;
+    }
+
+    const updatedSource = compiler.getCurrentProgram().getSourceFile(file);
+    if (updatedSource === undefined) {
+      // No longer existing program file requires a rebuild so clear out the candidates and stop collecting
+      candidates.clear();
+      break;
+    }
+
+    // Analyze the stale and updated file for changes
+    const fileCandidates = analyzeFileUpdates(
+      staleSource,
+      updatedSource,
+      compiler
+    );
+    if (fileCandidates) {
+      fileCandidates.forEach((node) => candidates.add(node));
+    } else {
+      // Unsupported HMR changes present
+      // Only template and style literal changes are allowed.
+      candidates.clear();
+      break;
+    }
+  }
+
+  return candidates;
+}
+
+/**
+ * Analyzes the updates of a source file for potential HMR component class candidates.
+ * A source file can contain candidates if only the Angular component metadata of a class
+ * has been changed and the metadata changes are only of supported fields.
+ * @param stale The stale (previous) source file instance.
+ * @param updated The updated source file instance.
+ * @param compiler An Angular compiler instance.
+ * @returns An array of candidate class declarations; or `null` if unsupported changes are present.
+ */
+export function analyzeFileUpdates(
+  stale: ts.SourceFile,
+  updated: ts.SourceFile,
+  compiler: ng.NgtscProgram['compiler']
+): ts.ClassDeclaration[] | null {
+  if (stale.statements.length !== updated.statements.length) {
+    return null;
+  }
+
+  const candidates: ts.ClassDeclaration[] = [];
+
+  for (let i = 0; i < updated.statements.length; ++i) {
+    const updatedNode = updated.statements[i];
+    const staleNode = stale.statements[i];
+
+    if (ts.isClassDeclaration(updatedNode)) {
+      if (!ts.isClassDeclaration(staleNode)) {
+        return null;
+      }
+
+      // Check class declaration differences (name/heritage/modifiers)
+      if (updatedNode.name?.text !== staleNode.name?.text) {
+        return null;
+      }
+      if (
+        !equalRangeText(
+          updatedNode.heritageClauses,
+          updated,
+          staleNode.heritageClauses,
+          stale
+        )
+      ) {
+        return null;
+      }
+      const updatedModifiers = ts.getModifiers(updatedNode);
+      const staleModifiers = ts.getModifiers(staleNode);
+      if (
+        updatedModifiers?.length !== staleModifiers?.length ||
+        !updatedModifiers?.every((updatedModifier) =>
+          staleModifiers?.some(
+            (staleModifier) => updatedModifier.kind === staleModifier.kind
+          )
+        )
+      ) {
+        return null;
+      }
+
+      // Check for component class nodes
+      const meta = compiler.getMeta(updatedNode);
+      if (
+        meta?.decorator &&
+        (meta as { isComponent?: boolean }).isComponent === true
+      ) {
+        const updatedDecorators = ts.getDecorators(updatedNode);
+        const staleDecorators = ts.getDecorators(staleNode);
+        if (
+          !staleDecorators ||
+          staleDecorators.length !== updatedDecorators?.length
+        ) {
+          return null;
+        }
+
+        // TODO: Check other decorators instead of assuming all multi-decorator components are unsupported
+        if (staleDecorators.length > 1) {
+          return null;
+        }
+
+        // Find index of component metadata decorator
+        const metaDecoratorIndex = updatedDecorators?.indexOf(meta.decorator);
+        assert(
+          metaDecoratorIndex !== undefined,
+          'Component metadata decorator should always be present on component class.'
+        );
+        const updatedDecoratorExpression = meta.decorator.expression;
+        assert(
+          ts.isCallExpression(updatedDecoratorExpression) &&
+            updatedDecoratorExpression.arguments.length === 1,
+          'Component metadata decorator should contain a call expression with a single argument.'
+        );
+
+        // Check the matching stale index for the component decorator
+        const staleDecoratorExpression =
+          staleDecorators[metaDecoratorIndex]?.expression;
+        if (
+          !staleDecoratorExpression ||
+          !ts.isCallExpression(staleDecoratorExpression) ||
+          staleDecoratorExpression.arguments.length !== 1
+        ) {
+          return null;
+        }
+
+        // Check decorator name/expression
+        // NOTE: This would typically be `Component` but can also be a property expression or some other alias.
+        // To avoid complex checks, this ensures the textual representation does not change. This has a low chance
+        // of a false positive if the expression is changed to still reference the `Component` type but has different
+        // text. However, it is rare for `Component` to not be used directly and additionally unlikely that it would
+        // be changed between edits. A false positive would also only lead to a difference of a full page reload versus
+        // an HMR update.
+        if (
+          !equalRangeText(
+            updatedDecoratorExpression.expression,
+            updated,
+            staleDecoratorExpression.expression,
+            stale
+          )
+        ) {
+          return null;
+        }
+
+        // Compare component meta decorator object literals
+        if (
+          hasUnsupportedMetaUpdates(
+            staleDecoratorExpression,
+            stale,
+            updatedDecoratorExpression,
+            updated
+          )
+        ) {
+          return null;
+        }
+
+        // Compare text of the member nodes to determine if any changes have occurred
+        if (
+          !equalRangeText(
+            updatedNode.members,
+            updated,
+            staleNode.members,
+            stale
+          )
+        ) {
+          // A change to a member outside a component's metadata is unsupported
+          return null;
+        }
+
+        // If all previous class checks passed, this class is supported for HMR updates
+        candidates.push(updatedNode);
+        continue;
+      }
+    }
+
+    // Compare text of the statement nodes to determine if any changes have occurred
+    // TODO: Consider expanding this to check semantic updates for each node kind
+    if (!equalRangeText(updatedNode, updated, staleNode, stale)) {
+      // A change to a statement outside a component's metadata is unsupported
+      return null;
+    }
+  }
+
+  return candidates;
+}
+
+/**
+ * The set of Angular component metadata fields that are supported by HMR updates.
+ */
+const SUPPORTED_FIELDS = new Set([
+  'template',
+  'templateUrl',
+  'styles',
+  'styleUrl',
+  'stylesUrl',
+]);
+
+/**
+ * Analyzes the metadata fields of a decorator call expression for unsupported HMR updates.
+ * Only updates to supported fields can be present for HMR to be viable.
+ * @param staleCall A call expression instance.
+ * @param staleSource The source file instance containing the stale call instance.
+ * @param updatedCall A call expression instance.
+ * @param updatedSource The source file instance containing the updated call instance.
+ * @returns true, if unsupported metadata updates are present; false, otherwise.
+ */
+function hasUnsupportedMetaUpdates(
+  staleCall: ts.CallExpression,
+  staleSource: ts.SourceFile,
+  updatedCall: ts.CallExpression,
+  updatedSource: ts.SourceFile
+): boolean {
+  const staleObject = staleCall.arguments[0];
+  const updatedObject = updatedCall.arguments[0];
+
+  if (
+    !ts.isObjectLiteralExpression(staleObject) ||
+    !ts.isObjectLiteralExpression(updatedObject)
+  ) {
+    return true;
+  }
+
+  const unsupportedFields: ts.Node[] = [];
+
+  for (const property of staleObject.properties) {
+    if (
+      !ts.isPropertyAssignment(property) ||
+      ts.isComputedPropertyName(property.name)
+    ) {
+      // Unsupported object literal property
+      return true;
+    }
+
+    const name = property.name.text;
+    if (SUPPORTED_FIELDS.has(name)) {
+      continue;
+    }
+
+    unsupportedFields.push(property.initializer);
+  }
+
+  let i = 0;
+  for (const property of updatedObject.properties) {
+    if (
+      !ts.isPropertyAssignment(property) ||
+      ts.isComputedPropertyName(property.name)
+    ) {
+      // Unsupported object literal property
+      return true;
+    }
+
+    const name = property.name.text;
+    if (SUPPORTED_FIELDS.has(name)) {
+      continue;
+    }
+
+    // Compare in order
+    if (
+      !equalRangeText(
+        property.initializer,
+        updatedSource,
+        unsupportedFields[i++],
+        staleSource
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return i !== unsupportedFields.length;
+}
+
+/**
+ * Compares the text from a provided range in a source file to the text of a range in a second source file.
+ * The comparison avoids making any intermediate string copies.
+ * @param firstRange A text range within the first source file.
+ * @param firstSource A source file instance.
+ * @param secondRange A text range within the second source file.
+ * @param secondSource A source file instance.
+ * @returns true, if the text from both ranges is equal; false, otherwise.
+ */
+function equalRangeText(
+  firstRange: ts.ReadonlyTextRange | undefined,
+  firstSource: ts.SourceFile,
+  secondRange: ts.ReadonlyTextRange | undefined,
+  secondSource: ts.SourceFile
+): boolean {
+  // Check matching undefined values
+  if (!firstRange || !secondRange) {
+    return firstRange === secondRange;
+  }
+
+  // Ensure lengths are equal
+  const firstLength = firstRange.end - firstRange.pos;
+  const secondLength = secondRange.end - secondRange.pos;
+  if (firstLength !== secondLength) {
+    return false;
+  }
+
+  // Check each character
+  for (let i = 0; i < firstLength; ++i) {
+    const firstChar = firstSource.text.charCodeAt(i + firstRange.pos);
+    const secondChar = secondSource.text.charCodeAt(i + secondRange.pos);
+    if (firstChar !== secondChar) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1524

## What is the new behavior?

When using the `liveReload` option in the `analog` plugin with Angular v19, the new HMR code generated by the compiler is handled by the vite plugin, enabling HMR updates without full page reloads.

- Inline styles and templates are supported
- External styles and templates are supported
- Page reloads occur when classes are changed (logic copied from Angular compilation)

```ts
/// <reference types="vitest" />

import { defineConfig } from 'vite';
import analog from '@analogjs/platform';

// https://vitejs.dev/config/
export default defineConfig(({ mode }) => ({
  // ..other config
  plugins: [analog({ liveReload: true })],
}));
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Links
https://vite.dev/guide/api-plugin.html#handlehotupdate
https://bjornlu.com/blog/hot-module-replacement-is-easy#importmetahotaccept

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/7A7iNCHhPpqwaNRgV1/giphy.gif"/>