### PR TITLE
fix(nx-plugin): ensure correct installation of Angular/Vite packages

### DIFF
--- a/packages/nx-plugin/src/generators/app/versions/dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/dependencies.ts
@@ -84,7 +84,7 @@ export const getAnalogDependencies = (
   // install 15.X deps for versions 15.8.0 =< 16.1.0
   if (lt(escapedNxVersion, '16.1.0')) {
     return {
-      '@angular/platform-server': angularVersion,
+      '@angular/platform-server': `^${angularVersion}`,
       '@analogjs/content': V15_X_ANALOG_JS_CONTENT,
       '@analogjs/router': V15_X_ANALOG_JS_ROUTER,
       'front-matter': V15_X_FRONT_MATTER,
@@ -97,7 +97,7 @@ export const getAnalogDependencies = (
   // install 16.X deps for versions 16.1.0 =< 16.10.0
   if (lt(escapedNxVersion, '17.0.0')) {
     return {
-      '@angular/platform-server': angularVersion,
+      '@angular/platform-server': `^${angularVersion}`,
       '@analogjs/content': V16_X_ANALOG_JS_CONTENT,
       '@analogjs/router': V16_X_ANALOG_JS_ROUTER,
       'front-matter': V16_X_FRONT_MATTER,
@@ -113,7 +113,7 @@ export const getAnalogDependencies = (
   // install 17.X deps for versions <18.0.0
   if (lt(escapedNxVersion, '18.0.0')) {
     return {
-      '@angular/platform-server': angularVersion,
+      '@angular/platform-server': `^${angularVersion}`,
       '@analogjs/content': V17_X_ANALOG_JS_CONTENT,
       '@analogjs/router': V17_X_ANALOG_JS_ROUTER,
       'front-matter': V17_X_FRONT_MATTER,
@@ -128,7 +128,7 @@ export const getAnalogDependencies = (
 
   // return latest 18.X deps for versions >= 18.0.0
   return {
-    '@angular/platform-server': angularVersion,
+    '@angular/platform-server': `^${angularVersion}`,
     '@analogjs/content': V18_X_ANALOG_JS_CONTENT,
     '@analogjs/router': V18_X_ANALOG_JS_ROUTER,
     'front-matter': V18_X_FRONT_MATTER,

--- a/packages/nx-plugin/src/utils/versions/dev-dependencies.ts
+++ b/packages/nx-plugin/src/utils/versions/dev-dependencies.ts
@@ -44,6 +44,7 @@ import {
   V19_X_JSDOM,
   V19_X_VITE_TSCONFIG_PATHS,
   V19_X_VITEST,
+  V19_X_VITE,
 } from './ng_19_X/versions';
 
 const devDependencyKeys = [
@@ -53,6 +54,7 @@ const devDependencyKeys = [
   'vite-tsconfig-paths',
   'vitest',
   '@nx/vite',
+  'vite',
 ] as const;
 export type AnalogDevDependency = (typeof devDependencyKeys)[number];
 
@@ -81,6 +83,7 @@ const getDevDependencies = (escapedAngularVersion: string) => {
       '@nx/vite': V15_X_NX_VITE,
       jsdom: V15_X_JSDOM,
       'vite-tsconfig-paths': V15_X_VITE_TSCONFIG_PATHS,
+      vite: V19_X_VITE,
       vitest: V15_X_VITEST,
     };
   }
@@ -94,6 +97,7 @@ const getDevDependencies = (escapedAngularVersion: string) => {
       '@nx/vite': V16_X_NX_VITE,
       jsdom: V16_X_JSDOM,
       'vite-tsconfig-paths': V16_X_VITE_TSCONFIG_PATHS,
+      vite: V19_X_VITE,
       vitest: V16_X_VITEST,
     };
   }
@@ -107,6 +111,7 @@ const getDevDependencies = (escapedAngularVersion: string) => {
       '@nx/vite': V17_X_NX_VITE,
       jsdom: V17_X_JSDOM,
       'vite-tsconfig-paths': V17_X_VITE_TSCONFIG_PATHS,
+      vite: V19_X_VITE,
       vitest: V17_X_VITEST,
     };
   }
@@ -120,6 +125,7 @@ const getDevDependencies = (escapedAngularVersion: string) => {
       '@nx/vite': V18_X_NX_VITE,
       jsdom: V18_X_JSDOM,
       'vite-tsconfig-paths': V18_X_VITE_TSCONFIG_PATHS,
+      vite: V19_X_VITE,
       vitest: V18_X_VITEST,
     };
   }
@@ -132,6 +138,7 @@ const getDevDependencies = (escapedAngularVersion: string) => {
     '@nx/vite': V19_X_NX_VITE,
     jsdom: V19_X_JSDOM,
     'vite-tsconfig-paths': V19_X_VITE_TSCONFIG_PATHS,
+    vite: V19_X_VITE,
     vitest: V19_X_VITEST,
   };
 };

--- a/packages/nx-plugin/src/utils/versions/ng_19_X/versions.ts
+++ b/packages/nx-plugin/src/utils/versions/ng_19_X/versions.ts
@@ -16,3 +16,4 @@ export const V19_X_NX_VITE = '^20.0.0';
 export const V19_X_JSDOM = '^22.0.0';
 export const V19_X_VITE_TSCONFIG_PATHS = '^4.2.0';
 export const V19_X_VITEST = '^2.0.0';
+export const V19_X_VITE = '^5.0.0';


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1565

## What is the new behavior?

- When using the Analog Nx preset or generating a new application, the latest `@angular/platform-server` version is installed.
- Vite is installed as a dev dependency.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
