### PR TITLE
fix(vite-plugin-angular): fix SSG and HMR of external component stylesheets

### DIFF
--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -12,6 +12,7 @@ import { MarkdownTemplateTransform } from './authoring/markdown-transform.js';
 
 import { createRequire } from 'node:module';
 import { createHash } from 'node:crypto';
+import path from 'path';
 
 const require = createRequire(import.meta.url);
 
@@ -33,6 +34,7 @@ export function augmentHostWithResources(
     isProd?: boolean;
     markdownTemplateTransforms?: MarkdownTemplateTransform[];
     inlineComponentStyles?: Map<string, string>;
+    externalComponentStyles?: Map<string, string>;
   }
 ) {
   const ts = require('typescript');
@@ -40,7 +42,6 @@ export function augmentHostWithResources(
   const baseGetSourceFile = (
     resourceHost as ts.CompilerHost
   ).getSourceFile.bind(resourceHost);
-  const externalStylesheets = new Map<string, string>();
 
   if (options.supportAnalogFormat) {
     (resourceHost as ts.CompilerHost).getSourceFile = (
@@ -187,6 +188,33 @@ export function augmentHostWithResources(
 
     return null;
   };
+
+  resourceHost.resourceNameToFileName = function (
+    resourceName,
+    containingFile
+  ) {
+    const resolvedPath = path.join(path.dirname(containingFile), resourceName);
+
+    // All resource names that have template file extensions are assumed to be templates
+    if (
+      !options.externalComponentStyles ||
+      hasTemplateExtension(resolvedPath)
+    ) {
+      return resolvedPath;
+    }
+
+    // For external stylesheets, create a unique identifier and store the mapping
+    let externalId = options.externalComponentStyles.get(resolvedPath);
+    if (externalId === undefined) {
+      externalId = createHash('sha256').update(resolvedPath).digest('hex');
+    }
+
+    const filename = externalId + path.extname(resolvedPath);
+
+    options.externalComponentStyles.set(filename, resolvedPath);
+
+    return filename;
+  };
 }
 
 export function augmentProgramWithVersioning(program: ts.Program): void {
@@ -260,4 +288,17 @@ export function mergeTransformers(
   }
 
   return result;
+}
+
+function hasTemplateExtension(file: string): boolean {
+  const extension = path.extname(file).toLowerCase();
+
+  switch (extension) {
+    case '.htm':
+    case '.html':
+    case '.svg':
+      return true;
+  }
+
+  return false;
 }

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -12,7 +12,7 @@ import { MarkdownTemplateTransform } from './authoring/markdown-transform.js';
 
 import { createRequire } from 'node:module';
 import { createHash } from 'node:crypto';
-import path from 'path';
+import path from 'node:path';
 
 const require = createRequire(import.meta.url);
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Fixes HMR of component `styleUrls` when using SSG. Without this patch, all component stylesheet urls will be added to the DOM twice, and only the first one will be reloaded dynamically so the changes won't appear on the page.

To test it locally, you can make a change in `apps/analog-app/src/app/pages/shipping/shipping.scss` and observe HMR working on `http://localhost:3000/shipping`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
