### PR TITLE
ci: disable file parallelism for card lib

### DIFF
--- a/libs/card/vite.config.ts
+++ b/libs/card/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }) => {
       include: ['**/*.spec.ts'],
       cacheDir: '../../node_modules/.vitest',
       pool: 'vmForks',
+      fileParallelism: false,
     },
     define: {
       'import.meta.vitest': mode !== 'production',


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When running `card` tests in parallel with node22+ and `vmForks` an error is thrown. This disables file parallelism for the card library to stabilize the tests in CI.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
