### PR TITLE
fix(vite-plugin-angular): add exception for agx to resourceNameToFileName

### DIFF
--- a/apps/blog-app/vite.config.ts
+++ b/apps/blog-app/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig(() => {
     },
     plugins: [
       analog({
+        liveReload: true,
         vite: {
           experimental: {
             supportAnalogFormat: true,

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -308,6 +308,7 @@ function hasTemplateExtension(file: string): boolean {
     case '.htm':
     case '.html':
     case '.svg':
+    case '.agx':
       return true;
   }
 


### PR DESCRIPTION
## PR Checklist

The fix for stylesheets introduced in this PR: https://github.com/analogjs/analog/pull/1548 was affecting `agx` file reads, causing this error when using `liveReload`:

```
Error: Unable to locate component resource: ad4a60f31e46cd89ca8510889c7b9419076f239c2fb9738980044ba80e354986.agx
```

## What is the new behavior?

This PR adds an exception for `.agx` files so the filenames are not hashed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/fwEPVxQuugbQVmwmN9/giphy.gif"/>
