### PR TITLE
fix(vite-plugin-angular): disable type checking diagnostics by default

### DIFF
--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -65,6 +65,10 @@ export interface Options {
    * requests to / in the production server build.
    */
   useAPIMiddleware?: boolean;
+  /**
+   * Disable type checking diagnostics by the Angular compiler
+   */
+  disableTypeChecking?: boolean;
 }
 
 export interface PrerenderContentDir {

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -29,6 +29,7 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
     ...angular({
       jit: platformOptions.jit,
       workspaceRoot: platformOptions.workspaceRoot,
+      disableTypeChecking: platformOptions.disableTypeChecking ?? false,
       include: [
         ...(platformOptions.include ?? []),
         ...(platformOptions.additionalPagesDirs ?? []).map(

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -137,7 +137,7 @@ export function angular(options?: PluginOptions): Plugin[] {
     include: options?.include ?? [],
     additionalContentDirs: options?.additionalContentDirs ?? [],
     liveReload: options?.liveReload ?? false,
-    disableTypeChecking: options?.disableTypeChecking ?? false,
+    disableTypeChecking: options?.disableTypeChecking ?? true,
   };
 
   // The file emitter created during `onStart` that will be used during the build in `onLoad` callbacks for TS files


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1551 
## What is the new behavior?

- Type checking diagnostics were added and enabled by default, which could break existing apps. The type checking is disabled in the plugin by default, and enabled in the platform plugin for apps.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/ZY8ACtLEMRODZcBdOj/giphy.gif"/>