### PR TITLE
fix(vite-plugin-angular): use ssr.noExternal for matching libraries during testing

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -18,15 +18,10 @@ export function angularVitestPlugin(): Plugin {
           exclude: ['@angular/cdk/testing'],
         },
         ssr: {
-          noExternal: [/cdk\/fesm2022/],
+          noExternal: [/cdk\/fesm2022/, /fesm2022(.*?)testing/, /fesm2015/],
         },
         test: {
           pool: userConfig.test?.pool ?? 'vmThreads',
-          server: {
-            deps: {
-              inline: [/fesm2022(.*?)testing/],
-            },
-          },
         },
       };
     },


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1530

## What is the new behavior?

- The `ssr.noExternal` array is used instead of the `test.server.inline.deps` array so Vitest can merge the items correctly and custom inline deps can be provided without being overwritten.
- Also added `/fesm2015/` for legacy library support without additional config

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/fB4q4O89sSWVCN3awV/giphy-downsized-medium.gif"/>