### PR TITLE
ci: skip caching for Vite tests, fix segfault with node 22 for card tests

### DIFF
--- a/libs/card/vite.config.ts
+++ b/libs/card/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(({ mode }) => {
       setupFiles: ['src/test-setup.ts'],
       include: ['**/*.spec.ts'],
       cacheDir: '../../node_modules/.vitest',
+      pool: 'vmForks',
     },
     define: {
       'import.meta.vitest': mode !== 'production',

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "e2e": "nx run-many --target e2e --projects create-analog-e2e,analog-app-e2e-cypress --parallel=1 --exclude analog-app-e2e-playwright",
     "test": "nx run-many --target test",
     "build:vite-ci": "npm run build",
-    "test:vite-ci": "nx run-many --target test --all",
+    "test:vite-ci": "nx run-many --target test --all --skip-nx-cache",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Skips nx caching when running Vite Ecosystem CI tests
- Changes `pool` for `card` tests to workaround segfault with node 22+

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/10tt2DwqDd4AWk/giphy.gif"/>