### PR TITLE
fix(vite-plugin-angular): correctly implement HMR of component styles

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -746,7 +746,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       tsCompilerOptions.compilationMode = 'experimental-local';
     }
 
-    if (pluginOptions.liveReload) {
+    if (pluginOptions.liveReload && watchMode) {
       tsCompilerOptions['_enableHmr'] = true;
       tsCompilerOptions['externalRuntimeStyles'] = true;
       // Workaround for https://github.com/angular/angular/issues/59310

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -14,7 +14,7 @@ import {
   ResolvedConfig,
   Connect,
 } from 'vite';
-import { encapsulateStyle } from '@angular/compiler';
+import * as ngCompiler from '@angular/compiler';
 
 import { createCompilerPlugin } from './compiler-plugin.js';
 import {
@@ -523,7 +523,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         if (pluginOptions.liveReload && isComponentStyleSheet(id)) {
           const { encapsulation, componentId } = getComponentStyleSheetMeta(id);
           if (encapsulation === 'emulated' && componentId) {
-            const encapsulated = encapsulateStyle(code, componentId);
+            const encapsulated = ngCompiler.encapsulateStyle(code, componentId);
             return {
               code: encapsulated,
               map: null,

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -350,15 +350,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
             return ctx.modules.map((mod) => {
               if (mod.id === ctx.file) {
-                // support Vite 6
-                if ('_clientModule' in mod) {
-                  (mod as any)['_clientModule'].isSelfAccepting = true;
-                }
-
-                return {
-                  ...mod,
-                  isSelfAccepting: true,
-                } as ModuleNode;
+                return markModuleSelfAccepting(mod);
               }
 
               return mod;
@@ -374,7 +366,45 @@ export function angular(options?: PluginOptions): Plugin[] {
           const isDirect = ctx.modules.find(
             (mod) => ctx.file === mod.file && mod.id?.includes('?direct')
           );
-          if (isDirect) {
+          if (pluginOptions.liveReload && isDirect?.id && isDirect.file) {
+            const isComponentStyle =
+              isDirect.type === 'css' && isDirect.id?.includes('ngcomp=');
+            if (isComponentStyle) {
+              const encapsulation = new URL(
+                isDirect.id,
+                'http://localhost'
+              ).searchParams.get('e');
+
+              // Track if the component uses ShadowDOM encapsulation (3 = ViewEncapsulation.ShadowDom)
+              // Shadow DOM components currently require a full reload.
+              // Vite's CSS hot replacement does not support shadow root searching.
+              if (encapsulation !== '3') {
+                ctx.server.ws.send({
+                  type: 'update',
+                  updates: [
+                    {
+                      type: 'css-update',
+                      timestamp: Date.now(),
+                      path: isDirect.id,
+                      acceptedPath: isDirect.file,
+                    },
+                  ],
+                });
+
+                return ctx.modules
+                  .filter((mod) => {
+                    // Component stylesheets will have 2 modules (*.component.scss and *.component.scss?direct&ngcomp=xyz&e=x)
+                    // We remove the module with the query params to prevent vite double logging the stylesheet name "hmr update *.component.scss, *.component.scss?direct&ngcomp=xyz&e=x"
+                    return mod.file !== ctx.file || mod.id !== isDirect.id;
+                  })
+                  .map((mod) => {
+                    if (mod.file === ctx.file) {
+                      return markModuleSelfAccepting(mod);
+                    }
+                    return mod;
+                  }) as ModuleNode[];
+              }
+            }
             return ctx.modules;
           }
 
@@ -407,15 +437,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
             return ctx.modules.map((mod) => {
               if (mod.id === ctx.file) {
-                // support Vite 6
-                if ('_clientModule' in mod) {
-                  (mod as any)['_clientModule'].isSelfAccepting = true;
-                }
-
-                return {
-                  ...mod,
-                  isSelfAccepting: true,
-                } as ModuleNode;
+                return markModuleSelfAccepting(mod);
               }
 
               return mod;
@@ -920,4 +942,16 @@ function getDiagnosticsForSourceFile(
     ...semanticDiagnostics,
     ...angularDiagnostics,
   ];
+}
+
+function markModuleSelfAccepting(mod: ModuleNode): ModuleNode {
+  // support Vite 6
+  if ('_clientModule' in mod) {
+    (mod as any)['_clientModule'].isSelfAccepting = true;
+  }
+
+  return {
+    ...mod,
+    isSelfAccepting: true,
+  } as ModuleNode;
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Follow up to https://github.com/analogjs/analog/pull/1539

## What is the new behavior?

In https://github.com/analogjs/analog/pull/1539 I thought I had fixed HMR, but actually what that change did was disable HMR for component stylesheets and trigger a full reload 🤦‍♂️ 

So this followup implements the missing pieces:
1. Implements the appropriate callback for component stylesheets in the `handleHotUpdate` plugin hook to reimplement HMR of component styles
2. Handles `ViewEncapsulation.Emulated` components by using the `encapsulateStyle` helper

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Relevant bits from the CLI where I based this code from:
* https://github.com/clydin/angular-cli/blob/602081d18f3c5e0a878f4bf0986461d8b6041130/packages/angular/build/src/builders/dev-server/vite-server.ts#L479-L514
* https://github.com/angular/angular-cli/blob/ddae37fdf3c1c93bd2ae9c51812a9d469b68bd77/packages/angular/build/src/tools/vite/middlewares/assets-middleware.ts#L84-L135

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNzU5ejEzdnVlYTB3OWsxZThnaXB4bHcyenlla3QwaTFxd3MzcnRpOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/uyoXx0qpUWfQs/200.webp">