### PR TITLE
fix(vite-plugin-angular): cache MarkedSetupService creation

### DIFF
--- a/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
@@ -1,17 +1,26 @@
 import { FRONTMATTER_REGEX } from './constants.js';
 import { type VFile } from 'vfile';
+import { type MarkedSetupService } from './marked-setup.service.js';
 
 export type MarkdownTemplateTransform = (
   content: string,
   fileName: string
 ) => string | Promise<string> | Promise<VFile>;
 
+let markedSetupServicePromise: undefined | Promise<MarkedSetupService>;
+
 export const defaultMarkdownTemplateTransform: MarkdownTemplateTransform =
   async (content: string) => {
-    const { MarkedSetupService } = await import('./marked-setup.service.js');
-
+    if (!markedSetupServicePromise) {
+      // set immediately to prevent other calls from seeing markedSetupServicePromise as
+      // undefined - can't use await here
+      markedSetupServicePromise = import('./marked-setup.service.js').then(
+        ({ MarkedSetupService }) => new MarkedSetupService()
+      );
+    }
     // read template sections, parse markdown
-    const markedSetupService = new MarkedSetupService();
+    const markedSetupService = await markedSetupServicePromise;
+
     const mdContent = markedSetupService
       .getMarkedInstance()
       .parse(


### PR DESCRIPTION
## PR Checklist

`defaultMarkdownTemplateTransform` was creating a new instance of `MarkedSetupService` each time the function ran. For a site with ~150 content files, this led to a wait time of ~10 mins per change for the page to update. The server would also sometimes crash with an out of memory error.

## What is the new behavior?

The `MarkedSetupService` is just created once, which brings the time for ~150 content files down to ~10 seconds.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/l4pT3pj8ptVDqepTW/giphy.gif"/>