### PR TITLE
fix(vite-plugin-angular): skip rebuilds before invalidation during testing

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -509,9 +509,11 @@ export function angular(options?: PluginOptions): Plugin[] {
           if (isTest) {
             const tsMod = viteServer?.moduleGraph.getModuleById(id);
             if (tsMod) {
-              sourceFileCache.invalidate([id]);
+              const invalidated = tsMod.lastInvalidationTimestamp;
 
-              if (testWatchMode) {
+              if (testWatchMode && invalidated) {
+                sourceFileCache.invalidate([id]);
+
                 await buildAndAnalyze();
               }
             }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When running tests in watch mode, the test files won't be re-compiled until they are invalidated. This increases the speed for the initial test run because files have not been changed since the first build

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
