### PR TITLE
fix(vite-plugin-angular): support double quotes in analog import attributes

### DIFF
--- a/packages/vite-plugin-angular/src/lib/authoring/analog.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.spec.ts
@@ -7,7 +7,7 @@ import External from './external.analog' with { analog: 'imports' };
 import { ExternalService } from './external' with { analog: 'providers' };
 import { ExternalEnum } from './external.model' with { analog: 'exposes' };
 import './noname.analog' with { analog: 'imports' };
-import './noname.ag' with { analog: 'imports' };
+import './noname.ag' with { analog: "imports" };
 
 defineMetadata({
   exposes: [Math],

--- a/packages/vite-plugin-angular/src/lib/authoring/analog.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.ts
@@ -215,7 +215,7 @@ function processAnalogScript(
 
       for (const attribute of attributes || []) {
         if (attribute.name === 'analog') {
-          const value = attribute.value.replaceAll("'", '');
+          const value = attribute.value.replaceAll("'", '').replaceAll('"', '');
           if (!(value in importAttributes)) {
             throw new Error(
               `[Analog] Invalid Analog import attribute ${value} in ${fileName}`


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

While using SFCs I had issues with the import attributes only supporting single quotes. I installed Analog in my NX mono repo and eslint is configured for double quotes.
I spent a couple of hours figuring out it was the quote not parsed correctly in the Analog file processor.
Maybe it's deliberate and I'm the only one in this space using double quotes, but I think double quotes should be supported regarding the spec for import attributes.
Also updated the test case.
I'm not sure that the implementation does cover any edge cases or should cover any other edge cases, any advice on this ?

## What is the new behavior?

Double and single are supported in the same way for import attributes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExYXlwbmtqd3YzczA2dHR4YjR6N2d6cjVha3RzcXhtYThhenZ6eWt5YiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/h7A9YxNGPCr3fjouNb/giphy.gif">