### PR TITLE
fix(vite-plugin-angular): use whole angular version for pending tasks replacement

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-pending-tasks.plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-pending-tasks.plugin.ts
@@ -1,6 +1,6 @@
 import { Plugin } from 'vite';
 
-import { angularMajor, angularPatch } from './utils/devkit.js';
+import { angularMajor, angularMinor, angularPatch } from './utils/devkit.js';
 
 /**
  * This plugin is a workaround for the ɵPendingTasks symbol being renamed
@@ -14,7 +14,7 @@ export function pendingTasksPlugin(): Plugin {
     name: 'analogjs-pending-tasks-plugin',
     transform(code, id) {
       if (
-        Number(`${angularMajor}.${angularPatch}`) < 19.4 &&
+        Number(`${angularMajor}${angularMinor}${angularPatch}`) < 1904 &&
         id.includes('analogjs-content.mjs')
       ) {
         return {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1554

## What is the new behavior?

The whole angular version is used to determine whether its earlier than version 19.0.4 when doing the replacement for the PendingTasks symbol.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/VeSvZhPrqgZxx2KpOA/giphy.gif"/>