### PR TITLE
fix(vite-plugin-angular): fix component HMR with angular 19.1.2

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -265,7 +265,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               return;
             }
 
-            if (!req.url.startsWith(ANGULAR_COMPONENT_PREFIX)) {
+            if (!req.url.includes(ANGULAR_COMPONENT_PREFIX)) {
               next();
 
               return;


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In angular `19.1.2` component template urls were changed to be relative via https://github.com/angular/angular/pull/59620. Unfortunately this breaks component template HMR with the vite plugin

![CleanShot 2025-01-20 at 18 03 59@2x](https://github.com/user-attachments/assets/0dc3bf4a-6f1c-4c7b-8d4d-a9804781fe45)

Luckily the fix is pretty straight forward (copied from https://github.com/angular/angular-cli/pull/29386)

## What is the new behavior?

Component template HMR works again

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWE5ZXhsY2lnMDdmbTJoamhvYmxzNmEyZzJoZWhybDEzczZvdWN3NSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vzO0Vc8b2VBLi/giphy.gif">
