### PR TITLE
fix(vite-plugin-angular): only store valid HMR updates and clear on a full page reload

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -285,7 +285,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             const resolvedId = resolve(process.cwd(), fileId);
             const invalidated =
               !!server.moduleGraph.getModuleById(resolvedId)
-                ?.lastInvalidationTimestamp;
+                ?.lastInvalidationTimestamp && classNames.get(resolvedId);
 
             // don't send an HMR update until the file has been invalidated
             if (!invalidated) {
@@ -451,6 +451,8 @@ export function angular(options?: PluginOptions): Plugin[] {
           return mods;
         }
 
+        // clear HMR updates with a full reload
+        classNames.clear();
         return ctx.modules;
       },
       resolveId(id, importer) {
@@ -941,7 +943,7 @@ export function createFileEmitter(
       for (const node of sourceFile.statements) {
         if (ts.isClassDeclaration(node) && node.name != null) {
           hmrUpdateCode = angularCompiler?.emitHmrUpdateModule(node);
-          classNames.set(file, node.name.getText());
+          !!hmrUpdateCode && classNames.set(file, node.name.getText());
         }
       }
     }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Only store valid HMR updates from the compiler. 
- Correctly clears cache of HMR updates when full page reload is triggered, presenting app rendering inconsistencies.
 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
