### PR TITLE
added angular-query to the internal deps list

### DIFF
--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -21,7 +21,7 @@ export function depsPlugin(options?: Options): Plugin[] {
               'rxfire',
               '@ng-web-apis/**',
               '@taiga-ui/**',
-              '@tanstack/angular-query-experimental'
+              '@tanstack/angular-query-experimental',
             ],
           },
           optimizeDeps: {

--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -21,6 +21,7 @@ export function depsPlugin(options?: Options): Plugin[] {
               'rxfire',
               '@ng-web-apis/**',
               '@taiga-ui/**',
+              '@tanstack/angular-query-experimental'
             ],
           },
           optimizeDeps: {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Vite showed the following error because the @tanstack-angular-experimental was not in the known dep list. 
![image](https://github.com/user-attachments/assets/5e1e4c5e-8f57-46fe-a5d3-8fcd474e0e4e)

Closes #

## What is the new behavior?
Serving analog project no longer shows RuntimeError for any injection from the @tanstack-angular-experimental library. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
