### PR TITLE
fix(vite-plugin-angular): fix HMR of component styles

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -712,6 +712,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
     if (pluginOptions.liveReload) {
       tsCompilerOptions['_enableHmr'] = true;
+      tsCompilerOptions['externalRuntimeStyles'] = true;
       // Workaround for https://github.com/angular/angular/issues/59310
       // Force extra instructions to be generated for HMR w/defer
       tsCompilerOptions['supportTestBed'] = true;


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1534

## What is the new behavior?

HMR of component styles works when using an NgModule bootstrapped application or when animations are enabled

Found by looking at the angular CLI source:
https://github.com/angular/angular-cli/blob/9b57ff0552736e6fef44c0ff7e6535f9ed832c6b/packages/angular/build/src/builders/dev-server/vite-server.ts#L142-L143

https://github.com/angular/angular-cli/blob/9b57ff0552736e6fef44c0ff7e6535f9ed832c6b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts#L707

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXc5bmh2cHlvc2Z2Zm1nNnV0NGx3bHZ5NHhxdnNwNmE0ZTNiaTZ1dCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MdA16VIoXKKxNE8Stk/giphy.webp">