### PR TITLE
fix(vite-plugin-angular): add detection for Vitest CLI in watch mode

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1,8 +1,58 @@
 import { describe, it, expect } from 'vitest';
-import { angular } from './angular-vite-plugin';
+import { angular, isTestWatchMode } from './angular-vite-plugin';
 
 describe('angularVitePlugin', () => {
   it('should work', () => {
     expect(angular()[0].name).toEqual('@analogjs/vite-plugin-angular');
+  });
+});
+
+describe('isTestWatchMode', () => {
+  it('should return false if vitest command not included in the command', () => {
+    const result = isTestWatchMode('vite');
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for vitest --run', () => {
+    const result = isTestWatchMode('vitest', ['--run']);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return true for vitest --no-run', () => {
+    const result = isTestWatchMode('vitest', ['--no-run']);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for vitest --watch', () => {
+    const result = isTestWatchMode('vitest', ['--watch']);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for vitest watch', () => {
+    const result = isTestWatchMode('vitest', ['watch']);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false for vitest --no-watch', () => {
+    const result = isTestWatchMode('vitest', ['--no-watch']);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for vitest --watch=false', () => {
+    const result = isTestWatchMode('vitest', ['--watch=false']);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for vitest --watch false', () => {
+    const result = isTestWatchMode('vitest', ['--watch', 'false']);
+
+    expect(result).toBeFalsy();
   });
 });


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1598 

## What is the new behavior?

When using the Vitest CLI directly, watch mode is picked up correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/gSRkSblDEjUuk/giphy.gif?cid=bd3ea57evq2uze1sjg6x1dxvojbuwiwq3297wykorlcwafkf&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>