### PR TITLE
fix(vite-plugin-angular): check for style extension in resourceNameToFileName

### DIFF
--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -207,10 +207,7 @@ export function augmentHostWithResources(
     const resolvedPath = path.join(path.dirname(containingFile), resourceName);
 
     // All resource names that have template file extensions are assumed to be templates
-    if (
-      !options.externalComponentStyles ||
-      hasTemplateExtension(resolvedPath)
-    ) {
+    if (!options.externalComponentStyles || !hasStyleExtension(resolvedPath)) {
       return resolvedPath;
     }
 
@@ -301,14 +298,12 @@ export function mergeTransformers(
   return result;
 }
 
-function hasTemplateExtension(file: string): boolean {
+function hasStyleExtension(file: string): boolean {
   const extension = path.extname(file).toLowerCase();
 
   switch (extension) {
-    case '.htm':
-    case '.html':
-    case '.svg':
-    case '.agx':
+    case '.css':
+    case '.scss':
       return true;
   }
 


### PR DESCRIPTION
## PR Checklist

Same issue as https://github.com/analogjs/analog/pull/1595 but it is also happening for `.ag` (and I assume `.analog`) files

## What is the new behavior?

Instead of checking for all valid exceptions, `resourceNameToFileName` will just check for style extensions (`.css` and `.scss`)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
