### PR TITLE
refactor: upgrade prettier to support new Angular syntax

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -14,1215 +14,903 @@
       "name": "Brandon",
       "avatar_url": "https://avatars.githubusercontent.com/u/42211?v=4",
       "profile": "https://brandonroberts.dev",
-      "contributions": [
-        "code",
-        "doc",
-        "ideas"
-      ]
+      "contributions": ["code", "doc", "ideas"]
     },
     {
       "login": "LayZeeDK",
       "name": "Lars Gyrup Brink Nielsen",
       "avatar_url": "https://avatars.githubusercontent.com/u/6364586?v=4",
       "profile": "https://dev.to/layzee",
-      "contributions": [
-        "doc",
-        "test"
-      ]
+      "contributions": ["doc", "test"]
     },
     {
       "login": "markostanimirovic",
       "name": "Marko Stanimirović",
       "avatar_url": "https://avatars.githubusercontent.com/u/17877290?v=4",
       "profile": "https://dev.to/markostanimirovic",
-      "contributions": [
-        "tool",
-        "infra",
-        "doc",
-        "code",
-        "design"
-      ]
+      "contributions": ["tool", "infra", "doc", "code", "design"]
     },
     {
       "login": "jasonhodges",
       "name": "Jason Hodges",
       "avatar_url": "https://avatars.githubusercontent.com/u/1988476?v=4",
       "profile": "https://github.com/jasonhodges",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "timdeschryver",
       "name": "Tim Deschryver",
       "avatar_url": "https://avatars.githubusercontent.com/u/28659384?v=4",
       "profile": "http://timdeschryver.dev",
-      "contributions": [
-        "infra"
-      ]
+      "contributions": ["infra"]
     },
     {
       "login": "dalenguyen",
       "name": "Dale Nguyen",
       "avatar_url": "https://avatars.githubusercontent.com/u/14116156?v=4",
       "profile": "http://dalenguyen.me",
-      "contributions": [
-        "code",
-        "design"
-      ]
+      "contributions": ["code", "design"]
     },
     {
       "login": "Villanuevand",
       "name": "Andrés Villanueva",
       "avatar_url": "https://avatars.githubusercontent.com/u/1209238?v=4",
       "profile": "https://github.com/Villanuevand",
-      "contributions": [
-        "doc",
-        "translation"
-      ]
+      "contributions": ["doc", "translation"]
     },
     {
       "login": "umairhm",
       "name": "Umair Hafeez",
       "avatar_url": "https://avatars.githubusercontent.com/u/6948878?v=4",
       "profile": "https://umairhafeez.com",
-      "contributions": [
-        "infra"
-      ]
+      "contributions": ["infra"]
     },
     {
       "login": "Yberion",
       "name": "Brandon Largeau",
       "avatar_url": "https://avatars.githubusercontent.com/u/4186385?v=4",
       "profile": "https://github.com/Yberion",
-      "contributions": [
-        "infra"
-      ]
+      "contributions": ["infra"]
     },
     {
       "login": "mainawycliffe",
       "name": "Maina Wycliffe",
       "avatar_url": "https://avatars.githubusercontent.com/u/12270550?v=4",
       "profile": "https://mainawycliffe.dev/",
-      "contributions": [
-        "code",
-        "infra"
-      ]
+      "contributions": ["code", "infra"]
     },
     {
       "login": "pjlamb12",
       "name": "Preston Lamb",
       "avatar_url": "https://avatars.githubusercontent.com/u/2006222?v=4",
       "profile": "http://www.prestonlamb.com",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "iamandrewluca",
       "name": "Andrew Luca",
       "avatar_url": "https://avatars.githubusercontent.com/u/1881266?v=4",
       "profile": "https://iamandrewluca.com",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "nartc",
       "name": "Chau Tran",
       "avatar_url": "https://avatars.githubusercontent.com/u/25516557?v=4",
       "profile": "https://nartc.me",
-      "contributions": [
-        "code",
-        "infra"
-      ]
+      "contributions": ["code", "infra"]
     },
     {
       "login": "simitch1",
       "name": "Simone ",
       "avatar_url": "https://avatars.githubusercontent.com/u/20285365?v=4",
       "profile": "https://github.com/simitch1",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "KylerJohnsonDev",
       "name": "Kyler Johnson",
       "avatar_url": "https://avatars.githubusercontent.com/u/75549176?v=4",
       "profile": "http://kylerjohnson.dev",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "marcjulian",
       "name": "Marc",
       "avatar_url": "https://avatars.githubusercontent.com/u/8985933?v=4",
       "profile": "https://marcjulian.de/?ref=github",
-      "contributions": [
-        "doc",
-        "code"
-      ]
+      "contributions": ["doc", "code"]
     },
     {
       "login": "himyjan",
       "name": "himyjan",
       "avatar_url": "https://avatars.githubusercontent.com/u/51815522?v=4",
       "profile": "https://github.com/himyjan",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "TicTak21",
       "name": "Alex Kovalev",
       "avatar_url": "https://avatars.githubusercontent.com/u/44474697?v=4",
       "profile": "https://github.com/TicTak21",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "nuhmanpk",
       "name": "Nuhman Pk",
       "avatar_url": "https://avatars.githubusercontent.com/u/62880706?v=4",
       "profile": "http://www.linkedin.com/in/nuhmanpk",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "miluoshi",
       "name": "Miloš Lajtman",
       "avatar_url": "https://avatars.githubusercontent.com/u/1130547?v=4",
       "profile": "https://github.com/miluoshi",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "profanis",
       "name": "profanis",
       "avatar_url": "https://avatars.githubusercontent.com/u/7045092?v=4",
       "profile": "https://www.youtube.com/c/CodeShotsWithProfanis",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "hrmcdonald",
       "name": "Reece McDonald",
       "avatar_url": "https://avatars.githubusercontent.com/u/39349270?v=4",
       "profile": "https://github.com/hrmcdonald",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "ilteoood",
       "name": "Matteo Pietro Dazzi",
       "avatar_url": "https://avatars.githubusercontent.com/u/6383527?v=4",
       "profile": "https://ilteoood.xyz/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "lukasmatta",
       "name": "Lukáš Matta",
       "avatar_url": "https://avatars.githubusercontent.com/u/4323927?v=4",
       "profile": "http://lukasmatta.com",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "lucianomurr",
       "name": "Luciano",
       "avatar_url": "https://avatars.githubusercontent.com/u/281553?v=4",
       "profile": "http://ngrome.io",
-      "contributions": [
-        "doc",
-        "code"
-      ]
+      "contributions": ["doc", "code"]
     },
     {
       "login": "goetzrobin",
       "name": "Robin Goetz",
       "avatar_url": "https://avatars.githubusercontent.com/u/35136007?v=4",
       "profile": "https://goetzrobin.github.io",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "ch1ffa",
       "name": "Vadim Evseev",
       "avatar_url": "https://avatars.githubusercontent.com/u/17417010?v=4",
       "profile": "https://github.com/ch1ffa",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "d-koppenhagen",
       "name": "Danny Koppenhagen",
       "avatar_url": "https://avatars.githubusercontent.com/u/4279702?v=4",
       "profile": "https://k9n.dev",
-      "contributions": [
-        "doc",
-        "code"
-      ]
+      "contributions": ["doc", "code"]
     },
     {
       "login": "TomWebwalker",
       "name": "Tomasz Flis",
       "avatar_url": "https://avatars.githubusercontent.com/u/11270899?v=4",
       "profile": "https://tomwebwalker.pl/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "AdditionAddict",
       "name": "AdditionAddict",
       "avatar_url": "https://avatars.githubusercontent.com/u/48436581?v=4",
       "profile": "https://github.com/AdditionAddict",
-      "contributions": [
-        "doc",
-        "code"
-      ]
+      "contributions": ["doc", "code"]
     },
     {
       "login": "sand4rt",
       "name": "Sander",
       "avatar_url": "https://avatars.githubusercontent.com/u/17591696?v=4",
       "profile": "https://www.linkedin.com/in/sander-t-0a461458",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "BaronVonPerko",
       "name": "Chris Perko",
       "avatar_url": "https://avatars.githubusercontent.com/u/5384791?v=4",
       "profile": "http://perko.dev",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "lydemann",
       "name": "Christian Lüdemann",
       "avatar_url": "https://avatars.githubusercontent.com/u/9210691?v=4",
       "profile": "https://christianlydemann.com",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "yassernasc",
       "name": "Yasser",
       "avatar_url": "https://avatars.githubusercontent.com/u/9917969?v=4",
       "profile": "http://yasser.page",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "MDyrcz5",
       "name": "Michał Dyrcz",
       "avatar_url": "https://avatars.githubusercontent.com/u/23345904?v=4",
       "profile": "https://github.com/MDyrcz5",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "otonielguajardo",
       "name": "Otoniel Guajardo",
       "avatar_url": "https://avatars.githubusercontent.com/u/23427095?v=4",
       "profile": "https://github.com/otonielguajardo",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "gergobergo",
       "name": "gergobergo",
       "avatar_url": "https://avatars.githubusercontent.com/u/25322572?v=4",
       "profile": "https://github.com/gergobergo",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "saurajit",
       "name": "saurajit",
       "avatar_url": "https://avatars.githubusercontent.com/u/3590300?v=4",
       "profile": "https://github.com/saurajit",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "zawasp",
       "name": "Mircea Rilă",
       "avatar_url": "https://avatars.githubusercontent.com/u/2464830?v=4",
       "profile": "http://www.monocube.com",
-      "contributions": [
-        "doc",
-        "infra"
-      ]
+      "contributions": ["doc", "infra"]
     },
     {
       "login": "Dafnik",
       "name": "Dominik",
       "avatar_url": "https://avatars.githubusercontent.com/u/16242839?v=4",
       "profile": "https://dafnik.me",
-      "contributions": [
-        "doc",
-        "code",
-        "infra"
-      ]
+      "contributions": ["doc", "code", "infra"]
     },
     {
       "login": "henriquecustodia",
       "name": "Henrique Custódia",
       "avatar_url": "https://avatars.githubusercontent.com/u/5140430?v=4",
       "profile": "https://henriquecustodia.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "isoden",
       "name": "ISODA Yu",
       "avatar_url": "https://avatars.githubusercontent.com/u/3771988?v=4",
       "profile": "https://isoden.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "ciradu2204",
       "name": "Cynthia Iradukunda",
       "avatar_url": "https://avatars.githubusercontent.com/u/37863089?v=4",
       "profile": "http://cynthia-developer.netlify.com",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "Drunkenpilot",
       "name": "Drunkenpilot",
       "avatar_url": "https://avatars.githubusercontent.com/u/2257567?v=4",
       "profile": "https://github.com/Drunkenpilot",
-      "contributions": [
-        "doc",
-        "code"
-      ]
+      "contributions": ["doc", "code"]
     },
     {
       "login": "jeremyhofer",
       "name": "Jeremy Hofer",
       "avatar_url": "https://avatars.githubusercontent.com/u/17076628?v=4",
       "profile": "https://github.com/jeremyhofer",
-      "contributions": [
-        "doc",
-        "code",
-        "infra"
-      ]
+      "contributions": ["doc", "code", "infra"]
     },
     {
       "login": "SOG-web",
       "name": "Olalekan Raheem",
       "avatar_url": "https://avatars.githubusercontent.com/u/61606062?v=4",
       "profile": "http://www.routechnology.tech",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "luishcastroc",
       "name": "Luis Castro",
       "avatar_url": "https://avatars.githubusercontent.com/u/13698269?v=4",
       "profile": "https://github.com/luishcastroc",
-      "contributions": [
-        "code",
-        "doc",
-        "translation"
-      ]
+      "contributions": ["code", "doc", "translation"]
     },
     {
       "login": "QuantariusRay",
       "name": "Q",
       "avatar_url": "https://avatars.githubusercontent.com/u/31900736?v=4",
       "profile": "https://github.com/QuantariusRay",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "cskiwi",
       "name": "Glenn Latomme",
       "avatar_url": "https://avatars.githubusercontent.com/u/847540?v=4",
       "profile": "https://github.com/cskiwi",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "justinrassier",
       "name": "Justin Rassier",
       "avatar_url": "https://avatars.githubusercontent.com/u/1228424?v=4",
       "profile": "http://www.justinrassier.com",
-      "contributions": [
-        "doc",
-        "code",
-        "infra"
-      ]
+      "contributions": ["doc", "code", "infra"]
     },
     {
       "login": "JeanMeche",
       "name": "Matthieu Riegler",
       "avatar_url": "https://avatars.githubusercontent.com/u/1300985?v=4",
       "profile": "http://riegler.fr",
-      "contributions": [
-        "doc",
-        "infra",
-        "code"
-      ]
+      "contributions": ["doc", "infra", "code"]
     },
     {
       "login": "ashley-hunter",
       "name": "Ashley Hunter",
       "avatar_url": "https://avatars.githubusercontent.com/u/20795331?v=4",
       "profile": "https://github.com/ashley-hunter",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "arturovt",
       "name": "Artur Androsovych",
       "avatar_url": "https://avatars.githubusercontent.com/u/7337691?v=4",
       "profile": "http://ng-guru.io",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "bluwy",
       "name": "Bjorn Lu",
       "avatar_url": "https://avatars.githubusercontent.com/u/34116392?v=4",
       "profile": "https://bjornlu.com",
-      "contributions": [
-        "infra"
-      ]
+      "contributions": ["infra"]
     },
     {
       "login": "omarbelkhodja",
       "name": "Omar BELKHODJA",
       "avatar_url": "https://avatars.githubusercontent.com/u/2501093?v=4",
       "profile": "https://github.com/omarbelkhodja",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "deepakrudrapaul",
       "name": "Deepak Rudra Paul",
       "avatar_url": "https://avatars.githubusercontent.com/u/25549935?v=4",
       "profile": "https://github.com/deepakrudrapaul",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "mavrukin",
       "name": "Michael Avrukin",
       "avatar_url": "https://avatars.githubusercontent.com/u/239147?v=4",
       "profile": "https://github.com/mavrukin",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "rlmestre",
       "name": "Rafael Mestre",
       "avatar_url": "https://avatars.githubusercontent.com/u/277805?v=4",
       "profile": "https://github.com/rlmestre",
-      "contributions": [
-        "code",
-        "doc",
-        "infra"
-      ]
+      "contributions": ["code", "doc", "infra"]
     },
     {
       "login": "santoshyadavdev",
       "name": "Santosh Yadav",
       "avatar_url": "https://avatars.githubusercontent.com/u/11923975?v=4",
       "profile": "https://github.com/santoshyadavdev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "Tenessy",
       "name": "Tenessy",
       "avatar_url": "https://avatars.githubusercontent.com/u/65855673?v=4",
       "profile": "https://github.com/Tenessy",
-      "contributions": [
-        "infra",
-        "code",
-        "test"
-      ]
+      "contributions": ["infra", "code", "test"]
     },
     {
       "login": "Jad31",
       "name": "Jad Chahed",
       "avatar_url": "https://avatars.githubusercontent.com/u/46532649?v=4",
       "profile": "https://github.com/Jad31",
-      "contributions": [
-        "doc",
-        "translation"
-      ]
+      "contributions": ["doc", "translation"]
     },
     {
       "login": "gesielrosa",
       "name": "Gesiel Rosa",
       "avatar_url": "https://avatars.githubusercontent.com/u/40439982?v=4",
       "profile": "https://www.gta-sa.com.br/",
-      "contributions": [
-        "doc",
-        "translation"
-      ]
+      "contributions": ["doc", "translation"]
     },
     {
       "login": "besimgurbuz",
       "name": "Besim Gürbüz",
       "avatar_url": "https://avatars.githubusercontent.com/u/33575384?v=4",
       "profile": "http://besimgurbuz.dev/",
-      "contributions": [
-        "doc",
-        "translation"
-      ]
+      "contributions": ["doc", "translation"]
     },
     {
       "login": "lukasnys",
       "name": "Lukas Nys",
       "avatar_url": "https://avatars.githubusercontent.com/u/22593230?v=4",
       "profile": "https://github.com/lukasnys",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "alaendle",
       "name": "Andreas Ländle",
       "avatar_url": "https://avatars.githubusercontent.com/u/969523?v=4",
       "profile": "https://github.com/alaendle",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Pascalmh",
       "name": "Pascal Küsgen",
       "avatar_url": "https://avatars.githubusercontent.com/u/498197?v=4",
       "profile": "https://ksgn.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "alejandrocuba",
       "name": "Alejandro Cuba Ruiz",
       "avatar_url": "https://avatars.githubusercontent.com/u/6283346?v=4",
       "profile": "http://alejandrocuba.com",
-      "contributions": [
-        "doc",
-        "translation"
-      ]
+      "contributions": ["doc", "translation"]
     },
     {
       "login": "Shreyas0410",
       "name": "Shreyas0410",
       "avatar_url": "https://avatars.githubusercontent.com/u/70795867?v=4",
       "profile": "https://github.com/Shreyas0410",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "Den-dp",
       "name": "Denis Bendrikov",
       "avatar_url": "https://avatars.githubusercontent.com/u/1770529?v=4",
       "profile": "https://github.com/Den-dp",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "iancharlesdouglas",
       "name": "iancharlesdouglas",
       "avatar_url": "https://avatars.githubusercontent.com/u/3481593?v=4",
       "profile": "https://github.com/iancharlesdouglas",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "ocombe",
       "name": "Olivier Combe",
       "avatar_url": "https://avatars.githubusercontent.com/u/265378?v=4",
       "profile": "https://twitter.com/OCombe",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "sasidharansd",
       "name": "Sasidharan SD",
       "avatar_url": "https://avatars.githubusercontent.com/u/47988127?v=4",
       "profile": "https://github.com/sasidharansd",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "ajitzero",
       "name": "Ajit Panigrahi",
       "avatar_url": "https://avatars.githubusercontent.com/u/19947758?v=4",
       "profile": "https://ajitpanigrahi.com",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "nemu69",
       "name": "nepage-l",
       "avatar_url": "https://avatars.githubusercontent.com/u/43633395?v=4",
       "profile": "https://github.com/nemu69",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Jefftopia",
       "name": "Jeff",
       "avatar_url": "https://avatars.githubusercontent.com/u/5161547?v=4",
       "profile": "https://jeffreysmith.ninja",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "thatsamsonkid",
       "name": "Sammy Mohamed",
       "avatar_url": "https://avatars.githubusercontent.com/u/22568206?v=4",
       "profile": "https://sammymohamed.com",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "joshuamorony",
       "name": "Josh Morony",
       "avatar_url": "https://avatars.githubusercontent.com/u/2578009?v=4",
       "profile": "https://www.joshmorony.com",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "ilirbeqirii",
       "name": "Ilir Beqiri",
       "avatar_url": "https://avatars.githubusercontent.com/u/24731032?v=4",
       "profile": "https://github.com/ilirbeqirii",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "remes2000",
       "name": "Michał Nieruchalski",
       "avatar_url": "https://avatars.githubusercontent.com/u/26173223?v=4",
       "profile": "https://github.com/remes2000",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "angelfraga",
       "name": "Angel Fraga Parodi",
       "avatar_url": "https://avatars.githubusercontent.com/u/11693938?v=4",
       "profile": "https://angelfraga.com/",
-      "contributions": [
-        "infra",
-        "code"
-      ]
+      "contributions": ["infra", "code"]
     },
     {
       "login": "alexfriesen",
       "name": "Alex",
       "avatar_url": "https://avatars.githubusercontent.com/u/1307706?v=4",
       "profile": "https://alexfriesen.net/",
-      "contributions": [
-        "infra",
-        "code"
-      ]
+      "contributions": ["infra", "code"]
     },
     {
       "login": "duluca",
       "name": "Doguhan Uluca",
       "avatar_url": "https://avatars.githubusercontent.com/u/822159?v=4",
       "profile": "https://github.com/duluca",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "nckirik",
       "name": "N. Can KIRIK",
       "avatar_url": "https://avatars.githubusercontent.com/u/53273233?v=4",
       "profile": "https://github.com/nckirik",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "ShPelles",
       "name": "ShPelles",
       "avatar_url": "https://avatars.githubusercontent.com/u/43875468?v=4",
       "profile": "https://github.com/ShPelles",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "pavankjadda",
       "name": "Pavan Kumar Jadda",
       "avatar_url": "https://avatars.githubusercontent.com/u/17564080?v=4",
       "profile": "https://pavankjadda.dev",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "monacodelisa",
       "name": "Esther White",
       "avatar_url": "https://avatars.githubusercontent.com/u/64324417?v=4",
       "profile": "https://monacodelisa.com/",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "Micha-Richter",
       "name": "Michael Richter",
       "avatar_url": "https://avatars.githubusercontent.com/u/12509902?v=4",
       "profile": "https://github.com/Micha-Richter",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "alator21",
       "name": "Rafael Triantafillidis",
       "avatar_url": "https://avatars.githubusercontent.com/u/24437129?v=4",
       "profile": "https://a21.dev",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "pi0",
       "name": "Pooya Parsa",
       "avatar_url": "https://avatars.githubusercontent.com/u/5158436?v=4",
       "profile": "https://github.com/pi0",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "crutchcorn",
       "name": "Corbin Crutchley",
       "avatar_url": "https://avatars.githubusercontent.com/u/9100169?v=4",
       "profile": "https://crutchcorn.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "leblancmeneses",
       "name": "Leblanc Meneses",
       "avatar_url": "https://avatars.githubusercontent.com/u/730804?v=4",
       "profile": "http://www.robusthaven.com",
-      "contributions": [
-        "infra",
-        "code",
-        "doc"
-      ]
+      "contributions": ["infra", "code", "doc"]
     },
     {
       "login": "jculvey",
       "name": "James Culveyhouse",
       "avatar_url": "https://avatars.githubusercontent.com/u/204386?v=4",
       "profile": "https://github.com/jculvey",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "naaajii",
       "name": "Naji",
       "avatar_url": "https://avatars.githubusercontent.com/u/54370141?v=4",
       "profile": "https://github.com/naaajii",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "SerkanSipahi",
       "name": "Bitcollage",
       "avatar_url": "https://avatars.githubusercontent.com/u/1880749?v=4",
       "profile": "https://honey.glass/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "sonukapoor",
       "name": "Sonu Kapoor",
       "avatar_url": "https://avatars.githubusercontent.com/u/59734?v=4",
       "profile": "https://github.com/sonukapoor",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "ezzabuzaid",
       "name": "ezzabuzaid",
       "avatar_url": "https://avatars.githubusercontent.com/u/29958503?v=4",
       "profile": "https://www.linkedin.com/in/ezzabuzaid",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "eduardoRoth",
       "name": "Eduardo Roth",
       "avatar_url": "https://avatars.githubusercontent.com/u/5419161?v=4",
       "profile": "https://eduardoroth.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "RyanClementsHax",
       "name": "Ryan Clements",
       "avatar_url": "https://avatars.githubusercontent.com/u/20916810?v=4",
       "profile": "https://ryanclements.dev/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "ByeongGi",
       "name": "ByeongGi",
       "avatar_url": "https://avatars.githubusercontent.com/u/11059706?v=4",
       "profile": "https://byeonggi.vercel.app/",
-      "contributions": [
-        "doc",
-        "translation"
-      ]
+      "contributions": ["doc", "translation"]
     },
     {
       "login": "yjaaidi",
       "name": "Younes Jaaidi",
       "avatar_url": "https://avatars.githubusercontent.com/u/2674658?v=4",
       "profile": "https://marmicode.io",
-      "contributions": [
-        "code",
-        "test"
-      ]
+      "contributions": ["code", "test"]
     },
     {
       "login": "BoogieMonsta",
       "name": "BoogMon",
       "avatar_url": "https://avatars.githubusercontent.com/u/73052877?v=4",
       "profile": "https://boogiemonsta.com/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "AmGarera",
       "name": "Anthony Garera",
       "avatar_url": "https://avatars.githubusercontent.com/u/6021169?v=4",
       "profile": "https://www.anthonygarera.com",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "stewones",
       "name": "Stewan",
       "avatar_url": "https://avatars.githubusercontent.com/u/719763?v=4",
       "profile": "http://stewan.io",
-      "contributions": [
-        "code",
-        "test"
-      ]
+      "contributions": ["code", "test"]
     },
     {
       "login": "NateRadebaugh",
       "name": "Nate Radebaugh",
       "avatar_url": "https://avatars.githubusercontent.com/u/130445?v=4",
       "profile": "https://naterad.com",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "WolfSoko",
       "name": "Wolfram Sokollek",
       "avatar_url": "https://avatars.githubusercontent.com/u/8589105?v=4",
       "profile": "https://angularexamples.wolsok.de/",
-      "contributions": [
-        "infra"
-      ]
+      "contributions": ["infra"]
     },
     {
       "login": "muhammaduxair",
       "name": "Muhammad Uzair",
       "avatar_url": "https://avatars.githubusercontent.com/u/64395440?v=4",
       "profile": "https://github.com/muhammaduxair",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "Laphatize",
       "name": "Pranav Ramesh",
       "avatar_url": "https://avatars.githubusercontent.com/u/23617187?v=4",
       "profile": "https://pranavramesh.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "benpsnyder",
       "name": "Ben Snyder",
       "avatar_url": "https://avatars.githubusercontent.com/u/707567?v=4",
       "profile": "https://snyder.tech",
-      "contributions": [
-        "doc",
-        "infra"
-      ]
+      "contributions": ["doc", "infra"]
     },
     {
       "login": "niklas-wortmann",
       "name": "Jan-Niklas W.",
       "avatar_url": "https://avatars.githubusercontent.com/u/6104311?v=4",
       "profile": "https://wordman.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "gultyayev",
       "name": "Sergey Gultyayev (Serhii Hultiaiev)",
       "avatar_url": "https://avatars.githubusercontent.com/u/22374911?v=4",
       "profile": "https://github.com/gultyayev",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "andersonmfjr",
       "name": "Anderson Feitosa",
       "avatar_url": "https://avatars.githubusercontent.com/u/66845464?v=4",
       "profile": "http://andersonmfjr.com",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "reboot25",
       "name": "Jun",
       "avatar_url": "https://avatars.githubusercontent.com/u/5337080?v=4",
       "profile": "https://github.com/reboot25",
-      "contributions": [
-        "doc",
-        "translation"
-      ]
+      "contributions": ["doc", "translation"]
     },
     {
       "login": "DerHerrGammler",
       "name": "Felix Herold",
       "avatar_url": "https://avatars.githubusercontent.com/u/30802629?v=4",
       "profile": "https://github.com/DerHerrGammler",
-      "contributions": [
-        "doc",
-        "translation"
-      ]
+      "contributions": ["doc", "translation"]
     },
     {
       "login": "s0h311",
       "name": "Soheil Nazari [CHECK24]",
       "avatar_url": "https://avatars.githubusercontent.com/u/113988347?v=4",
       "profile": "http://soheilnazari.de",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "illunix",
       "name": "Maksymilian Szokalski",
       "avatar_url": "https://avatars.githubusercontent.com/u/42069493?v=4",
       "profile": "https://github.com/illunix",
-      "contributions": [
-        "infra",
-        "code"
-      ]
+      "contributions": ["infra", "code"]
     },
     {
       "login": "osnoser1",
       "name": "Alfonso Andrés López Molina",
       "avatar_url": "https://avatars.githubusercontent.com/u/1179744?v=4",
       "profile": "https://github.com/osnoser1",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "nermalcat69",
       "name": "Nermal",
       "avatar_url": "https://avatars.githubusercontent.com/u/73933669?v=4",
       "profile": "https://arjunaditya.xyz",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "tobiasegli",
       "name": "tobiasegli",
       "avatar_url": "https://avatars.githubusercontent.com/u/20181671?v=4",
       "profile": "http://tobiasegli.ch",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "lars0n",
       "name": "Larson",
       "avatar_url": "https://avatars.githubusercontent.com/u/15248125?v=4",
       "profile": "https://github.com/lars0n",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "ilyassFouih",
       "name": "Ilyass ",
       "avatar_url": "https://avatars.githubusercontent.com/u/33469478?v=4",
       "profile": "https://github.com/ilyassFouih",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "bbodine1",
       "name": "Brad Bodine",
       "avatar_url": "https://avatars.githubusercontent.com/u/2924609?v=4",
       "profile": "http://bradbodine.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "kilesh-mhzn",
       "name": "Kilesh Maharjan",
       "avatar_url": "https://avatars.githubusercontent.com/u/78723506?v=4",
       "profile": "https://github.com/kilesh-mhzn",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "redfox-mx",
       "name": "Diego Jesús",
       "avatar_url": "https://avatars.githubusercontent.com/u/20145660?v=4",
       "profile": "https://github.com/redfox-mx",
-      "contributions": [
-        "code",
-        "infra"
-      ]
+      "contributions": ["code", "infra"]
     },
     {
       "login": "Rockerturner",
       "name": "Rockerturner",
       "avatar_url": "https://avatars.githubusercontent.com/u/25847930?v=4",
       "profile": "https://github.com/Rockerturner",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "EmmanuelDemey",
       "name": "Emmanuel DEMEY",
       "avatar_url": "https://avatars.githubusercontent.com/u/555768?v=4",
       "profile": "http://gillespie59.github.io/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "nickytonline",
       "name": "Nick Taylor",
       "avatar_url": "https://avatars.githubusercontent.com/u/833231?v=4",
       "profile": "https://nickyt.co",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "alexrosepizant",
       "name": "Alex Rose-Pizant",
       "avatar_url": "https://avatars.githubusercontent.com/u/7753376?v=4",
       "profile": "https://github.com/alexrosepizant",
-      "contributions": [
-        "infra"
-      ]
+      "contributions": ["infra"]
     },
     {
       "login": "mattlewis92",
       "name": "Matt Lewis",
       "avatar_url": "https://avatars.githubusercontent.com/u/6425649?v=4",
       "profile": "https://mattlewis.me/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "BaptisteMahe",
       "name": "Baptiste Mahé",
       "avatar_url": "https://avatars.githubusercontent.com/u/41227846?v=4",
       "profile": "https://www.linkedin.com/in/baptiste-mah%C3%A9-95b425180/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     }
   ],
   "contributorsPerLine": 7,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -701,7 +701,7 @@
       "login": "ajitzero",
       "name": "Ajit Panigrahi",
       "avatar_url": "https://avatars.githubusercontent.com/u/19947758?v=4",
-      "profile": "https://beta.ajitpanigrahi.com",
+      "profile": "https://ajitpanigrahi.com",
       "contributions": [
         "code"
       ]

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,12 @@
   "singleQuote": true,
   "overrides": [
     {
+      "files": "*.md",
+      "options": {
+        "printWidth": 80
+      }
+    },
+    {
       "files": "*.analog",
       "options": {
         "parser": "angular"

--- a/apps/analog-app-e2e-cypress/src/e2e/cart.cy.ts
+++ b/apps/analog-app-e2e-cypress/src/e2e/cart.cy.ts
@@ -15,7 +15,7 @@ describe('Cart', () => {
       onBeforeLoad: (win) => {
         cy.stub(win.console, 'warn').as('consoleWarn');
       },
-    })
+    }),
   );
 
   it(`Given the user has added a phone to the cart
@@ -33,7 +33,7 @@ describe('Cart', () => {
     cart.navigateTo();
 
     Object.values(phones).forEach((phone) =>
-      cart.getPriceByName(phone.name).contains(phone.price)
+      cart.getPriceByName(phone.name).contains(phone.price),
     );
   });
 
@@ -55,7 +55,7 @@ describe('Cart', () => {
     cy.get('@consoleWarn').should(
       'have.been.calledWithMatch',
       /your order has been submitted/i,
-      { name, address }
+      { name, address },
     );
     cart.getItems().should('not.exist');
   });

--- a/apps/analog-app-e2e-cypress/src/e2e/products.cy.ts
+++ b/apps/analog-app-e2e-cypress/src/e2e/products.cy.ts
@@ -20,7 +20,7 @@ describe('Products', () => {
 
     cy.on('window:alert', (alert) => {
       expect(alert).to.contain(
-        /you will be notified when the product goes on sale/i
+        /you will be notified when the product goes on sale/i,
       );
     });
   });

--- a/apps/analog-app-e2e-playwright/tests/app.spec.ts
+++ b/apps/analog-app-e2e-playwright/tests/app.spec.ts
@@ -32,7 +32,7 @@ describe('My Store', () => {
   test(`Given the user has navigated to the home page
     Then the app title is visible`, async () => {
     await expect(
-      page.locator('role=heading[level=1] >> text=My Store')
+      page.locator('role=heading[level=1] >> text=My Store'),
     ).toContain(/My Store/i);
   });
 });

--- a/apps/analog-app-e2e-playwright/tests/cart.spec.ts
+++ b/apps/analog-app-e2e-playwright/tests/cart.spec.ts
@@ -70,7 +70,7 @@ describe('Cart', () => {
     });
     await cartPage.navigateTo();
     expect(
-      await cartPage.getPriceByName(phone.name, phone.price).elementHandle()
+      await cartPage.getPriceByName(phone.name, phone.price).elementHandle(),
     ).toBeTruthy();
   });
 
@@ -92,12 +92,12 @@ describe('Cart', () => {
 
     for (const phone of allPhones) {
       expect(
-        await cartPage.getPriceByName(phone.name, phone.price).elementHandle()
+        await cartPage.getPriceByName(phone.name, phone.price).elementHandle(),
       ).toBeTruthy();
     }
 
     expect(await cartPage.cartItems().elementHandles()).toHaveLength(
-      allPhones.length
+      allPhones.length,
     );
   });
 
@@ -132,7 +132,7 @@ describe('Cart', () => {
     await cartPage.purchaseOrder();
 
     expect(await message[0].evaluate((p) => p)).toMatch(
-      /your order has been submitted/i
+      /your order has been submitted/i,
     );
     expect(await message[1].evaluate((p) => p)).toEqual({ name, address });
     expect(await cartPage.cartItems().elementHandles()).toHaveLength(0);

--- a/apps/analog-app-e2e-playwright/tests/products.spec.ts
+++ b/apps/analog-app-e2e-playwright/tests/products.spec.ts
@@ -63,7 +63,7 @@ describe('Products', () => {
 
     await productsListPage.getNotifyButtonByName(phones.xl.name).click();
     expect(dialogMessage).toMatch(
-      /you will be notified when the product goes on sale/i
+      /you will be notified when the product goes on sale/i,
     );
   });
 
@@ -75,7 +75,7 @@ describe('Products', () => {
     const phone = phones.standard;
     await productsListPage.navigateToDetail(phone.name);
     expect(await productDetailPage.getPrice().textContent()).toContain(
-      phone.price
+      phone.price,
     );
   });
 

--- a/apps/analog-app/index.html
+++ b/apps/analog-app/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/apps/analog-app/src/app/app.config.ts
+++ b/apps/analog-app/src/app/app.config.ts
@@ -25,11 +25,11 @@ export const appConfig: ApplicationConfig = {
     provideFileRouter(
       withNavigationErrorHandler(console.error),
       withDebugRoutes(),
-      withExtraRoutes(fallbackRoutes)
+      withExtraRoutes(fallbackRoutes),
     ),
     provideHttpClient(
       withFetch(),
-      withInterceptors([requestContextInterceptor])
+      withInterceptors([requestContextInterceptor]),
     ),
     provideClientHydration(withEventReplay()),
   ],

--- a/apps/analog-app/src/app/cart.service.ts
+++ b/apps/analog-app/src/app/cart.service.ts
@@ -25,7 +25,7 @@ export class CartService {
 
   getShippingPrices() {
     return this.http.get<{ type: string; price: number }[]>(
-      '/assets/shipping.json'
+      '/assets/shipping.json',
     );
   }
 }

--- a/apps/analog-app/src/app/pages/newsletter.page.ts
+++ b/apps/analog-app/src/app/pages/newsletter.page.ts
@@ -16,24 +16,25 @@ type FormErrors =
     <h3>Newsletter Signup</h3>
 
     @if (!signedUp()) {
-    <form
-      method="post"
-      (onSuccess)="onSuccess()"
-      (onError)="onError($any($event))"
-      (onStateChange)="errors.set(undefined)"
-    >
-      <div>
-        <label for="email"> Email </label>
-        <input type="email" name="email" />
-      </div>
+      <form
+        method="post"
+        (onSuccess)="onSuccess()"
+        (onError)="onError($any($event))"
+        (onStateChange)="errors.set(undefined)"
+      >
+        <div>
+          <label for="email"> Email </label>
+          <input type="email" name="email" />
+        </div>
 
-      <button class="button" type="submit">Submit</button>
-    </form>
+        <button class="button" type="submit">Submit</button>
+      </form>
 
-    @if( errors()?.email ) {
-    <p>{{ errors()?.email }}</p>
-    } } @else {
-    <div>Thanks for signing up!</div>
+      @if (errors()?.email) {
+        <p>{{ errors()?.email }}</p>
+      }
+    } @else {
+      <div>Thanks for signing up!</div>
     }
   `,
 })

--- a/apps/analog-app/src/app/pages/products.[productId].page.ts
+++ b/apps/analog-app/src/app/pages/products.[productId].page.ts
@@ -40,7 +40,7 @@ export default class ProductDetailsComponent implements OnInit {
       .subscribe((products) => {
         // Find the product that correspond with the id provided in route.
         this.product = products.find(
-          (product) => product.id === productIdFromRoute
+          (product) => product.id === productIdFromRoute,
         );
       });
   }

--- a/apps/analog-app/src/app/pages/search.page.ts
+++ b/apps/analog-app/src/app/pages/search.page.ts
@@ -20,8 +20,8 @@ import type { load } from './search.server';
       <button class="button" type="submit">Submit</button>
     </form>
 
-    @if(searchTerm()) {
-    <p>Search Term: {{ searchTerm() }}</p>
+    @if (searchTerm()) {
+      <p>Search Term: {{ searchTerm() }}</p>
     }
   `,
 })

--- a/apps/analog-app/src/main-cf.server.ts
+++ b/apps/analog-app/src/main-cf.server.ts
@@ -19,7 +19,7 @@ export function bootstrap() {
 export default async function render(
   url: string,
   document: string,
-  serverContext: ServerContext
+  serverContext: ServerContext,
 ) {
   const html = await renderApplication(bootstrap, {
     document,

--- a/apps/analog-app/src/test-setup.ts
+++ b/apps/analog-app/src/test-setup.ts
@@ -8,5 +8,5 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/apps/analog-preset-e2e/tests/analog-preset.spec.ts
+++ b/apps/analog-preset-e2e/tests/analog-preset.spec.ts
@@ -8,7 +8,7 @@ describe('analog-preset-e2e', () => {
 
     await runCommandAsync(
       `npx create-nx-workspace@latest ${project} --preset @analogjs/platform --analogAppName analog-app --no-nx-cloud`,
-      { cwd: process.cwd() }
+      { cwd: process.cwd() },
     );
 
     await runCommandAsync(`nx test analog-app`, {
@@ -20,7 +20,7 @@ describe('analog-preset-e2e', () => {
     });
 
     expect(() =>
-      checkFilesExist(`${tmpDir}/dist/analog-app/client/index.html`)
+      checkFilesExist(`${tmpDir}/dist/analog-app/client/index.html`),
     ).not.toThrow();
 
     rmdirSync(tmpDir, { recursive: true });

--- a/apps/astro-app-e2e-playwright/tests/app.spec.ts
+++ b/apps/astro-app-e2e-playwright/tests/app.spec.ts
@@ -33,30 +33,30 @@ describe.skip('AstroApp', () => {
   describe('Given the user has navigated to the home page', () => {
     test('Then client side rendered CardComponent is rendered', async () => {
       const componentLocator = page.locator(
-        'astro-island[component-export="CardComponent"]'
+        'astro-island[component-export="CardComponent"]',
       );
       await expect(
-        componentLocator.locator('>> text=Angular (Client Side)')
+        componentLocator.locator('>> text=Angular (Client Side)'),
       ).toContain(/Angular \(Client Side\)/i);
     });
 
     test('Then server side rendered CardComponent is rendered', async () => {
       const componentLocator = page.locator('astro-card');
       await expect(
-        componentLocator.locator('>> text=Angular (server side binding)')
+        componentLocator.locator('>> text=Angular (server side binding)'),
       ).toContain(/Angular \(server side binding\)/i);
     });
 
     test.skip('Then client side rendered CardComponent should emit an event on click', async () => {
       const console = waitForConsole();
       const componentLocator = page.locator(
-        '[data-analog-id=card-component-1]'
+        '[data-analog-id=card-component-1]',
       );
       const elementLocator = componentLocator.locator('li');
       await elementLocator.click();
 
       await expect(await console).toBe(
-        'event received from card-component-1: clicked'
+        'event received from card-component-1: clicked',
       );
     });
   });
@@ -68,7 +68,7 @@ describe.skip('AstroApp', () => {
     it('Then an Angular component should be rendered', async () => {
       const componentLocator = page.locator('astro-card');
       await expect(componentLocator.locator('>> text=Angular')).toContain(
-        /Angular/
+        /Angular/,
       );
     });
   });

--- a/apps/blog-app/index.html
+++ b/apps/blog-app/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/apps/blog-app/src/app/app.config.ts
+++ b/apps/blog-app/src/app/app.config.ts
@@ -17,11 +17,11 @@ export const appConfig: ApplicationConfig = {
       withMarkdownRenderer({
         loadMermaid: !import.meta.env.SSR ? () => import('mermaid') : undefined,
       }),
-      withShikiHighlighter()
+      withShikiHighlighter(),
     ),
     provideFileRouter(
       withInMemoryScrolling({ anchorScrolling: 'enabled' }),
-      withEnabledBlockingInitialNavigation()
+      withEnabledBlockingInitialNavigation(),
     ),
   ],
 };

--- a/apps/blog-app/src/app/pages/archived/[slug].page.ts
+++ b/apps/blog-app/src/app/pages/archived/[slug].page.ts
@@ -44,6 +44,6 @@ export default class ArchivedPostComponent {
   readonly toc$ = this.post$.pipe(
     map(() => {
       return this.renderer.getContentHeadings();
-    })
+    }),
   );
 }

--- a/apps/blog-app/src/app/pages/archived/resolvers.ts
+++ b/apps/blog-app/src/app/pages/archived/resolvers.ts
@@ -5,7 +5,7 @@ import { ArchivedPostAttributes } from './models';
 
 // temporary
 function injectActivePostAttributes(
-  route: ActivatedRouteSnapshot
+  route: ActivatedRouteSnapshot,
 ): ArchivedPostAttributes {
   const file = injectContentFiles<ArchivedPostAttributes>().find(
     (contentFile) => {
@@ -14,7 +14,7 @@ function injectActivePostAttributes(
           `/src/content/archived/${route.params['slug']}.md` ||
         contentFile.slug === route.params['slug']
       );
-    }
+    },
   );
 
   return file!.attributes;

--- a/apps/blog-app/src/app/pages/blog/[slug].page.ts
+++ b/apps/blog-app/src/app/pages/blog/[slug].page.ts
@@ -41,6 +41,6 @@ export default class BlogPostComponent {
   readonly toc$ = this.post$.pipe(
     map(() => {
       return this.renderer.getContentHeadings();
-    })
+    }),
   );
 }

--- a/apps/blog-app/src/app/pages/blog/resolvers.ts
+++ b/apps/blog-app/src/app/pages/blog/resolvers.ts
@@ -6,7 +6,7 @@ import { PostAttributes } from './models';
 
 // temporary
 function injectActivePostAttributes(
-  route: ActivatedRouteSnapshot
+  route: ActivatedRouteSnapshot,
 ): PostAttributes {
   const file = injectContentFiles<PostAttributes>().find((contentFile) => {
     return (

--- a/apps/blog-app/src/server/routes/v1/[...slug].ts
+++ b/apps/blog-app/src/server/routes/v1/[...slug].ts
@@ -4,7 +4,7 @@ import { ImageResponse } from '@analogjs/content/og';
 
 export default defineEventHandler(async (event) => {
   const fontFile = await fetch(
-    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff'
+    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff',
   );
   const fontData: ArrayBuffer = await fontFile.arrayBuffer();
   const query = getQuery(event); // query params

--- a/apps/create-analog-e2e/tests/create-analog.spec.ts
+++ b/apps/create-analog-e2e/tests/create-analog.spec.ts
@@ -40,7 +40,7 @@ describe.skip('create-analog e2e', () => {
 
     await runCommandAsync(
       `node ./dist/packages/create-analog/index.js ${project} --template angular-v17 --skipTailwind`,
-      { cwd: process.cwd() }
+      { cwd: process.cwd() },
     );
 
     await runCommandAsync(`pnpm i`, {
@@ -54,22 +54,22 @@ describe.skip('create-analog e2e', () => {
     emptyDir(`${tmpDir}/node_modules/@analogjs`);
     copyDir(
       `${process.cwd()}/node_modules/@analogjs`,
-      `${tmpDir}/node_modules/@analogjs`
+      `${tmpDir}/node_modules/@analogjs`,
     );
 
     const angularJson = JSON.parse(
-      fs.readFileSync(`${tmpDir}/angular.json`, 'utf-8')
+      fs.readFileSync(`${tmpDir}/angular.json`, 'utf-8'),
     );
     angularJson.projects['my-app'].root = '.';
     fs.writeFileSync(
       `${tmpDir}/angular.json`,
-      JSON.stringify(angularJson, null, 2)
+      JSON.stringify(angularJson, null, 2),
     );
 
     let viteConfig = fs.readFileSync(`${tmpDir}/vite.config.ts`, 'utf-8');
     viteConfig = viteConfig.replace(
       'analog()',
-      `analog({ vite: { tsconfig: '${tmpDir}/tsconfig.spec.json' } })`
+      `analog({ vite: { tsconfig: '${tmpDir}/tsconfig.spec.json' } })`,
     );
 
     fs.writeFileSync(`${tmpDir}/vite.config.ts`, viteConfig);
@@ -83,7 +83,7 @@ describe.skip('create-analog e2e', () => {
     });
 
     expect(() =>
-      checkFilesExist(`${tmpDir}/dist/analog/public/index.html`)
+      checkFilesExist(`${tmpDir}/dist/analog/public/index.html`),
     ).not.toThrow();
 
     fs.rmdirSync(tmpDir, { recursive: true });
@@ -95,7 +95,7 @@ describe.skip('create-analog e2e', () => {
 
     await runCommandAsync(
       `node ./dist/packages/create-analog/index.js ${project} --template blog --skipTailwind`,
-      { cwd: process.cwd() }
+      { cwd: process.cwd() },
     );
 
     await runCommandAsync(`pnpm i`, {
@@ -109,23 +109,23 @@ describe.skip('create-analog e2e', () => {
     emptyDir(`${tmpDir}/node_modules/@analogjs`);
     copyDir(
       `${process.cwd()}/node_modules/@analogjs`,
-      `${tmpDir}/node_modules/@analogjs`
+      `${tmpDir}/node_modules/@analogjs`,
     );
 
     const angularJson = JSON.parse(
-      fs.readFileSync(`${tmpDir}/angular.json`, 'utf-8')
+      fs.readFileSync(`${tmpDir}/angular.json`, 'utf-8'),
     );
 
     angularJson.projects['blog'].root = '.';
     fs.writeFileSync(
       `${tmpDir}/angular.json`,
-      JSON.stringify(angularJson, null, 2)
+      JSON.stringify(angularJson, null, 2),
     );
 
     let viteConfig = fs.readFileSync(`${tmpDir}/vite.config.ts`, 'utf-8');
     viteConfig = viteConfig.replace(
       'analog()',
-      `analog({ vite: { tsconfig: '${tmpDir}/tsconfig.spec.json' } })`
+      `analog({ vite: { tsconfig: '${tmpDir}/tsconfig.spec.json' } })`,
     );
 
     fs.writeFileSync(`${tmpDir}/vite.config.ts`, viteConfig);
@@ -140,16 +140,16 @@ describe.skip('create-analog e2e', () => {
 
     const appConfigContent = fs.readFileSync(
       `${tmpDir}/src/app/app.config.ts`,
-      'utf-8'
+      'utf-8',
     );
 
     // ensure highlighter is added
     expect(appConfigContent).toContain(
-      `import { withPrismHighlighter } from '@analogjs/content/prism-highlighter'`
+      `import { withPrismHighlighter } from '@analogjs/content/prism-highlighter'`,
     );
 
     expect(() =>
-      checkFilesExist(`${tmpDir}/dist/analog/public/index.html`)
+      checkFilesExist(`${tmpDir}/dist/analog/public/index.html`),
     ).not.toThrow();
 
     fs.rmdirSync(tmpDir, { recursive: true });
@@ -161,7 +161,7 @@ describe.skip('create-analog e2e', () => {
 
     await runCommandAsync(
       `node ./dist/packages/create-analog/index.js ${project} --template angular-v17 --skipTailwind`,
-      { cwd: process.cwd() }
+      { cwd: process.cwd() },
     );
 
     await runCommandAsync(`pnpm i`, {
@@ -176,19 +176,19 @@ describe.skip('create-analog e2e', () => {
       `ng update @angular/cli @angular/core --next --allow-dirty`,
       {
         cwd: tmpDir,
-      }
+      },
     );
 
     emptyDir(`${tmpDir}/node_modules/@analogjs`);
     copyDir(
       `${process.cwd()}/node_modules/@analogjs`,
-      `${tmpDir}/node_modules/@analogjs`
+      `${tmpDir}/node_modules/@analogjs`,
     );
 
     let viteConfig = fs.readFileSync(`${tmpDir}/vite.config.ts`, 'utf-8');
     viteConfig = viteConfig.replace(
       'analog()',
-      `analog({ vite: { tsconfig: '${tmpDir}/tsconfig.spec.json' } })`
+      `analog({ vite: { tsconfig: '${tmpDir}/tsconfig.spec.json' } })`,
     );
 
     fs.writeFileSync(`${tmpDir}/vite.config.ts`, viteConfig);
@@ -202,7 +202,7 @@ describe.skip('create-analog e2e', () => {
     });
 
     expect(() =>
-      checkFilesExist(`${tmpDir}/dist/analog/public/index.html`)
+      checkFilesExist(`${tmpDir}/dist/analog/public/index.html`),
     ).not.toThrow();
 
     fs.rmdirSync(tmpDir, { recursive: true });

--- a/apps/docs-app/docs/experimental/sfc/index.md
+++ b/apps/docs-app/docs/experimental/sfc/index.md
@@ -449,7 +449,7 @@ Just like with `.md` files you can dynamically search and filter `.agx` content 
 <script lang="ts">
   // posts.[slug].page.analog
   import { injectContent } from '@analogjs/content';
-  import { MarkdownComponent } from '@analogjs/content' with { analog: 'imports' }
+  import { MarkdownComponent } from '@analogjs/content' with { analog: 'imports' };
   import { toSignal } from '@angular/core/rxjs-interop';
 
   import { PostAttributes } from './models';

--- a/apps/docs-app/docs/features/api/og-image-generation.md
+++ b/apps/docs-app/docs/features/api/og-image-generation.md
@@ -45,7 +45,7 @@ import { ImageResponse } from '@analogjs/content/og';
 
 export default defineEventHandler(async (event) => {
   const fontFile = await fetch(
-    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff'
+    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff',
   );
   const fontData: ArrayBuffer = await fontFile.arrayBuffer();
   const query = getQuery(event); // query params

--- a/apps/docs-app/docs/features/api/overview.md
+++ b/apps/docs-app/docs/features/api/overview.md
@@ -83,7 +83,7 @@ Dynamic API routes are defined by using the filename as the route path enclosed 
 import { defineEventHandler } from 'h3';
 
 export default defineEventHandler(
-  (event) => `Hello ${event.context.params?.['name']}!`
+  (event) => `Hello ${event.context.params?.['name']}!`,
 );
 ```
 

--- a/apps/docs-app/docs/features/data-fetching/overview.md
+++ b/apps/docs-app/docs/features/data-fetching/overview.md
@@ -34,7 +34,7 @@ export function bootstrap() {
 export default async function render(
   url: string,
   document: string,
-  serverContext: ServerContext
+  serverContext: ServerContext,
 ) {
   const html = await renderApplication(bootstrap, {
     document,
@@ -87,7 +87,7 @@ export const appConfig: ApplicationConfig = {
     provideFileRouter(withNavigationErrorHandler(console.error)),
     provideHttpClient(
       withFetch(),
-      withInterceptors([requestContextInterceptor])
+      withInterceptors([requestContextInterceptor]),
     ),
     provideClientHydration(),
   ],

--- a/apps/docs-app/docs/features/data-fetching/server-side-data-fetching.md
+++ b/apps/docs-app/docs/features/data-fetching/server-side-data-fetching.md
@@ -63,7 +63,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideFileRouter(
       withComponentInputBinding(),
-      withNavigationErrorHandler(console.error)
+      withNavigationErrorHandler(console.error),
     ),
     provideHttpClient(),
     provideClientHydration(),

--- a/apps/docs-app/docs/features/routing/content.md
+++ b/apps/docs-app/docs/features/routing/content.md
@@ -256,7 +256,7 @@ export interface PostAttributes {
 })
 export default class BlogComponent {
   readonly posts = injectContentFiles<PostAttributes>((contentFile) =>
-    contentFile.filename.includes('/src/content/blog/')
+    contentFile.filename.includes('/src/content/blog/'),
   );
 }
 ```

--- a/apps/docs-app/docs/features/routing/overview.md
+++ b/apps/docs-app/docs/features/routing/overview.md
@@ -121,7 +121,7 @@ export default class ProductDetailsPageComponent {
   private readonly route = inject(ActivatedRoute);
 
   readonly productId$ = this.route.paramMap.pipe(
-    map((params) => params.get('productId'))
+    map((params) => params.get('productId')),
   );
 }
 ```
@@ -239,7 +239,7 @@ export default class ProductDetailsPageComponent {
   private readonly route = inject(ActivatedRoute);
 
   readonly productId$ = this.route.paramMap.pipe(
-    map((params) => params.get('productId'))
+    map((params) => params.get('productId')),
   );
 }
 ```

--- a/apps/docs-app/docs/features/testing/vitest.md
+++ b/apps/docs-app/docs/features/testing/vitest.md
@@ -117,7 +117,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -136,7 +136,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -263,7 +263,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -319,7 +319,7 @@ describe('CardComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [CardComponent],
-    })
+    }),
   );
 
   beforeEach(() => {

--- a/apps/docs-app/docs/guides/forms.md
+++ b/apps/docs-app/docs/guides/forms.md
@@ -44,24 +44,25 @@ type FormErrors =
     <h3>Newsletter Signup</h3>
 
     @if (!signedUp()) {
-    <form
-      method="post"
-      (onSuccess)="onSuccess()"
-      (onError)="onError($any($event))"
-      (onStateChange)="errors.set(undefined)"
-    >
-      <div>
-        <label for="email"> Email </label>
-        <input type="email" name="email" />
-      </div>
+      <form
+        method="post"
+        (onSuccess)="onSuccess()"
+        (onError)="onError($any($event))"
+        (onStateChange)="errors.set(undefined)"
+      >
+        <div>
+          <label for="email"> Email </label>
+          <input type="email" name="email" />
+        </div>
 
-      <button class="button" type="submit">Submit</button>
-    </form>
+        <button class="button" type="submit">Submit</button>
+      </form>
 
-    @if( errors()?.email ) {
-    <p>{{ errors()?.email }}</p>
-    } } @else {
-    <div>Thanks for signing up!</div>
+      @if (errors()?.email) {
+        <p>{{ errors()?.email }}</p>
+      }
+    } @else {
+      <div>Thanks for signing up!</div>
     }
   `,
 })
@@ -177,8 +178,8 @@ import type { load } from './search.server';
       <button class="button" type="submit">Submit</button>
     </form>
 
-    @if(searchTerm()) {
-    <p>Search Term: {{ searchTerm() }}</p>
+    @if (searchTerm()) {
+      <p>Search Term: {{ searchTerm() }}</p>
     }
   `,
 })

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/api/og-image-generation.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/api/og-image-generation.md
@@ -45,7 +45,7 @@ import { ImageResponse } from '@analogjs/content/og';
 
 export default defineEventHandler(async (event) => {
   const fontFile = await fetch(
-    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff'
+    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff',
   );
   const fontData: ArrayBuffer = await fontFile.arrayBuffer();
   const query = getQuery(event); // query params

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/api/overview.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/api/overview.md
@@ -82,7 +82,7 @@ Dynamische API-Routen werden durch die Verwendung des Dateinamens als Routenpfad
 import { defineEventHandler } from 'h3';
 
 export default defineEventHandler(
-  (event) => `Hello ${event.context.params?.['name']}!`
+  (event) => `Hello ${event.context.params?.['name']}!`,
 );
 ```
 

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/data-fetching/overview.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/data-fetching/overview.md
@@ -34,7 +34,7 @@ export function bootstrap() {
 export default async function render(
   url: string,
   document: string,
-  serverContext: ServerContext
+  serverContext: ServerContext,
 ) {
   const html = await renderApplication(bootstrap, {
     document,
@@ -87,7 +87,7 @@ export const appConfig: ApplicationConfig = {
     provideFileRouter(withNavigationErrorHandler(console.error)),
     provideHttpClient(
       withFetch(),
-      withInterceptors([requestContextInterceptor])
+      withInterceptors([requestContextInterceptor]),
     ),
     provideClientHydration(),
   ],

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/data-fetching/server-side-data-fetching.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/data-fetching/server-side-data-fetching.md
@@ -61,7 +61,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideFileRouter(
       withComponentInputBinding(),
-      withNavigationErrorHandler(console.error)
+      withNavigationErrorHandler(console.error),
     ),
     provideHttpClient(),
     provideClientHydration(),

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/routing/content.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/routing/content.md
@@ -250,7 +250,7 @@ export interface PostAttributes {
 })
 export default class BlogComponent {
   readonly posts = injectContentFiles<PostAttributes>((contentFile) =>
-    contentFile.filename.includes('/src/content/blog/')
+    contentFile.filename.includes('/src/content/blog/'),
   );
 }
 ```

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/routing/overview.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/routing/overview.md
@@ -115,7 +115,7 @@ export default class ProductDetailsPageComponent {
   private readonly route = inject(ActivatedRoute);
 
   readonly productId$ = this.route.paramMap.pipe(
-    map((params) => params.get('productId'))
+    map((params) => params.get('productId')),
   );
 }
 ```
@@ -233,7 +233,7 @@ export default class ProductDetailsPageComponent {
   private readonly route = inject(ActivatedRoute);
 
   readonly productId$ = this.route.paramMap.pipe(
-    map((params) => params.get('productId'))
+    map((params) => params.get('productId')),
   );
 }
 ```

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/testing/vitest.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/testing/vitest.md
@@ -113,7 +113,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -276,7 +276,7 @@ describe('CardComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [CardComponent],
-    })
+    }),
   );
 
   beforeEach(() => {

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/experimental/sfc/index.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/experimental/sfc/index.md
@@ -450,7 +450,7 @@ Al igual que con los archivos `.md`, puedes buscar y filtrar dinámicamente arch
 <script lang="ts">
   // posts.[slug].page.analog
   import { injectContent } from '@analogjs/content';
-  import { MarkdownComponent } from '@analogjs/content' with { analog: 'imports' }
+  import { MarkdownComponent } from '@analogjs/content' with { analog: 'imports' };
   import { toSignal } from '@angular/core/rxjs-interop';
 
   import { PostAttributes } from './models';

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/api/og-image-generation.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/api/og-image-generation.md
@@ -45,7 +45,7 @@ import { ImageResponse } from '@analogjs/content/og';
 
 export default defineEventHandler(async (event) => {
   const fontFile = await fetch(
-    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff'
+    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff',
   );
   const fontData: ArrayBuffer = await fontFile.arrayBuffer();
   const query = getQuery(event); // query params

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/api/overview.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/api/overview.md
@@ -81,7 +81,7 @@ Las rutas API dinámicas se definen usando el nombre de fichero como la ruta de 
 import { defineEventHandler } from 'h3';
 
 export default defineEventHandler(
-  (event: H3Event) => `Hello ${event.context.params?.['name']}!`
+  (event: H3Event) => `Hello ${event.context.params?.['name']}!`,
 );
 ```
 

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/data-fetching/overview.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/data-fetching/overview.md
@@ -34,7 +34,7 @@ export function bootstrap() {
 export default async function render(
   url: string,
   document: string,
-  serverContext: ServerContext
+  serverContext: ServerContext,
 ) {
   const html = await renderApplication(bootstrap, {
     document,
@@ -87,7 +87,7 @@ export const appConfig: ApplicationConfig = {
     provideFileRouter(withNavigationErrorHandler(console.error)),
     provideHttpClient(
       withFetch(),
-      withInterceptors([requestContextInterceptor])
+      withInterceptors([requestContextInterceptor]),
     ),
     provideClientHydration(),
   ],

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/data-fetching/server-side-data-fetching.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/data-fetching/server-side-data-fetching.md
@@ -62,7 +62,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideFileRouter(
       withComponentInputBinding(),
-      withNavigationErrorHandler(console.error)
+      withNavigationErrorHandler(console.error),
     ),
     provideHttpClient(),
     provideClientHydration(),

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/routing/content.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/routing/content.md
@@ -258,7 +258,7 @@ export interface PostAttributes {
 })
 export default class BlogComponent {
   readonly posts = injectContentFiles<PostAttributes>((contentFile) =>
-    contentFile.filename.includes('/src/content/blog/')
+    contentFile.filename.includes('/src/content/blog/'),
   );
 }
 ```

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/routing/overview.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/routing/overview.md
@@ -115,7 +115,7 @@ export default class ProductDetailsPageComponent {
   private readonly route = inject(ActivatedRoute);
 
   readonly productId$ = this.route.paramMap.pipe(
-    map((params) => params.get('productId'))
+    map((params) => params.get('productId')),
   );
 }
 ```
@@ -233,7 +233,7 @@ export default class ProductDetailsPageComponent {
   private readonly route = inject(ActivatedRoute);
 
   readonly productId$ = this.route.paramMap.pipe(
-    map((params) => params.get('productId'))
+    map((params) => params.get('productId')),
   );
 }
 ```

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/testing/vitest.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/testing/vitest.md
@@ -117,7 +117,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -136,7 +136,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -263,7 +263,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -319,7 +319,7 @@ describe('CardComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [CardComponent],
-    })
+    }),
   );
 
   beforeEach(() => {

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/guides/migrating.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/guides/migrating.md
@@ -254,7 +254,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -310,7 +310,7 @@ describe('CardComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [CardComponent],
-    })
+    }),
   );
 
   beforeEach(() => {

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/experimental/sfc/index.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/experimental/sfc/index.md
@@ -449,7 +449,7 @@ slug: 'hello'
 <script lang="ts">
   // posts.[slug].page.analog
   import { injectContent } from '@analogjs/content';
-  import { MarkdownComponent } from '@analogjs/content' with { analog: 'imports' }
+  import { MarkdownComponent } from '@analogjs/content' with { analog: 'imports' };
   import { toSignal } from '@angular/core/rxjs-interop';
 
   import { PostAttributes } from './models';

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/api/og-image-generation.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/api/og-image-generation.md
@@ -47,7 +47,7 @@ import { ImageResponse } from '@analogjs/content/og';
 
 export default defineEventHandler(async (event) => {
   const fontFile = await fetch(
-    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff'
+    'https://og-playground.vercel.app/inter-latin-ext-700-normal.woff',
   );
   const fontData: ArrayBuffer = await fontFile.arrayBuffer();
   const query = getQuery(event); // query params

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/api/overview.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/api/overview.md
@@ -81,7 +81,7 @@ export default defineConfig(({ mode }) => {
 import { defineEventHandler } from 'h3';
 
 export default defineEventHandler(
-  (event) => `Hello ${event.context.params?.['name']}!`
+  (event) => `Hello ${event.context.params?.['name']}!`,
 );
 ```
 

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/data-fetching/overview.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/data-fetching/overview.md
@@ -38,7 +38,7 @@ export function bootstrap() {
 export default async function render(
   url: string,
   document: string,
-  serverContext: ServerContext
+  serverContext: ServerContext,
 ) {
   const html = await renderApplication(bootstrap, {
     document,
@@ -91,7 +91,7 @@ export const appConfig: ApplicationConfig = {
     provideFileRouter(withNavigationErrorHandler(console.error)),
     provideHttpClient(
       withFetch(),
-      withInterceptors([requestContextInterceptor])
+      withInterceptors([requestContextInterceptor]),
     ),
     provideClientHydration(),
   ],

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/data-fetching/server-side-data-fetching.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/data-fetching/server-side-data-fetching.md
@@ -61,7 +61,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideFileRouter(
       withComponentInputBinding(),
-      withNavigationErrorHandler(console.error)
+      withNavigationErrorHandler(console.error),
     ),
     provideHttpClient(),
     provideClientHydration(),

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/routing/content.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/routing/content.md
@@ -255,7 +255,7 @@ export interface PostAttributes {
 })
 export default class BlogComponent {
   readonly posts = injectContentFiles<PostAttributes>((contentFile) =>
-    contentFile.filename.includes('/src/content/blog/')
+    contentFile.filename.includes('/src/content/blog/'),
   );
 }
 ```

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/routing/overview.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/routing/overview.md
@@ -115,7 +115,7 @@ export default class ProductDetailsPageComponent {
   private readonly route = inject(ActivatedRoute);
 
   readonly productId$ = this.route.paramMap.pipe(
-    map((params) => params.get('productId'))
+    map((params) => params.get('productId')),
   );
 }
 ```
@@ -233,7 +233,7 @@ export default class ProductDetailsPageComponent {
   private readonly route = inject(ActivatedRoute);
 
   readonly productId$ = this.route.paramMap.pipe(
-    map((params) => params.get('productId'))
+    map((params) => params.get('productId')),
   );
 }
 ```

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/testing/vitest.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/testing/vitest.md
@@ -117,7 +117,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -280,7 +280,7 @@ describe('CardComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [CardComponent],
-    })
+    }),
   );
 
   beforeEach(() => {

--- a/apps/docs-app/src/components/StackblitzButton/index.tsx
+++ b/apps/docs-app/src/components/StackblitzButton/index.tsx
@@ -12,7 +12,7 @@ export default function StackblitzButton(): JSX.Element {
     <Link
       className={clsx(
         'button button--outline button--lg',
-        styles.stackblitzLink
+        styles.stackblitzLink,
       )}
       to="https://analogjs.org/new"
     >

--- a/apps/docs-app/src/pages/index.tsx
+++ b/apps/docs-app/src/pages/index.tsx
@@ -26,7 +26,7 @@ function HomepageHeader() {
           <Link
             className={clsx(
               'button button--secondary button--lg',
-              styles.readDocsButton
+              styles.readDocsButton,
             )}
             to="/docs"
           >
@@ -140,7 +140,7 @@ function SponsorSection() {
           <Link
             className={clsx(
               'button button--secondary button--lg',
-              styles.sponsorButton
+              styles.sponsorButton,
             )}
             href="https://github.com/sponsors/brandonroberts"
           >

--- a/apps/ng-app/index.html
+++ b/apps/ng-app/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/apps/ng-app/src/app/app.config.ts
+++ b/apps/ng-app/src/app/app.config.ts
@@ -11,7 +11,7 @@ export const appConfig: ApplicationConfig = {
     provideContent(
       withMarkdownRenderer(),
       // NOTE: .agx files are not affected by the highlighter yet.
-      withPrismHighlighter()
+      withPrismHighlighter(),
     ),
   ],
 };

--- a/apps/ng-app/src/app/hello.ts
+++ b/apps/ng-app/src/app/hello.ts
@@ -9,7 +9,11 @@ import Hello from './hello.ag';
     <p>Below me is a cool hello though</p>
     <Hello text="this is from the boring HelloOriginal" />
   `,
-  styles: `p { color: teal; }`,
+  styles: `
+    p {
+      color: teal;
+    }
+  `,
   imports: [Hello],
 })
 // eslint-disable-next-line @angular-eslint/component-class-suffix

--- a/apps/ng-app/src/main.ts
+++ b/apps/ng-app/src/main.ts
@@ -4,5 +4,5 @@ import { appConfig } from './app/app.config';
 import AppComponent from './app/app.component.ag';
 
 bootstrapApplication(AppComponent, appConfig).catch((err) =>
-  console.error(err)
+  console.error(err),
 );

--- a/apps/ng-app/src/test-setup.ts
+++ b/apps/ng-app/src/test-setup.ts
@@ -8,5 +8,5 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/apps/ng-app/src/vite-env.d.ts
+++ b/apps/ng-app/src/vite-env.d.ts
@@ -29,7 +29,7 @@ declare global {
         | 'styles'
         | 'outputs'
         | 'inputs'
-      >
+      >,
     ) => void;
 
     /**

--- a/apps/nx-plugin-e2e/tests/nx-plugin.spec.ts
+++ b/apps/nx-plugin-e2e/tests/nx-plugin.spec.ts
@@ -29,7 +29,7 @@ describe.skip('nx-plugin e2e', () => {
   it('should create hello-world', async () => {
     const project = uniq('app');
     await runNxCommandAsync(
-      `generate @analogjs/platform:app ${project} --addTailwind=true --addTRPC=true`
+      `generate @analogjs/platform:app ${project} --addTailwind=true --addTRPC=true`,
     );
     copyNodeModules(['@analogjs']);
 
@@ -39,12 +39,12 @@ describe.skip('nx-plugin e2e', () => {
     renameFile(`${project}/postcss.config.js`, `${project}/postcss.config.cjs`);
     renameFile(
       `${project}/tailwind.config.js`,
-      `${project}/tailwind.config.cjs`
+      `${project}/tailwind.config.cjs`,
     );
     const postCssConfig = readFile(`${project}/postcss.config.cjs`);
     updateFile(
       `${project}/postcss.config.cjs`,
-      postCssConfig.replace('tailwind.config.js', 'tailwind.config.cjs')
+      postCssConfig.replace('tailwind.config.js', 'tailwind.config.cjs'),
     );
 
     await runNxCommandAsync(`test ${project}`);

--- a/apps/trpc-app-e2e-playwright/tests/app.spec.ts
+++ b/apps/trpc-app-e2e-playwright/tests/app.spec.ts
@@ -39,7 +39,7 @@ describe.skip('tRPC Demo App', () => {
   test(`Given the user has navigated to the home page
     Then the app title is visible`, async () => {
     await expect(
-      page.locator('role=heading[level=1] >> text=Analog + tRPC')
+      page.locator('role=heading[level=1] >> text=Analog + tRPC'),
     ).toContain(/Analog + tRPC/i);
   });
 

--- a/apps/trpc-app-e2e-playwright/tests/fixtures/notes.po.ts
+++ b/apps/trpc-app-e2e-playwright/tests/fixtures/notes.po.ts
@@ -18,7 +18,7 @@ export class NotesPage {
 
   async removeNote(index: number) {
     await this.waitForTrpcResponse(
-      this.page.getByTestId('removeNoteAtIndexBtn' + index).click()
+      this.page.getByTestId('removeNoteAtIndexBtn' + index).click(),
     );
   }
 

--- a/apps/trpc-app/index.html
+++ b/apps/trpc-app/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="dark h-full" lang="en">
   <head>
     <meta charset="utf-8" />

--- a/apps/trpc-app/src/app/pages/index.page.ts
+++ b/apps/trpc-app/src/app/pages/index.page.ts
@@ -109,7 +109,7 @@ export default class HomeComponent {
   public triggerRefresh$ = new Subject<void>();
   public notes$ = this.triggerRefresh$.pipe(
     switchMap(() => this._trpc.note.list.query()),
-    shareReplay(1)
+    shareReplay(1),
   );
   public newNote = '';
   public loggedIn = signal(false);
@@ -125,7 +125,7 @@ export default class HomeComponent {
           ...h,
           authorization: this.loggedIn() ? 'Bearer authToken' : undefined,
         })),
-      { allowSignalWrites: true }
+      { allowSignalWrites: true },
     );
   }
 
@@ -155,7 +155,7 @@ export default class HomeComponent {
         catchError((e) => {
           this.error.set(e);
           return of(null);
-        })
+        }),
       )
       .subscribe(() => this.triggerRefresh$.next());
   }

--- a/apps/trpc-app/src/main.ts
+++ b/apps/trpc-app/src/main.ts
@@ -5,5 +5,5 @@ import { AppComponent } from './app/app.component';
 import { appConfig } from './app.config';
 
 bootstrapApplication(AppComponent, appConfig).catch((err) =>
-  console.error(err)
+  console.error(err),
 );

--- a/apps/trpc-app/src/server/trpc/routers/notes.ts
+++ b/apps/trpc-app/src/server/trpc/routers/notes.ts
@@ -9,21 +9,21 @@ export const noteRouter = router({
     .input(
       z.object({
         title: z.string(),
-      })
+      }),
     )
     .mutation(({ input }) =>
       notes.push({
         id: noteId++,
         note: input.title,
         createdAt: new Date(),
-      })
+      }),
     ),
   list: publicProcedure.query(() => notes),
   remove: protectedProcedure
     .input(
       z.object({
         id: z.number(),
-      })
+      }),
     )
     .mutation(({ input }) => {
       const index = notes.findIndex((note) => input.id === note.id);

--- a/apps/trpc-app/src/test-setup.ts
+++ b/apps/trpc-app/src/test-setup.ts
@@ -8,5 +8,5 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/decorate-angular-cli.js
+++ b/decorate-angular-cli.js
@@ -30,7 +30,7 @@ try {
   output = require('@nx/workspace').output;
 } catch (e) {
   console.warn(
-    'Angular CLI could not be decorated to enable computation caching. Please ensure @nx/workspace is installed.'
+    'Angular CLI could not be decorated to enable computation caching. Please ensure @nx/workspace is installed.',
   );
   process.exit(0);
 }

--- a/libs/card/src/lib/autocomplete/autocomplete.component.html
+++ b/libs/card/src/lib/autocomplete/autocomplete.component.html
@@ -10,7 +10,7 @@
   />
   <mat-autocomplete #autocomplete="matAutocomplete" autoActiveFirstOption>
     @for (option of filteredOptions(); track option) {
-    <mat-option [value]="option.value">{{ option.label }}</mat-option>
+      <mat-option [value]="option.value">{{ option.label }}</mat-option>
     }
   </mat-autocomplete>
 </mat-form-field>

--- a/libs/card/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/card/src/lib/autocomplete/autocomplete.component.ts
@@ -44,8 +44,8 @@ export class AutocompleteComponent {
 
     return Object.freeze(
       this.options.filter((option) =>
-        option.label.toLocaleLowerCase().includes(value)
-      )
+        option.label.toLocaleLowerCase().includes(value),
+      ),
     );
   });
 }

--- a/libs/card/src/test-setup.ts
+++ b/libs/card/src/test-setup.ts
@@ -11,5 +11,5 @@ import {
 
 TestBed.initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/libs/shared/feature/src/test-setup.ts
+++ b/libs/shared/feature/src/test-setup.ts
@@ -11,5 +11,5 @@ import {
 
 TestBed.initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/libs/top-bar/src/test-setup.ts
+++ b/libs/top-bar/src/test-setup.ts
@@ -12,5 +12,5 @@ import {
 
 TestBed.initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "postcss-import": "~15.1.0",
     "postcss-preset-env": "~8.0.1",
     "postcss-url": "~10.1.3",
-    "prettier": "^2.8.3",
+    "prettier": "^3.4.2",
     "prismjs": "^1.29.0",
     "prompts": "^2.4.2",
     "rimraf": "^6.0.1",

--- a/packages/astro-angular/src/client.ts
+++ b/packages/astro-angular/src/client.ts
@@ -15,7 +15,7 @@ export default (element: HTMLElement) => {
       clientProviders?: (Provider | EnvironmentProviders)[];
     },
     props?: Record<string, unknown>,
-    _childHTML?: unknown
+    _childHTML?: unknown,
   ) => {
     createApplication({
       providers: [...(Component.clientProviders || [])],
@@ -33,7 +33,7 @@ export default (element: HTMLElement) => {
             if (
               mirror.inputs.some(
                 ({ templateName, propName }) =>
-                  templateName === key || propName === key
+                  templateName === key || propName === key,
               )
             ) {
               componentRef.setInput(key, value);
@@ -45,7 +45,7 @@ export default (element: HTMLElement) => {
           const destroySubject = new Subject<void>();
           element.setAttribute(
             'data-analog-id',
-            props['data-analog-id'] as string
+            props['data-analog-id'] as string,
           );
 
           mirror.outputs.forEach(({ templateName, propName }) => {

--- a/packages/astro-angular/src/index.ts
+++ b/packages/astro-angular/src/index.ts
@@ -43,7 +43,7 @@ function getViteConfiguration(vite?: PluginOptions) {
             return {
               code: code.replace(
                 'new xhr2.XMLHttpRequest',
-                'new (xhr2.default.XMLHttpRequest || xhr2.default)'
+                'new (xhr2.default.XMLHttpRequest || xhr2.default)',
               ),
             };
           }
@@ -77,7 +77,7 @@ export default function (options?: AngularOptions): AstroIntegration {
         addRenderer(getRenderer());
         updateConfig({
           vite: getViteConfiguration(
-            options?.vite
+            options?.vite,
           ) as DeepPartial<ViteUserConfig>,
         });
       },
@@ -88,7 +88,7 @@ export default function (options?: AngularOptions): AstroIntegration {
         ) {
           console.warn(
             `[warning] The Angular integration doesn't support Shiki syntax highlighting in MDX files. Overriding with Prism.\n
-To disable this warning, set the syntaxHighlight option in your astro.config.mjs mdx() integration to 'prism' or false.`
+To disable this warning, set the syntaxHighlight option in your astro.config.mjs mdx() integration to 'prism' or false.`,
           );
         }
         if (process.env['NODE_ENV'] === 'production') {

--- a/packages/astro-angular/src/server.ts
+++ b/packages/astro-angular/src/server.ts
@@ -30,7 +30,7 @@ const ANALOG_ASTRO_STATIC_PROPS = new InjectionToken<{
 function check(
   Component: ComponentType<unknown>,
   _props: Record<string, unknown>,
-  _children: unknown
+  _children: unknown,
 ) {
   return !!reflectComponentType(Component);
 }
@@ -47,7 +47,7 @@ const STATIC_PROPS_HOOK_PROVIDER: Provider = {
     }: {
       props: Record<string, unknown>;
       mirror: ComponentMirror<unknown>;
-    }
+    },
   ) => {
     return () => {
       const compRef = appRef.components[0];
@@ -59,7 +59,7 @@ const STATIC_PROPS_HOOK_PROVIDER: Provider = {
             // that aren't actually Input defined on the Component
             mirror.inputs.some(
               ({ templateName, propName }) =>
-                templateName === key || propName === key
+                templateName === key || propName === key,
             )
           ) {
             compRef.setInput(key, value);
@@ -78,7 +78,7 @@ async function renderToStaticMarkup(
     renderProviders: (Provider | EnvironmentProviders)[];
   },
   props: Record<string, unknown>,
-  _children: unknown
+  _children: unknown,
 ) {
   const mirror = reflectComponentType(Component);
   const appId =

--- a/packages/astro-angular/src/utils.ts
+++ b/packages/astro-angular/src/utils.ts
@@ -2,12 +2,12 @@ export function addOutputListener(
   analogId: string,
   outputName: string,
   callback: (...args: any[]) => unknown,
-  eventListenerOptions: EventListenerOptions = {}
+  eventListenerOptions: EventListenerOptions = {},
 ) {
   const observer = new MutationObserver((mutations) => {
     const foundTarget = mutations.find(
       (mutation) =>
-        (mutation.target as HTMLElement).dataset?.['analogId'] === analogId
+        (mutation.target as HTMLElement).dataset?.['analogId'] === analogId,
     )?.target;
 
     if (foundTarget) {

--- a/packages/content-plugin/src/migrations/update-markdown-renderer-feature/update-markdown-renderer-feature.spec.ts
+++ b/packages/content-plugin/src/migrations/update-markdown-renderer-feature/update-markdown-renderer-feature.spec.ts
@@ -40,7 +40,7 @@ export const appConfig: ApplicationConfig = {
       withMarkdownRenderer()
     )
   ],
-};`
+};`,
     );
   }
 
@@ -49,7 +49,7 @@ export const appConfig: ApplicationConfig = {
     await update(tree);
     const configContent = tree.read(
       'apps/my-app/src/app/app.config.ts',
-      'utf-8'
+      'utf-8',
     );
     expect(configContent).toContain('withPrismHighlighter()');
     expect(configContent).toContain('@analogjs/content/prism-highlighter');

--- a/packages/content-plugin/src/migrations/update-markdown-renderer-feature/update-markdown-renderer-feature.ts
+++ b/packages/content-plugin/src/migrations/update-markdown-renderer-feature/update-markdown-renderer-feature.ts
@@ -33,7 +33,7 @@ export default async function update(host: Tree) {
           (node): node is CallExpression =>
             Node.isCallExpression(node) &&
             node.getText().includes('provideContent') &&
-            node.getText().includes('withMarkdownRenderer')
+            node.getText().includes('withMarkdownRenderer'),
         );
 
         if (provideContentNode) {

--- a/packages/content/og/src/lib/og.ts
+++ b/packages/content/og/src/lib/og.ts
@@ -8,7 +8,7 @@ import { ImageResponseOptions } from './options.js';
 
 export const generateImage = async (
   element: string,
-  options: ImageResponseOptions
+  options: ImageResponseOptions,
 ) => {
   const elementHtml = toReactElement(element);
   const svg = await satori(elementHtml as any, {

--- a/packages/content/prism-highlighter/src/lib/prism-highlighter.ts
+++ b/packages/content/prism-highlighter/src/lib/prism-highlighter.ts
@@ -48,7 +48,7 @@ export class PrismHighlighter extends MarkedContentHighlighter {
         return Prism.highlight(
           code,
           diff ? Prism.languages['diff'] : Prism.languages[lang],
-          lang
+          lang,
         );
       },
     });

--- a/packages/content/shiki-highlighter/src/index.ts
+++ b/packages/content/shiki-highlighter/src/index.ts
@@ -21,7 +21,7 @@ export type WithShikiHighlighterOptions = ShikiHighlightOptions & {
 };
 
 export function withShikiHighlighter(
-  _opts: WithShikiHighlighterOptions = {}
+  _opts: WithShikiHighlighterOptions = {},
 ): Provider[] {
   return [
     {

--- a/packages/content/src/lib/anchor-navigation.directive.spec.ts
+++ b/packages/content/src/lib/anchor-navigation.directive.spec.ts
@@ -199,7 +199,7 @@ function setup() {
     .injector.get(AnchorNavigationDirective);
   const handleNavigation = vi.spyOn(
     anchorNavigationDirective,
-    'handleNavigation'
+    'handleNavigation',
   );
 
   function selectById(id: string): HTMLElement {

--- a/packages/content/src/lib/anchor-navigation.directive.ts
+++ b/packages/content/src/lib/anchor-navigation.directive.ts
@@ -40,7 +40,7 @@ function hasTargetSelf(anchorElement: HTMLAnchorElement): boolean {
 
 function isInternalUrl(
   anchorElement: HTMLAnchorElement,
-  document: Document
+  document: Document,
 ): boolean {
   return (
     anchorElement.host === document.location.host &&

--- a/packages/content/src/lib/content-file.ts
+++ b/packages/content/src/lib/content-file.ts
@@ -1,5 +1,5 @@
 export interface ContentFile<
-  Attributes extends Record<string, any> = Record<string, any>
+  Attributes extends Record<string, any> = Record<string, any>,
 > {
   filename: string;
   slug: string;

--- a/packages/content/src/lib/content-files-list-token.ts
+++ b/packages/content/src/lib/content-files-list-token.ts
@@ -25,5 +25,5 @@ export const CONTENT_FILES_LIST_TOKEN = new InjectionToken<ContentFile[]>(
         };
       });
     },
-  }
+  },
 );

--- a/packages/content/src/lib/content-files-token.ts
+++ b/packages/content/src/lib/content-files-token.ts
@@ -32,7 +32,7 @@ export const CONTENT_FILES_TOKEN = new InjectionToken<
       if (newFilename !== undefined) {
         const objectFilename = newFilename.replace(
           /^\/(.*?)\/content/,
-          '/src/content'
+          '/src/content',
         );
         objectUsingSlugAttribute[objectFilename] =
           value as () => Promise<string>;

--- a/packages/content/src/lib/content-renderer.ts
+++ b/packages/content/src/lib/content-renderer.ts
@@ -49,7 +49,7 @@ export class NoopContentRenderer implements ContentRenderer {
 
   getContentHeadings(): Array<TableOfContentItem> {
     const key = makeStateKey<TableOfContentItem[]>(
-      `content-headings-${this.contentId}`
+      `content-headings-${this.contentId}`,
     );
 
     if (import.meta.env.SSR === true) {

--- a/packages/content/src/lib/content.spec.ts
+++ b/packages/content/src/lib/content.spec.ts
@@ -130,7 +130,7 @@ Test Content`),
       expect(c.content).toMatch('Test Content');
       expect(c.attributes).toEqual({ slug: 'custom-prefix-slug-test' });
       expect(c.filename).toEqual(
-        '/src/content/customPrefix/custom-prefix-slug-test'
+        '/src/content/customPrefix/custom-prefix-slug-test',
       );
       expect(c.slug).toEqual('custom-prefix-slug-test');
     });
@@ -275,7 +275,7 @@ Test Content`),
         string,
         () => Promise<string | { default: any; metadata: any }>
       >;
-    }>
+    }>,
   ) {
     TestBed.configureTestingModule({
       providers: [
@@ -284,7 +284,7 @@ Test Content`),
           provide: ActivatedRoute,
           useValue: {
             paramMap: of(
-              convertToParamMap(args.routeParams ?? { slug: 'test' })
+              convertToParamMap(args.routeParams ?? { slug: 'test' }),
             ),
           },
         },
@@ -298,7 +298,7 @@ Test Content`),
         ContentFile<TestAttributes | Record<string, never>>
       > =>
         TestBed.runInInjectionContext(() =>
-          injectContent<TestAttributes>(args.customParam, args.customFallback)
+          injectContent<TestAttributes>(args.customParam, args.customFallback),
         ),
     };
   }

--- a/packages/content/src/lib/content.ts
+++ b/packages/content/src/lib/content.ts
@@ -12,13 +12,13 @@ import { waitFor } from './utils/zone-wait-for';
 import { RenderTaskService } from './render-task.service';
 
 function getContentFile<
-  Attributes extends Record<string, any> = Record<string, any>
+  Attributes extends Record<string, any> = Record<string, any>,
 >(
   contentFiles: Record<string, () => Promise<string>>,
   prefix: string,
   slug: string,
   fallback: string,
-  renderTaskService: RenderTaskService
+  renderTaskService: RenderTaskService,
 ): Observable<ContentFile<Attributes | Record<string, never>>> {
   const filePath = `/src/content/${prefix}${slug}`;
   const contentFile =
@@ -50,7 +50,7 @@ function getContentFile<
           observer.complete();
         });
       }
-    }
+    },
   ).pipe(
     map((contentFile) => {
       if (typeof contentFile === 'string') {
@@ -70,7 +70,7 @@ function getContentFile<
         attributes: contentFile.metadata,
         content: contentFile.default,
       };
-    })
+    }),
   );
 }
 
@@ -81,7 +81,7 @@ function getContentFile<
  * @param fallback fallback text if content file is not found (default: 'No Content Found')
  */
 export function injectContent<
-  Attributes extends Record<string, any> = Record<string, any>
+  Attributes extends Record<string, any> = Record<string, any>,
 >(
   param:
     | string
@@ -92,7 +92,7 @@ export function injectContent<
     | {
         customFilename: string;
       } = 'slug',
-  fallback = 'No Content Found'
+  fallback = 'No Content Found',
 ): Observable<ContentFile<Attributes | Record<string, never>>> {
   const contentFiles = inject(CONTENT_FILES_TOKEN);
   const renderTaskService = inject(RenderTaskService);
@@ -111,7 +111,7 @@ export function injectContent<
             prefix,
             slug,
             fallback,
-            renderTaskService
+            renderTaskService,
           );
         }
         return of({
@@ -121,7 +121,7 @@ export function injectContent<
           content: fallback,
         });
       }),
-      tap(() => renderTaskService.clearRenderTask(task))
+      tap(() => renderTaskService.clearRenderTask(task)),
     );
   } else {
     return getContentFile<Attributes>(
@@ -129,7 +129,7 @@ export function injectContent<
       '',
       param.customFilename,
       fallback,
-      renderTaskService
+      renderTaskService,
     ).pipe(tap(() => renderTaskService.clearRenderTask(task)));
   }
 }

--- a/packages/content/src/lib/inject-content-files.spec.ts
+++ b/packages/content/src/lib/inject-content-files.spec.ts
@@ -64,11 +64,11 @@ describe('injectContentFiles', () => {
     ];
 
     const contentFilterFn: InjectContentFilesFilterFunction<TestAttributes> = (
-      contentFile
+      contentFile,
     ) => !!contentFile.filename.includes('/src/content/blog/');
     const { injectContentFiles } = setup<TestAttributes>(
       contentFiles,
-      contentFilterFn
+      contentFilterFn,
     );
     const injectedFiles = injectContentFiles();
     const expectedContentFiles = [contentFiles[2]];
@@ -77,7 +77,7 @@ describe('injectContentFiles', () => {
 
   function setup<Attributes extends Record<string, any>>(
     contentFiles: ContentFile[] = [],
-    filterFn?: InjectContentFilesFilterFunction<Attributes>
+    filterFn?: InjectContentFilesFilterFunction<Attributes>,
   ) {
     TestBed.configureTestingModule({
       providers: [RenderTaskService],
@@ -88,7 +88,7 @@ describe('injectContentFiles', () => {
     return {
       injectContentFiles: () =>
         TestBed.runInInjectionContext(() =>
-          injectContentFiles<Attributes>(filterFn)
+          injectContentFiles<Attributes>(filterFn),
         ),
     };
   }

--- a/packages/content/src/lib/inject-content-files.ts
+++ b/packages/content/src/lib/inject-content-files.ts
@@ -4,12 +4,12 @@ import { CONTENT_FILES_LIST_TOKEN } from './content-files-list-token';
 import { RenderTaskService } from './render-task.service';
 
 export function injectContentFiles<Attributes extends Record<string, any>>(
-  filterFn?: InjectContentFilesFilterFunction<Attributes>
+  filterFn?: InjectContentFilesFilterFunction<Attributes>,
 ): ContentFile<Attributes>[] {
   const renderTaskService = inject(RenderTaskService);
   const task = renderTaskService.addRenderTask();
   const allContentFiles = inject(
-    CONTENT_FILES_LIST_TOKEN
+    CONTENT_FILES_LIST_TOKEN,
   ) as ContentFile<Attributes>[];
   renderTaskService.clearRenderTask(task);
 
@@ -25,5 +25,5 @@ export function injectContentFiles<Attributes extends Record<string, any>>(
 export type InjectContentFilesFilterFunction<T extends Record<string, any>> = (
   value: ContentFile<T>,
   index: number,
-  array: ContentFile<T>[]
+  array: ContentFile<T>[],
 ) => boolean;

--- a/packages/content/src/lib/markdown-content-renderer.service.spec.ts
+++ b/packages/content/src/lib/markdown-content-renderer.service.spec.ts
@@ -53,14 +53,14 @@ Lorem ipsum 2....
     let result = await service.render(testCode);
 
     expect(result).toContain(
-      '<pre class="language-javascript"><code class="language-javascript">'
+      '<pre class="language-javascript"><code class="language-javascript">',
     );
 
     testCode = "```typescript\nconsole.log('Hello, world!');\n```";
     result = await service.render(testCode);
 
     expect(result).toContain(
-      '<pre class="language-typescript"><code class="language-typescript">'
+      '<pre class="language-typescript"><code class="language-typescript">',
     );
   });
 });

--- a/packages/content/src/lib/markdown-route.component.ts
+++ b/packages/content/src/lib/markdown-route.component.ts
@@ -27,7 +27,7 @@ export default class AnalogMarkdownRouteComponent implements AfterViewChecked {
   contentRenderer = inject(ContentRenderer);
 
   protected content: SafeHtml = this.sanitizer.bypassSecurityTrustHtml(
-    this.route.snapshot.data['renderedAnalogContent']
+    this.route.snapshot.data['renderedAnalogContent'],
   );
 
   @Input() classes = 'analog-markdown-route';

--- a/packages/content/src/lib/markdown.component.ts
+++ b/packages/content/src/lib/markdown.component.ts
@@ -88,7 +88,7 @@ export default class AnalogMarkdownComponent
       filter((content) => typeof content === 'string'),
       mergeMap((contentString) => this.renderContent(contentString)),
       map((content) => this.sanitizer.bypassSecurityTrustHtml(content)),
-      catchError((e) => of(`There was an error ${e}`))
+      catchError((e) => of(`There was an error ${e}`)),
     );
   }
 
@@ -113,7 +113,7 @@ export default class AnalogMarkdownComponent
           // Explicitly running mermaid as ngAfterViewChecked
           // has probably already been called
           this.mermaid?.default.run();
-        })
+        }),
     );
   }
 }

--- a/packages/content/src/lib/marked-content-highlighter.ts
+++ b/packages/content/src/lib/marked-content-highlighter.ts
@@ -24,7 +24,7 @@ export function withHighlighter(
           | AbstractType<MarkedContentHighlighter>;
       }
     | { useFactory: (...deps: any[]) => MarkedContentHighlighter }
-  ) & { deps?: ProviderToken<any>[] }
+  ) & { deps?: ProviderToken<any>[] },
 ): Provider {
   return { provide: MarkedContentHighlighter, ...provider } as Provider;
 }

--- a/packages/content/src/lib/parse-raw-content-file.ts
+++ b/packages/content/src/lib/parse-raw-content-file.ts
@@ -1,7 +1,7 @@
 import fm from 'front-matter';
 
 export function parseRawContentFile<Attributes extends Record<string, any>>(
-  rawContentFile: string
+  rawContentFile: string,
 ): { content: string; attributes: Attributes } {
   const { body, attributes } = fm<Attributes>(rawContentFile);
   return { content: body, attributes };

--- a/packages/content/src/lib/provide-content.ts
+++ b/packages/content/src/lib/provide-content.ts
@@ -14,7 +14,7 @@ const CONTENT_RENDERER_PROVIDERS: Provider[] = [
 ];
 
 export function withMarkdownRenderer(
-  options?: MarkdownRendererOptions
+  options?: MarkdownRendererOptions,
 ): Provider {
   return [
     CONTENT_RENDERER_PROVIDERS,

--- a/packages/content/src/lib/utils/zone-wait-for.ts
+++ b/packages/content/src/lib/utils/zone-wait-for.ts
@@ -15,7 +15,7 @@ export async function waitFor<T>(prom: Promise<T> | Observable<T>): Promise<T> {
     `AnalogContentResolve-${Math.random()}`,
     () => {},
     {},
-    () => {}
+    () => {},
   );
   return prom.then((p: T) => {
     macroTask.invoke();

--- a/packages/content/src/test-setup.ts
+++ b/packages/content/src/test-setup.ts
@@ -12,5 +12,5 @@ import {
 
 TestBed.initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/packages/create-analog/__tests__/cli.spec.ts
+++ b/packages/create-analog/__tests__/cli.spec.ts
@@ -11,7 +11,7 @@ const genPath = join(__dirname, projectName);
 
 const run = (
   args: string[],
-  options: SyncOptions<string> = {}
+  options: SyncOptions<string> = {},
 ): ExecaSyncReturnValue<string> => {
   return commandSync(`node ${CLI_PATH} ${args.join(' ')}`, options);
 };
@@ -61,7 +61,7 @@ test('prompts for the starter if none supplied', () => {
 test.skip('prompts for the framework on supplying an invalid template', () => {
   const { stdout } = run([projectName, '--template', 'unknown']);
   expect(stdout).toContain(
-    `"unknown" isn't a valid template. Please choose from below:`
+    `"unknown" isn't a valid template. Please choose from below:`,
   );
 });
 
@@ -87,7 +87,7 @@ test('successfully scaffolds a project based on angular starter template', () =>
       '--analogSFC',
       'false',
     ],
-    { cwd: __dirname }
+    { cwd: __dirname },
   );
   const generatedFiles = readdirSync(genPath).sort();
 
@@ -99,7 +99,7 @@ test('successfully scaffolds a project based on angular starter template', () =>
 test('works with the -t alias', () => {
   const { stdout } = run(
     [projectName, '-t', 'latest', '--skipTailwind', '--analogSFC', 'false'],
-    { cwd: __dirname }
+    { cwd: __dirname },
   );
   const generatedFiles = readdirSync(genPath).sort();
 

--- a/packages/create-analog/index.js
+++ b/packages/create-analog/index.js
@@ -150,7 +150,7 @@ async function init() {
         onCancel: () => {
           throw new Error(red('✖') + ' Operation cancelled');
         },
-      }
+      },
     );
   } catch (cancelled) {
     console.log(cancelled.message);
@@ -188,7 +188,7 @@ async function init() {
   const templateDir = path.resolve(
     fileURLToPath(import.meta.url),
     '..',
-    `template-${template}`
+    `template-${template}`,
   );
 
   const filesDir = path.resolve(fileURLToPath(import.meta.url), '..', `files`);
@@ -219,7 +219,7 @@ async function init() {
   const pkgInfo = pkgFromUserAgent(process.env.npm_config_user_agent);
   const pkgManager = pkgInfo ? pkgInfo.name : 'npm';
   const pkg = JSON.parse(
-    fs.readFileSync(path.join(templateDir, `package.json`), 'utf-8')
+    fs.readFileSync(path.join(templateDir, `package.json`), 'utf-8'),
   );
 
   pkg.name = packageName || getProjectName();
@@ -284,7 +284,7 @@ function copy(src, dest) {
  */
 function isValidPackageName(projectName) {
   return /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(
-    projectName
+    projectName,
   );
 }
 
@@ -366,21 +366,21 @@ function getStartCommand(pkgManager) {
 function addTailwindDirectives(write, filesDir) {
   write(
     'src/styles.css',
-    fs.readFileSync(path.join(filesDir, `styles.css`), 'utf-8')
+    fs.readFileSync(path.join(filesDir, `styles.css`), 'utf-8'),
   );
 }
 
 function addPostCssConfig(write, filesDir) {
   write(
     'postcss.config.cjs',
-    fs.readFileSync(path.join(filesDir, `postcss.config.cjs`), 'utf-8')
+    fs.readFileSync(path.join(filesDir, `postcss.config.cjs`), 'utf-8'),
   );
 }
 
 function addTailwindConfig(write, filesDir) {
   write(
     'tailwind.config.ts',
-    fs.readFileSync(path.join(filesDir, `tailwind.config.ts`), 'utf-8')
+    fs.readFileSync(path.join(filesDir, `tailwind.config.ts`), 'utf-8'),
   );
 }
 
@@ -389,7 +389,7 @@ function addTailwindDevDependencies(pkg) {
     (packageName) => {
       const [name, version] = packageName.split('@');
       pkg.devDependencies[name] = version;
-    }
+    },
   );
 }
 
@@ -472,7 +472,7 @@ function setComponentFormat(root, filesDir, write, template, useAnalogSFC) {
   if (useAnalogSFC) {
     write(
       'src/analog-env.d.ts',
-      fs.readFileSync(path.join(filesDir, 'analog-env.d.ts'), 'utf-8')
+      fs.readFileSync(path.join(filesDir, 'analog-env.d.ts'), 'utf-8'),
     );
   }
 }
@@ -484,7 +484,7 @@ function replacePlaceholders(root, files, config) {
     const newFileContent = Object.keys(config).reduce(
       (content, placeholder) =>
         content.replace(RegExp(placeholder, 'g'), config[placeholder]),
-      fileContent
+      fileContent,
     );
     fs.writeFileSync(filePath, newFileContent);
   }

--- a/packages/nx-plugin/src/generators/app/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/app/generator.spec.ts
@@ -15,10 +15,10 @@ describe('nx-plugin generator', () => {
   const setup = async (
     options: AnalogNxApplicationGeneratorOptions,
     nxVersion = '20.0.0',
-    standalone = false
+    standalone = false,
   ) => {
     const tree = createTreeWithEmptyWorkspace(
-      standalone ? {} : { layout: 'apps-libs' }
+      standalone ? {} : { layout: 'apps-libs' },
     );
     console.log('nx', nxVersion);
     addDependenciesToPackageJson(tree, {}, { nx: nxVersion });
@@ -32,12 +32,12 @@ describe('nx-plugin generator', () => {
 
   const verifyCoreDependenciesNxV16_0_0_AngularV15_X = (
     dependencies: Record<string, string>,
-    devDependencies: Record<string, string>
+    devDependencies: Record<string, string>,
   ) => {
     expect(dependencies['@analogjs/content']).toBe('0.1.9');
     expect(dependencies['@analogjs/router']).toBe('0.1.0-alpha.10');
     expect(dependencies['@angular/platform-server']).toBe(
-      dependencies['@angular/core']
+      dependencies['@angular/core'],
     );
     expect(dependencies['front-matter']).toBe('^4.0.2');
     expect(dependencies['marked']).toBe('^4.2.4');
@@ -51,7 +51,7 @@ describe('nx-plugin generator', () => {
     expect(devDependencies['@nx/eslint']).toBeTruthy();
     expect(devDependencies['@analogjs/platform']).toBe('0.1.0-beta.22');
     expect(devDependencies['@analogjs/vite-plugin-angular']).toBe(
-      '0.2.0-alpha.29'
+      '0.2.0-alpha.29',
     );
     expect(devDependencies['@nx/vite']).toBe('~16.0.0');
     expect(devDependencies['jsdom']).toBe('^20.0.0');
@@ -62,12 +62,12 @@ describe('nx-plugin generator', () => {
 
   const verifyCoreDependenciesAngularV16_X = (
     dependencies: Record<string, string>,
-    devDependencies: Record<string, string>
+    devDependencies: Record<string, string>,
   ) => {
     expect(dependencies['@analogjs/content']).toBe('^0.2.0');
     expect(dependencies['@analogjs/router']).toBe('^0.2.0');
     expect(dependencies['@angular/platform-server']).toBe(
-      dependencies['@angular/core']
+      dependencies['@angular/core'],
     );
     expect(dependencies['front-matter']).toBe('^4.0.2');
     expect(dependencies['marked']).toBe('^5.0.2');
@@ -92,12 +92,12 @@ describe('nx-plugin generator', () => {
 
   const verifyCoreDependenciesNxV17_AngularV16_X = (
     dependencies: Record<string, string>,
-    devDependencies: Record<string, string>
+    devDependencies: Record<string, string>,
   ) => {
     expect(dependencies['@analogjs/content']).toBe('^1.2.0');
     expect(dependencies['@analogjs/router']).toBe('^1.2.0');
     expect(dependencies['@angular/platform-server']).toBe(
-      dependencies['@angular/core']
+      dependencies['@angular/core'],
     );
     expect(dependencies['front-matter']).toBe('^4.0.2');
     expect(dependencies['marked']).toBe('^5.0.2');
@@ -122,12 +122,12 @@ describe('nx-plugin generator', () => {
 
   const verifyCoreDependenciesNxV18_AngularV17_X = (
     dependencies: Record<string, string>,
-    devDependencies: Record<string, string>
+    devDependencies: Record<string, string>,
   ) => {
     expect(dependencies['@analogjs/content']).toBeDefined();
     expect(dependencies['@analogjs/router']).toBeDefined();
     expect(dependencies['@angular/platform-server']).toBe(
-      dependencies['@angular/core']
+      dependencies['@angular/core'],
     );
     expect(dependencies['front-matter']).toBe('^4.0.2');
     expect(dependencies['marked']).toBe('^5.0.2');
@@ -155,7 +155,7 @@ describe('nx-plugin generator', () => {
   const verifyConfig = (
     config: ProjectConfiguration,
     name: string,
-    standalone = false
+    standalone = false,
   ) => {
     expect(config.projectType).toBe('application');
     expect(config.root).toBe(standalone ? name : 'apps/' + name);
@@ -181,15 +181,15 @@ describe('nx-plugin generator', () => {
   const verifyHomePageExists = (
     tree: Tree,
     appName: string,
-    standalone = false
+    standalone = false,
   ) => {
     const hasHomePageFile = tree.exists(
-      `${standalone ? '' : 'apps/'}${appName}/src/app/pages/(home).page.ts`
+      `${standalone ? '' : 'apps/'}${appName}/src/app/pages/(home).page.ts`,
     );
     const hasWelcomeComponentFile = tree.exists(
       `${
         standalone ? '' : 'apps/'
-      }${appName}/src/app/pages/analog-welcome.component.ts`
+      }${appName}/src/app/pages/analog-welcome.component.ts`,
     );
     expect(hasHomePageFile).toBeTruthy();
     expect(hasWelcomeComponentFile).toBeTruthy();
@@ -198,21 +198,21 @@ describe('nx-plugin generator', () => {
   const verifyEslint = (
     tree: Tree,
     config: ProjectConfiguration,
-    devDependencies: Record<string, string>
+    devDependencies: Record<string, string>,
   ) => {
     expect(devDependencies['@nx/eslint']).toBeDefined();
   };
 
   const verifyTailwindIsSetUp = (
     tree: Tree,
-    devDependencies: Record<string, string>
+    devDependencies: Record<string, string>,
   ) => {
     expect(devDependencies['tailwindcss']).toBeDefined();
     const hasTailwindConfigFile = tree.exists(
-      'apps/tailwind-app/tailwind.config.ts'
+      'apps/tailwind-app/tailwind.config.ts',
     );
     const hasPostCSSConfigFile = tree.exists(
-      'apps/tailwind-app/postcss.config.cjs'
+      'apps/tailwind-app/postcss.config.cjs',
     );
     expect(hasTailwindConfigFile).toBeTruthy();
     expect(hasPostCSSConfigFile).toBeTruthy();
@@ -220,13 +220,13 @@ describe('nx-plugin generator', () => {
 
   const verifyTrpcIsSetUp = (
     tree: Tree,
-    dependencies: Record<string, string>
+    dependencies: Record<string, string>,
   ) => {
     expect(dependencies['@analogjs/trpc']).toBeDefined();
     const hasTrpcClientFile = tree.exists('apps/trpc-app/src/trpc-client.ts');
     const hasNoteFile = tree.exists('apps/trpc-app/src/note.ts');
     const hasTrpcServerRoute = tree.exists(
-      'apps/trpc-app/src/server/routes/trpc/[trpc].ts'
+      'apps/trpc-app/src/server/routes/trpc/[trpc].ts',
     );
     expect(hasTrpcClientFile).toBeTruthy();
     expect(hasNoteFile).toBeTruthy();
@@ -244,13 +244,13 @@ describe('nx-plugin generator', () => {
 
   const verifyTrpcIsNotSetUp = (
     tree: Tree,
-    dependencies: Record<string, string>
+    dependencies: Record<string, string>,
   ) => {
     expect(dependencies['@analogjs/trpc']).not.toBeDefined();
     const hasTrpcClientFile = tree.exists('apps/trpc-app/src/trpc-client.ts');
     const hasNoteFile = tree.exists('apps/trpc-app/src/note.ts');
     const hasTrpcServerRoute = tree.exists(
-      'apps/trpc-app/src/server/routes/trpc/[trpc].ts'
+      'apps/trpc-app/src/server/routes/trpc/[trpc].ts',
     );
     expect(hasTrpcClientFile).toBeFalsy();
     expect(hasNoteFile).toBeFalsy();
@@ -362,7 +362,7 @@ describe('nx-plugin generator', () => {
           analogAppName,
           addTailwind: true,
         },
-        '17.0.0'
+        '17.0.0',
       );
       const { dependencies, devDependencies } = readJson(tree, 'package.json');
 
@@ -379,7 +379,7 @@ describe('nx-plugin generator', () => {
       const analogAppName = 'trpc-app';
       const { config, tree } = await setup(
         { analogAppName, addTRPC: true },
-        '17.0.0'
+        '17.0.0',
       );
       const { dependencies, devDependencies } = readJson(tree, 'package.json');
 
@@ -428,7 +428,7 @@ describe('nx-plugin generator', () => {
           analogAppName,
           addTailwind: true,
         },
-        '16.10.0'
+        '16.10.0',
       );
       const { dependencies, devDependencies } = readJson(tree, 'package.json');
 
@@ -445,7 +445,7 @@ describe('nx-plugin generator', () => {
       const analogAppName = 'trpc-app';
       const { config, tree } = await setup(
         { analogAppName, addTRPC: true },
-        '16.10.0'
+        '16.10.0',
       );
       const { dependencies, devDependencies } = readJson(tree, 'package.json');
 
@@ -466,7 +466,7 @@ describe('nx-plugin generator', () => {
 
       verifyCoreDependenciesNxV16_0_0_AngularV15_X(
         dependencies,
-        devDependencies
+        devDependencies,
       );
 
       verifyConfig(config, analogAppName);
@@ -483,13 +483,13 @@ describe('nx-plugin generator', () => {
           analogAppName,
           addTailwind: true,
         },
-        '16.0.0'
+        '16.0.0',
       );
       const { dependencies, devDependencies } = readJson(tree, 'package.json');
 
       verifyCoreDependenciesNxV16_0_0_AngularV15_X(
         dependencies,
-        devDependencies
+        devDependencies,
       );
 
       verifyConfig(config, analogAppName);
@@ -503,13 +503,13 @@ describe('nx-plugin generator', () => {
       const analogAppName = 'trpc-app';
       const { config, tree } = await setup(
         { analogAppName, addTRPC: true },
-        '16.0.0'
+        '16.0.0',
       );
       const { dependencies, devDependencies } = readJson(tree, 'package.json');
 
       verifyCoreDependenciesNxV16_0_0_AngularV15_X(
         dependencies,
-        devDependencies
+        devDependencies,
       );
 
       verifyConfig(config, analogAppName);
@@ -523,7 +523,7 @@ describe('nx-plugin generator', () => {
     test('should error out due to unsupported Nx version', async () => {
       const analogAppName = 'analog';
       await expect(setup({ analogAppName }, '15.1.0')).rejects.toThrow(
-        'Nx v15.2.0 or newer is required to install Analog'
+        'Nx v15.2.0 or newer is required to install Analog',
       );
     });
   });

--- a/packages/nx-plugin/src/generators/app/generator.ts
+++ b/packages/nx-plugin/src/generators/app/generator.ts
@@ -37,7 +37,7 @@ export interface NormalizedOptions
 function normalizeOptions(
   tree: Tree,
   options: AnalogNxApplicationGeneratorOptions,
-  nxVersion: string
+  nxVersion: string,
 ): NormalizedOptions {
   const isNx = tree.exists('/nx.json');
   const appsDir = isNx ? getWorkspaceLayout(tree).appsDir : 'projects';
@@ -70,7 +70,7 @@ function normalizeOptions(
 
 export async function appGenerator(
   tree: Tree,
-  options: AnalogNxApplicationGeneratorOptions
+  options: AnalogNxApplicationGeneratorOptions,
 ) {
   const nxVersion = getInstalledPackageVersion(tree, 'nx');
 
@@ -80,13 +80,13 @@ export async function appGenerator(
 
   if (belowMinimumSupportedNxVersion(nxVersion)) {
     throw new Error(
-      stripIndents`Nx v15.2.0 or newer is required to install Analog`
+      stripIndents`Nx v15.2.0 or newer is required to install Analog`,
     );
   }
 
   if (belowMinimumSupportedNxtRPCVersion(nxVersion) && options.addTRPC) {
     console.warn(
-      'Nx v16.1.0 or newer is required to use tRPC with Analog. Skipping installation.'
+      'Nx v16.1.0 or newer is required to use tRPC with Analog. Skipping installation.',
     );
     options.addTRPC = false;
   }
@@ -95,7 +95,7 @@ export async function appGenerator(
   const angularVersion = await initializeAngularWorkspace(
     tree,
     nxVersion,
-    normalizedOptions
+    normalizedOptions,
   );
   const majorAngularVersion = major(coerce(angularVersion));
 
@@ -116,7 +116,7 @@ export async function appGenerator(
     parsedTags,
     name,
     appsDir,
-    nxPackageNamespace
+    nxPackageNamespace,
   );
 
   addFiles(tree, normalizedOptions, majorAngularVersion);

--- a/packages/nx-plugin/src/generators/app/lib/add-analog-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-analog-dependencies.ts
@@ -9,7 +9,7 @@ import { getAnalogDevDependencies } from '../versions/dev-dependencies';
 export async function addAnalogDependencies(
   tree: Tree,
   nxVersion: string,
-  angularVersion: string
+  angularVersion: string,
 ) {
   const dependencies = getAnalogDependencies(nxVersion, angularVersion);
   const devDependencies = getAnalogDevDependencies(nxVersion);
@@ -18,7 +18,7 @@ export async function addAnalogDependencies(
   removeDependenciesFromPackageJson(
     tree,
     ['@analogjs/platform'],
-    ['@analogjs/platform']
+    ['@analogjs/platform'],
   );
   addDependenciesToPackageJson(tree, dependencies, devDependencies);
 }

--- a/packages/nx-plugin/src/generators/app/lib/add-analog-project-config.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-analog-project-config.ts
@@ -8,7 +8,7 @@ export function addAnalogProjectConfig(
   parsedTags: string[],
   name: string,
   appsDir: string,
-  nxPackageNamespace: string
+  nxPackageNamespace: string,
 ) {
   const isStandalone = appsDir === '.';
   const isNx = tree.exists('/nx.json');

--- a/packages/nx-plugin/src/generators/app/lib/add-eslint.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-eslint.ts
@@ -4,7 +4,7 @@ import { NormalizedOptions } from '../generator';
 export async function addEslint(
   tree: Tree,
   majorNxVersion: number,
-  options: NormalizedOptions
+  options: NormalizedOptions,
 ): Promise<void> {
   const linterOptions = {
     // needed to not depend on linter package

--- a/packages/nx-plugin/src/generators/app/lib/add-files.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-files.ts
@@ -5,7 +5,7 @@ import { NormalizedOptions } from '../generator';
 export function addFiles(
   tree: Tree,
   options: NormalizedOptions,
-  majorAngularVersion: number
+  majorAngularVersion: number,
 ) {
   const isNx = tree.exists('/nx.json');
   const templateOptions = {
@@ -18,7 +18,7 @@ export function addFiles(
     tree,
     join(__dirname, '..', 'files', 'template-angular-v' + majorAngularVersion),
     options.projectRoot,
-    templateOptions
+    templateOptions,
   );
 
   if (!tree.exists('/angular.json') && !tree.exists('/tsconfig.base.json')) {
@@ -26,7 +26,7 @@ export function addFiles(
       tree,
       join(__dirname, '..', 'files', 'root'),
       '.',
-      templateOptions
+      templateOptions,
     );
   }
 }

--- a/packages/nx-plugin/src/generators/app/lib/add-home-page.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-home-page.ts
@@ -5,7 +5,7 @@ import { NormalizedOptions } from '../generator';
 export function addHomePage(
   tree: Tree,
   options: NormalizedOptions,
-  majorAngularVersion: number
+  majorAngularVersion: number,
 ) {
   const templateOptions = {
     ...options,
@@ -17,7 +17,7 @@ export function addHomePage(
     tree,
     join(__dirname, '..', 'files', 'index-page'),
     options.projectRoot,
-    templateOptions
+    templateOptions,
   );
 
   let pageDirectory = options.addTailwind ? 'tailwind' : 'css';
@@ -29,6 +29,6 @@ export function addHomePage(
     tree,
     join(__dirname, '..', 'files', 'welcome-components', pageDirectory),
     options.projectRoot,
-    templateOptions
+    templateOptions,
   );
 }

--- a/packages/nx-plugin/src/generators/app/lib/add-tailwind-config.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-tailwind-config.ts
@@ -33,7 +33,7 @@ export interface NormalizedGeneratorOptions extends GeneratorOptions {
 
 export async function setupTailwindGenerator(
   tree: Tree,
-  rawOptions: GeneratorOptions
+  rawOptions: GeneratorOptions,
 ): Promise<GeneratorCallback> {
   const options = normalizeOptions(rawOptions);
   const project = readProjectConfiguration(tree, options.project);

--- a/packages/nx-plugin/src/generators/app/lib/add-tailwind-helpers.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-tailwind-helpers.ts
@@ -19,7 +19,7 @@ import {
 import { relative } from 'node:path';
 
 export function normalizeOptions(
-  options: GeneratorOptions
+  options: GeneratorOptions,
 ): NormalizedGeneratorOptions {
   return {
     ...options,
@@ -28,7 +28,7 @@ export function normalizeOptions(
 }
 
 export function detectTailwindInstalledVersion(
-  tree: Tree
+  tree: Tree,
 ): '2' | '3' | undefined {
   const { dependencies, devDependencies } = readJson(tree, 'package.json');
   const tailwindVersion =
@@ -41,7 +41,7 @@ export function detectTailwindInstalledVersion(
   const version = checkAndCleanWithSemver('tailwindcss', tailwindVersion);
   if (lt(version, '2.0.0')) {
     throw new Error(
-      `The Tailwind CSS version "${tailwindVersion}" is not supported. Please upgrade to v2.0.0 or higher.`
+      `The Tailwind CSS version "${tailwindVersion}" is not supported. Please upgrade to v2.0.0 or higher.`,
     );
   }
 
@@ -57,20 +57,20 @@ export function addTailwindRequiredPackages(tree: Tree): GeneratorCallback {
       autoprefixer: pkgVersions.autoprefixer,
       postcss: pkgVersions.postcss,
       tailwindcss: pkgVersions.tailwindcss,
-    }
+    },
   );
 }
 
 export function updateApplicationStyles(
   tree: Tree,
   options: NormalizedGeneratorOptions,
-  project: ProjectConfiguration
+  project: ProjectConfiguration,
 ): void {
   let stylesEntryPoint = options.stylesEntryPoint;
 
   if (stylesEntryPoint && !tree.exists(stylesEntryPoint)) {
     throw new Error(
-      `The provided styles entry point "${stylesEntryPoint}" could not be found.`
+      `The provided styles entry point "${stylesEntryPoint}" could not be found.`,
     );
   }
 
@@ -80,7 +80,7 @@ export function updateApplicationStyles(
     if (!stylesEntryPoint) {
       throw new Error(
         stripIndents`Could not find a styles entry point for project "${options.project}".
-        Please specify a styles entry point using the "--stylesEntryPoint" option.`
+        Please specify a styles entry point using the "--stylesEntryPoint" option.`,
       );
     }
   }
@@ -92,14 +92,14 @@ export function updateApplicationStyles(
     @tailwind components;
     @tailwind utilities;
 
-    ${stylesEntryPointContent}`
+    ${stylesEntryPointContent}`,
   );
 }
 
 function findStylesEntryPoint(
   tree: Tree,
   options: NormalizedGeneratorOptions,
-  project: ProjectConfiguration
+  project: ProjectConfiguration,
 ): string | undefined {
   // first check for common names
   const possibleStylesEntryPoints = [
@@ -110,7 +110,7 @@ function findStylesEntryPoint(
   ];
 
   const stylesEntryPoint = possibleStylesEntryPoints.find((s) =>
-    tree.exists(s)
+    tree.exists(s),
   );
   if (stylesEntryPoint) {
     return stylesEntryPoint;
@@ -130,7 +130,7 @@ function findStylesEntryPoint(
       ? s.startsWith(project.root) && tree.exists(s)
       : s.input.startsWith(project.root) &&
         s.inject !== false &&
-        tree.exists(s.input)
+        tree.exists(s.input),
   );
 
   if (!style) {
@@ -143,7 +143,7 @@ function findStylesEntryPoint(
 export function addTailwindConfigPathToProject(
   tree: Tree,
   options: NormalizedGeneratorOptions,
-  project: ProjectConfiguration
+  project: ProjectConfiguration,
 ): void {
   const buildTarget = project.targets?.[options.buildTarget];
 
@@ -151,7 +151,7 @@ export function addTailwindConfigPathToProject(
     throw new Error(
       stripIndents`The target "${options.buildTarget}" was not found for project "${options.project}".
       If you are using a different build target, please provide it using the "--buildTarget" option.
-      If the project is not a buildable or publishable library, you don't need to setup TailwindCSS for it.`
+      If the project is not a buildable or publishable library, you don't need to setup TailwindCSS for it.`,
     );
   }
 
@@ -161,7 +161,7 @@ export function addTailwindConfigPathToProject(
   ) {
     throw new Error(
       stripIndents`The "${buildTarget.options.tailwindConfig}" file is already configured for the project "${options.project}". Are you sure this is the right project to set up Tailwind?
-      If you are sure, you can remove the configuration and re-run the generator.`
+      If you are sure, you can remove the configuration and re-run the generator.`,
     );
   }
 
@@ -185,12 +185,12 @@ export function addTailwindConfigPathToProject(
 export function addTailwindConfigFile(
   tree: Tree,
   options: GeneratorOptions,
-  project: ProjectConfiguration
+  project: ProjectConfiguration,
 ): void {
   if (tree.exists(joinPathFragments(project.root, 'tailwind.config.js'))) {
     throw new Error(
       stripIndents`The "tailwind.config" file already exists in the project "${options.project}". Are you sure this is the right project to set up Tailwind?
-      If you are sure, you can remove the existing file and re-run the generator.`
+      If you are sure, you can remove the existing file and re-run the generator.`,
     );
   }
 
@@ -204,7 +204,7 @@ export function addTailwindConfigFile(
       {
         relativeSourceRoot: relative(project.root, project.sourceRoot),
         template: '',
-      }
+      },
     );
     return;
   }
@@ -216,6 +216,6 @@ export function addTailwindConfigFile(
     {
       relativeSourceRoot: relative(project.root, project.sourceRoot),
       template: '',
-    }
+    },
   );
 }

--- a/packages/nx-plugin/src/generators/app/lib/add-trpc.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-trpc.ts
@@ -7,7 +7,7 @@ export async function addTrpc(
   tree: Tree,
   projectRoot: string,
   nxVersion: string,
-  options: NormalizedOptions
+  options: NormalizedOptions,
 ) {
   const dependencies = getTrpcDependencies(nxVersion);
   addDependenciesToPackageJson(tree, dependencies, {});
@@ -20,6 +20,6 @@ export async function addTrpc(
     tree,
     join(__dirname, '..', 'files', 'trpc'),
     projectRoot,
-    templateOptions
+    templateOptions,
   );
 }

--- a/packages/nx-plugin/src/generators/app/lib/initialize-analog-workspace.ts
+++ b/packages/nx-plugin/src/generators/app/lib/initialize-analog-workspace.ts
@@ -16,33 +16,33 @@ import {
 export async function initializeAngularWorkspace(
   tree: Tree,
   installedNxVersion: string,
-  normalizedOptions: NormalizedOptions
+  normalizedOptions: NormalizedOptions,
 ) {
   let angularVersion = getInstalledPackageVersion(tree, '@angular/core');
 
   if (!angularVersion) {
     console.log(
-      'Angular has not been installed yet. Creating an Angular application'
+      'Angular has not been installed yet. Creating an Angular application',
     );
 
     if (major(installedNxVersion) >= 16) {
       angularVersion = await initWithNxNamespace(
         tree,
         installedNxVersion,
-        normalizedOptions.skipFormat
+        normalizedOptions.skipFormat,
       );
     } else {
       angularVersion = await initWithNrwlNamespace(
         tree,
         installedNxVersion,
-        normalizedOptions.skipFormat
+        normalizedOptions.skipFormat,
       );
     }
   }
 
   if (belowMinimumSupportedAngularVersion(angularVersion)) {
     throw new Error(
-      stripIndents`Analog only supports an Angular version of 15 and higher`
+      stripIndents`Analog only supports an Angular version of 15 and higher`,
     );
   }
 
@@ -52,7 +52,7 @@ export async function initializeAngularWorkspace(
 const initWithNxNamespace = async (
   tree: Tree,
   installedNxVersion: string,
-  skipFormat = true
+  skipFormat = true,
 ) => {
   const versions = getNxDependencies(installedNxVersion);
 
@@ -79,7 +79,7 @@ const initWithNxNamespace = async (
       '@nx/devkit': versions['@nx/devkit'],
       '@nx/eslint': versions['@nx/eslint'],
       typescript: '~5.5.0',
-    }
+    },
   );
 
   return getInstalledPackageVersion(tree, '@angular/core', null, true);
@@ -88,7 +88,7 @@ const initWithNxNamespace = async (
 const initWithNrwlNamespace = async (
   tree: Tree,
   installedNxVersion: string,
-  skipFormat = true
+  skipFormat = true,
 ) => {
   const versions = getNrwlDependencies(installedNxVersion);
   try {
@@ -105,7 +105,7 @@ const initWithNrwlNamespace = async (
       '@nrwl/devkit': versions['@nrwl/devkit'],
       '@nrwl/angular': versions['@nrwl/angular'],
       '@nrwl/linter': versions['@nrwl/linter'],
-    }
+    },
   );
   await (
     await import(

--- a/packages/nx-plugin/src/generators/app/versions/dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/dependencies.ts
@@ -70,14 +70,14 @@ export type ExtendedDependenciesRecord = AnalogDependency15Record &
 
 export const getAnalogDependencies = (
   nxVersion: string,
-  angularVersion: string
+  angularVersion: string,
 ): ExtendedDependenciesRecord => {
   const escapedNxVersion = nxVersion.replace(/[~^]/, '');
 
   // fail out for versions <15.2.0
   if (lt(escapedNxVersion, '15.2.0')) {
     throw new Error(
-      stripIndents`Nx v15.2.0 or newer is required to install Analog`
+      stripIndents`Nx v15.2.0 or newer is required to install Analog`,
     );
   }
 

--- a/packages/nx-plugin/src/generators/app/versions/dev-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/dev-dependencies.ts
@@ -56,7 +56,7 @@ const devDependencyKeys = [
 export type AnalogDevDependency = (typeof devDependencyKeys)[number];
 
 export const getAnalogDevDependencies = (
-  nxVersion: string
+  nxVersion: string,
 ): Record<AnalogDevDependency, string> => {
   const escapedNxVersion = nxVersion.replace(/[~^]/, '');
 
@@ -70,7 +70,7 @@ const getViteDependency = (escapedNxVersion: string) => {
   // fail out for versions <15.2.0
   if (lt(escapedNxVersion, '15.2.0')) {
     throw new Error(
-      stripIndents`Nx v15.2.0 or newer is required to install Analog`
+      stripIndents`Nx v15.2.0 or newer is required to install Analog`,
     );
   }
   // install 15.8 deps for versions 15.8.0 =< 16.0.0
@@ -111,7 +111,7 @@ const getDevDependencies = (escapedNxVersion: string) => {
   // fail out for versions <15.2.0
   if (lt(escapedNxVersion, '15.2.0')) {
     throw new Error(
-      stripIndents`Nx v15.2.0 or newer is required to install Analog`
+      stripIndents`Nx v15.2.0 or newer is required to install Analog`,
     );
   }
 

--- a/packages/nx-plugin/src/generators/app/versions/nx-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/nx-dependencies.ts
@@ -31,14 +31,14 @@ const nrwlDependencyKeys = [
 ] as const;
 export type NrwlDependency = (typeof nrwlDependencyKeys)[number];
 export const getNrwlDependencies = (
-  nxVersion: string
+  nxVersion: string,
 ): Record<NrwlDependency, string> => {
   const escapedNxVersion = clean(nxVersion);
 
   // fail out for versions <15.2.0
   if (lt(escapedNxVersion, '15.2.0')) {
     throw new Error(
-      stripIndents`Nx v15.2.0 or newer is required to install Analog`
+      stripIndents`Nx v15.2.0 or newer is required to install Analog`,
     );
   }
 
@@ -53,21 +53,21 @@ export const getNrwlDependencies = (
 
   // error for @nrwl to @nx namespace change for Nx >= 16
   throw new Error(
-    stripIndents`As of Nx 16.0.0 the @nrwl scope has been replaced with the @nx scope. Please use @nx scope to install version ${nxVersion}`
+    stripIndents`As of Nx 16.0.0 the @nrwl scope has been replaced with the @nx scope. Please use @nx scope to install version ${nxVersion}`,
   );
 };
 
 const nxDependencyKeys = ['@nx/devkit', '@nx/angular', '@nx/eslint'] as const;
 export type NxDependency = (typeof nxDependencyKeys)[number];
 export const getNxDependencies = (
-  nxVersion: string
+  nxVersion: string,
 ): Record<NxDependency, string> => {
   const escapedNxVersion = clean(nxVersion);
 
   // error for @nrwl to @nx namespace changes for Nx < 16
   if (lt(escapedNxVersion, '16.0.0')) {
     throw new Error(
-      stripIndents`The @nx scope is only supported in Nx 16.0.0 and newer. Please use @nrwl scope to install version ${nxVersion}`
+      stripIndents`The @nx scope is only supported in Nx 16.0.0 and newer. Please use @nrwl scope to install version ${nxVersion}`,
     );
   }
 

--- a/packages/nx-plugin/src/generators/app/versions/trpc-dependencies.ts
+++ b/packages/nx-plugin/src/generators/app/versions/trpc-dependencies.ts
@@ -44,14 +44,14 @@ const tRPCDependencyKeys = [
 export type TrpcDependency = (typeof tRPCDependencyKeys)[number];
 
 export const getTrpcDependencies = (
-  nxVersion: string
+  nxVersion: string,
 ): Record<TrpcDependency, string> => {
   const escapedNxVersion = clean(nxVersion);
 
   // fail out for versions <15.2.0
   if (lt(escapedNxVersion, '15.2.0')) {
     throw new Error(
-      stripIndents`Nx v15.2.0 or newer is required to install Analog`
+      stripIndents`Nx v15.2.0 or newer is required to install Analog`,
     );
   }
 

--- a/packages/nx-plugin/src/generators/init/generator.ts
+++ b/packages/nx-plugin/src/generators/init/generator.ts
@@ -37,7 +37,7 @@ function addFiles(tree: Tree, options: SetupAnalogGeneratorSchema) {
     tree,
     join(__dirname, 'files'),
     projectConfig.root || '.',
-    templateOptions
+    templateOptions,
   );
 
   if (options.vitest) {
@@ -45,14 +45,14 @@ function addFiles(tree: Tree, options: SetupAnalogGeneratorSchema) {
       tree,
       join(__dirname, 'test-files'),
       projectConfig.root || '.',
-      templateOptions
+      templateOptions,
     );
   }
 }
 
 export async function setupAnalogGenerator(
   tree: Tree,
-  options: SetupAnalogGeneratorSchema
+  options: SetupAnalogGeneratorSchema,
 ) {
   const angularVersion = getInstalledPackageVersion(tree, '@angular/core');
 

--- a/packages/nx-plugin/src/generators/init/lib/update-app-tsconfig.ts
+++ b/packages/nx-plugin/src/generators/init/lib/update-app-tsconfig.ts
@@ -8,7 +8,7 @@ interface TsConfig {
 
 export function updateAppTsConfig(
   tree: Tree,
-  schema: SetupAnalogGeneratorSchema
+  schema: SetupAnalogGeneratorSchema,
 ) {
   const projects = getProjects(tree);
 
@@ -16,7 +16,7 @@ export function updateAppTsConfig(
 
   const tsconfigPath = joinPathFragments(
     projectConfig.root,
-    'tsconfig.app.json'
+    'tsconfig.app.json',
   );
 
   if (tree.exists(tsconfigPath)) {
@@ -28,7 +28,7 @@ export function updateAppTsConfig(
 
         return json;
       },
-      { expectComments: true, allowTrailingComma: true }
+      { expectComments: true, allowTrailingComma: true },
     );
   }
 }

--- a/packages/nx-plugin/src/generators/init/lib/update-build-target.ts
+++ b/packages/nx-plugin/src/generators/init/lib/update-build-target.ts
@@ -10,7 +10,7 @@ import { SetupAnalogGeneratorSchema } from '../schema';
 
 export function updateBuildTarget(
   tree: Tree,
-  schema: SetupAnalogGeneratorSchema
+  schema: SetupAnalogGeneratorSchema,
 ) {
   const angularJsonPath = '/angular.json';
 
@@ -54,13 +54,13 @@ export function updateBuildTarget(
       options: {
         configFile: `${joinPathFragments(
           projectConfig.root,
-          'vite.config.ts'
+          'vite.config.ts',
         )}`,
         main: `${joinPathFragments(projectConfig.root, 'src/main.ts')}`,
         outputPath: `dist/${joinPathFragments(projectConfig.root, 'client')}`,
         tsConfig: `${joinPathFragments(
           projectConfig.root,
-          'tsconfig.app.json'
+          'tsconfig.app.json',
         )}`,
       },
     };

--- a/packages/nx-plugin/src/generators/init/lib/update-index-html.ts
+++ b/packages/nx-plugin/src/generators/init/lib/update-index-html.ts
@@ -13,7 +13,7 @@ export function updateIndex(tree: Tree, schema: SetupAnalogGeneratorSchema) {
     const indexContents = tree.read(indexPath, 'utf-8');
     let updatedIndex = indexContents.replace(
       '</body>',
-      '<script type="module" src="/src/main.ts"></script></body>'
+      '<script type="module" src="/src/main.ts"></script></body>',
     );
     updatedIndex = updatedIndex.replace(`"favicon.ico"`, `"/favicon.ico"`);
     tree.write(indexPath, updatedIndex);

--- a/packages/nx-plugin/src/generators/init/lib/update-package-json.ts
+++ b/packages/nx-plugin/src/generators/init/lib/update-package-json.ts
@@ -10,7 +10,7 @@ import { SetupAnalogGeneratorSchema } from '../schema';
 
 export function updatePackageJson(
   tree: Tree,
-  schema: SetupAnalogGeneratorSchema
+  schema: SetupAnalogGeneratorSchema,
 ) {
   const angularJsonPath = '/angular.json';
   const packageJsonPath = '/package.json';
@@ -27,7 +27,7 @@ export function updatePackageJson(
 
     const packageJsonPath = joinPathFragments(
       projectConfig.root,
-      'package.json'
+      'package.json',
     );
 
     writeJson(tree, packageJsonPath, { type: 'module' });

--- a/packages/nx-plugin/src/generators/init/lib/update-serve-target.ts
+++ b/packages/nx-plugin/src/generators/init/lib/update-serve-target.ts
@@ -9,7 +9,7 @@ import { SetupAnalogGeneratorSchema } from '../schema';
 
 export function updateServeTarget(
   tree: Tree,
-  schema: SetupAnalogGeneratorSchema
+  schema: SetupAnalogGeneratorSchema,
 ) {
   const angularJsonPath = '/angular.json';
 
@@ -43,7 +43,7 @@ export function updateServeTarget(
 
         return json;
       },
-      { expectComments: true, allowTrailingComma: true }
+      { expectComments: true, allowTrailingComma: true },
     );
   } else {
     const projects = getProjects(tree);

--- a/packages/nx-plugin/src/generators/init/lib/update-test-target.ts
+++ b/packages/nx-plugin/src/generators/init/lib/update-test-target.ts
@@ -9,7 +9,7 @@ import { SetupAnalogGeneratorSchema } from '../schema';
 
 export function updateTestTarget(
   tree: Tree,
-  schema: SetupAnalogGeneratorSchema
+  schema: SetupAnalogGeneratorSchema,
 ) {
   const angularJsonPath = '/angular.json';
   const commonConfig = {
@@ -30,7 +30,7 @@ export function updateTestTarget(
 
         return json;
       },
-      { expectComments: true, allowTrailingComma: true }
+      { expectComments: true, allowTrailingComma: true },
     );
   } else {
     const projects = getProjects(tree);

--- a/packages/nx-plugin/src/generators/init/lib/update-test-tsconfig.ts
+++ b/packages/nx-plugin/src/generators/init/lib/update-test-tsconfig.ts
@@ -13,7 +13,7 @@ interface TsConfig {
 
 export function updateTestTsConfig(
   tree: Tree,
-  schema: SetupAnalogGeneratorSchema
+  schema: SetupAnalogGeneratorSchema,
 ) {
   const projects = getProjects(tree);
 
@@ -21,7 +21,7 @@ export function updateTestTsConfig(
 
   const tsconfigPath = joinPathFragments(
     projectConfig.root,
-    'tsconfig.spec.json'
+    'tsconfig.spec.json',
   );
 
   if (tree.exists(tsconfigPath)) {
@@ -37,7 +37,7 @@ export function updateTestTsConfig(
 
         return json;
       },
-      { expectComments: true, allowTrailingComma: true }
+      { expectComments: true, allowTrailingComma: true },
     );
   }
 }

--- a/packages/nx-plugin/src/generators/page/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/page/generator.spec.ts
@@ -40,7 +40,7 @@ describe('analog-page generator', () => {
     await setup(options);
     await analogPageGenerator(tree, options);
     expect(
-      tree.read('apps/test/src/app/pages/home.page.ts', 'utf-8')
+      tree.read('apps/test/src/app/pages/home.page.ts', 'utf-8'),
     ).toMatchSnapshot('page');
   });
 
@@ -54,7 +54,7 @@ describe('analog-page generator', () => {
 
     await setup(options);
     await expect(analogPageGenerator(tree, options)).rejects.toThrow(
-      'A redirectPath is required when redirectPage is true.'
+      'A redirectPath is required when redirectPage is true.',
     );
   });
 
@@ -70,7 +70,7 @@ describe('analog-page generator', () => {
     await setup(options);
     await analogPageGenerator(tree, options);
     expect(
-      tree.read('apps/test/src/app/pages/home.page.ts', 'utf-8')
+      tree.read('apps/test/src/app/pages/home.page.ts', 'utf-8'),
     ).toMatchSnapshot('page');
   });
 
@@ -87,7 +87,7 @@ describe('analog-page generator', () => {
     await setup(options);
     await analogPageGenerator(tree, options);
     expect(
-      tree.read('apps/test/src/app/pages/home.page.ts', 'utf-8')
+      tree.read('apps/test/src/app/pages/home.page.ts', 'utf-8'),
     ).toMatchSnapshot('page');
   });
 
@@ -102,13 +102,13 @@ describe('analog-page generator', () => {
     await setup(options);
     await analogPageGenerator(tree, options);
     expect(
-      tree.read('apps/test/src/app/pages/blog/post.page.ts', 'utf-8')
+      tree.read('apps/test/src/app/pages/blog/post.page.ts', 'utf-8'),
     ).toMatchSnapshot('page');
 
     options.pathname = 'products/[products]';
     await analogPageGenerator(tree, options);
     expect(
-      tree.read('apps/test/src/app/pages/products/[products].page.ts', 'utf-8')
+      tree.read('apps/test/src/app/pages/products/[products].page.ts', 'utf-8'),
     ).toMatchSnapshot('page');
 
     options.pathname = `(customers)/demo/home`;
@@ -116,8 +116,8 @@ describe('analog-page generator', () => {
     expect(
       tree.read(
         'apps/test/src/app/pages/(customers)/demo/home.page.ts',
-        'utf-8'
-      )
+        'utf-8',
+      ),
     ).toMatchSnapshot('page');
 
     options.pathname = 'products/products.[productId]';
@@ -125,14 +125,14 @@ describe('analog-page generator', () => {
     expect(
       tree.read(
         'apps/test/src/app/pages/products/products.[productId].page.ts',
-        'utf-8'
-      )
+        'utf-8',
+      ),
     ).toMatchSnapshot('page');
 
     options.pathname = '(blog)';
     await analogPageGenerator(tree, options);
     expect(
-      tree.read('apps/test/src/app/pages/(blog).page.ts', 'utf-8')
+      tree.read('apps/test/src/app/pages/(blog).page.ts', 'utf-8'),
     ).toMatchSnapshot('page');
   });
 });

--- a/packages/nx-plugin/src/generators/page/generator.ts
+++ b/packages/nx-plugin/src/generators/page/generator.ts
@@ -13,7 +13,7 @@ import { AnalogPageGeneratorSchema, NormalizedSchema } from './schema';
 
 function normalizeOptions(
   tree: Tree,
-  options: AnalogPageGeneratorSchema
+  options: AnalogPageGeneratorSchema,
 ): NormalizedSchema {
   const projectRoot = `${getWorkspaceLayout(tree).appsDir}/${options.project}`;
   return {
@@ -28,7 +28,7 @@ function generateFileName(input: string) {
     return input.replace(/\[[a-zA-Z0-9-]+\]/, (match) => {
       const wordId = match.slice(1, -1);
       const camelCaseWordId = wordId.replace(/-([a-zA-Z0-9])/g, (_, letter) =>
-        letter.toUpperCase()
+        letter.toUpperCase(),
       );
       return `[${camelCaseWordId}]`;
     });
@@ -58,12 +58,12 @@ function addFiles(tree: Tree, options: NormalizedSchema) {
 
 export async function analogPageGenerator(
   tree: Tree,
-  options: AnalogPageGeneratorSchema
+  options: AnalogPageGeneratorSchema,
 ) {
   const normalizedOptions = normalizeOptions(tree, options);
   if (options.redirectPage && !options.redirectPath) {
     throw new Error(
-      stripIndents`A redirectPath is required when redirectPage is true.`
+      stripIndents`A redirectPath is required when redirectPage is true.`,
     );
   }
   addFiles(tree, normalizedOptions);

--- a/packages/nx-plugin/src/generators/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.spec.ts
@@ -10,7 +10,7 @@ import { AnalogNxApplicationGeneratorOptions } from '../app/schema';
 describe('preset generator', () => {
   const setup = async (
     options: AnalogNxApplicationGeneratorOptions,
-    nxVersion = '17.0.0'
+    nxVersion = '17.0.0',
   ) => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     addDependenciesToPackageJson(tree, { nx: nxVersion }, {});

--- a/packages/nx-plugin/src/generators/preset/generator.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.ts
@@ -3,6 +3,6 @@ import { PresetGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: PresetGeneratorSchema) {
   return await import('../app/generator').then(({ appGenerator }) =>
-    appGenerator(tree, options)
+    appGenerator(tree, options),
   );
 }

--- a/packages/nx-plugin/src/generators/setup-vitest/generator.ts
+++ b/packages/nx-plugin/src/generators/setup-vitest/generator.ts
@@ -29,13 +29,13 @@ function addFiles(tree: Tree, options: SetupVitestGeneratorSchema) {
     tree,
     join(__dirname, 'files'),
     projectConfig.root || '.',
-    templateOptions
+    templateOptions,
   );
 }
 
 export async function setupVitestGenerator(
   tree: Tree,
-  options: SetupVitestGeneratorSchema
+  options: SetupVitestGeneratorSchema,
 ) {
   const angularVersion = getInstalledPackageVersion(tree, '@angular/core');
 

--- a/packages/nx-plugin/src/generators/setup-vitest/lib/update-test-target.ts
+++ b/packages/nx-plugin/src/generators/setup-vitest/lib/update-test-target.ts
@@ -9,7 +9,7 @@ import { SetupVitestGeneratorSchema } from '../schema';
 
 export function updateTestTarget(
   tree: Tree,
-  schema: SetupVitestGeneratorSchema
+  schema: SetupVitestGeneratorSchema,
 ) {
   const angularJsonPath = '/angular.json';
 
@@ -24,7 +24,7 @@ export function updateTestTarget(
 
         return json;
       },
-      { expectComments: true, allowTrailingComma: true }
+      { expectComments: true, allowTrailingComma: true },
     );
   } else {
     const projects = getProjects(tree);

--- a/packages/nx-plugin/src/generators/setup-vitest/lib/update-tsconfig.ts
+++ b/packages/nx-plugin/src/generators/setup-vitest/lib/update-tsconfig.ts
@@ -18,7 +18,7 @@ export function updateTsConfig(tree: Tree, schema: SetupVitestGeneratorSchema) {
 
   const tsconfigPath = joinPathFragments(
     projectConfig.root,
-    'tsconfig.spec.json'
+    'tsconfig.spec.json',
   );
 
   if (tree.exists(tsconfigPath)) {
@@ -36,7 +36,7 @@ export function updateTsConfig(tree: Tree, schema: SetupVitestGeneratorSchema) {
 
         return json;
       },
-      { expectComments: true, allowTrailingComma: true }
+      { expectComments: true, allowTrailingComma: true },
     );
   }
 }

--- a/packages/nx-plugin/src/utils/version-utils.ts
+++ b/packages/nx-plugin/src/utils/version-utils.ts
@@ -5,7 +5,7 @@ export function getInstalledPackageVersion(
   tree: Tree,
   packageName: string,
   defaultVersion?: string,
-  raw = false
+  raw = false,
 ): string | null {
   const pkgJson = readJson(tree, 'package.json');
   const installedPackageVersion =

--- a/packages/nx-plugin/src/utils/versions/dependencies.ts
+++ b/packages/nx-plugin/src/utils/versions/dependencies.ts
@@ -63,7 +63,7 @@ const dependencyKeys = [
 export type AnalogDependency = (typeof dependencyKeys)[number];
 
 export const getAnalogDependencies = (
-  ngVersion: string
+  ngVersion: string,
 ): Record<AnalogDependency, string> => {
   const escapedNgVersion = ngVersion.replace(/[~^]/, '');
 

--- a/packages/nx-plugin/src/utils/versions/dev-dependencies.ts
+++ b/packages/nx-plugin/src/utils/versions/dev-dependencies.ts
@@ -59,7 +59,7 @@ const devDependencyKeys = [
 export type AnalogDevDependency = (typeof devDependencyKeys)[number];
 
 export const getAnalogDevDependencies = (
-  ngVersion: string
+  ngVersion: string,
 ): Record<AnalogDevDependency, string> => {
   const escapedNgVersion = ngVersion.replace(/[~^]/, '');
 

--- a/packages/platform/src/lib/content-plugin.ts
+++ b/packages/platform/src/lib/content-plugin.ts
@@ -31,7 +31,7 @@ export function contentPlugin(
     highlighter: 'prism',
     markedOptions: { mangle: true },
   },
-  options?: Options
+  options?: Options,
 ): Plugin[] {
   const cache = new Map<string, Content>();
 
@@ -130,14 +130,14 @@ export function contentPlugin(
         );
         const markedSetupService = new MarkedSetupService(
           markedOptions,
-          markedHighlighter
+          markedHighlighter,
         );
         const mdContent = (await markedSetupService
           .getMarkedInstance()
           .parse(body)) as unknown as string;
 
         return `export default ${JSON.stringify(
-          `---\n${frontmatter}\n---\n\n${mdContent}`
+          `---\n${frontmatter}\n---\n\n${mdContent}`,
         )}`;
       },
     },
@@ -157,17 +157,17 @@ export function contentPlugin(
               `${root}/src/content/**/*.md`,
               `${root}/src/content/**/*.agx`,
               ...(options?.additionalContentDirs || [])?.map(
-                (glob) => `${workspaceRoot}${glob}/**/*.{md,agx}`
+                (glob) => `${workspaceRoot}${glob}/**/*.{md,agx}`,
               ),
             ],
-            { dot: true }
+            { dot: true },
           );
 
           const eagerImports: string[] = [];
 
           contentFilesList.forEach((module, index) => {
             eagerImports.push(
-              `import { default as analog_module_${index} } from "${module}?analog-content-list=true";`
+              `import { default as analog_module_${index} } from "${module}?analog-content-list=true";`,
             );
           });
 
@@ -176,21 +176,21 @@ export function contentPlugin(
             `
             let ANALOG_CONTENT_FILE_LIST = {${contentFilesList.map(
               (module, index) =>
-                `"${module.replace(root, '')}": analog_module_${index}`
+                `"${module.replace(root, '')}": analog_module_${index}`,
             )}};
-          `
+          `,
           );
 
           const agxFiles: string[] = fg.sync(
             [
               `${root}/src/content/**/*.agx`,
               ...(options?.additionalContentDirs || [])?.map(
-                (glob) => `${workspaceRoot}${glob}/**/*.agx`
+                (glob) => `${workspaceRoot}${glob}/**/*.agx`,
               ),
             ],
             {
               dot: true,
-            }
+            },
           );
 
           result = result.replace(
@@ -198,9 +198,9 @@ export function contentPlugin(
             `
           let ANALOG_AGX_FILES = {${agxFiles.map(
             (module) =>
-              `"${module.replace(root, '')}": () => import('${module}')`
+              `"${module.replace(root, '')}": () => import('${module}')`,
           )}};
-          `
+          `,
           );
 
           if (!code.includes('analog_module_')) {

--- a/packages/platform/src/lib/content/marked/marked-setup.service.ts
+++ b/packages/platform/src/lib/content/marked/marked-setup.service.ts
@@ -10,7 +10,7 @@ export class MarkedSetupService {
 
   constructor(
     private readonly options?: WithMarkedOptions,
-    private readonly highlighter?: MarkedContentHighlighter
+    private readonly highlighter?: MarkedContentHighlighter,
   ) {
     const renderer = new marked.Renderer();
     renderer.code = (code: string, lang: string) => {

--- a/packages/platform/src/lib/content/prism/prism-highlighter.ts
+++ b/packages/platform/src/lib/content/prism/prism-highlighter.ts
@@ -69,7 +69,7 @@ export class PrismHighlighter extends MarkedContentHighlighter {
         return Prism.highlight(
           code,
           diff ? Prism.languages['diff'] : Prism.languages[lang],
-          lang
+          lang,
         );
       },
     });

--- a/packages/platform/src/lib/content/shiki/index.ts
+++ b/packages/platform/src/lib/content/shiki/index.ts
@@ -35,6 +35,6 @@ export function getShikiHighlighter({
     highlighter as ShikiHighlighterOptions,
     highlight,
     container,
-    !!highlighter.langs.includes('mermaid')
+    !!highlighter.langs.includes('mermaid'),
   );
 }

--- a/packages/platform/src/lib/content/shiki/shiki-highlighter.ts
+++ b/packages/platform/src/lib/content/shiki/shiki-highlighter.ts
@@ -41,7 +41,7 @@ export class ShikiHighlighter extends MarkedContentHighlighter {
     private highlighterOptions: ShikiHighlighterOptions,
     private highlightOptions: ShikiHighlightOptions,
     private container: string,
-    private hasLoadMermaid = false
+    private hasLoadMermaid = false,
   ) {
     super();
   }
@@ -63,8 +63,8 @@ export class ShikiHighlighter extends MarkedContentHighlighter {
               meta: { __raw: props.join(' ') },
               theme: 'github-dark',
             },
-            this.highlightOptions
-          )
+            this.highlightOptions,
+          ),
         );
       },
     });

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -33,7 +33,7 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
       include: [
         ...(platformOptions.include ?? []),
         ...(platformOptions.additionalPagesDirs ?? []).map(
-          (pageDir) => `${pageDir}/**/*.page.ts`
+          (pageDir) => `${pageDir}/**/*.page.ts`,
         ),
       ],
       additionalContentDirs: platformOptions.additionalContentDirs,

--- a/packages/platform/src/lib/router-plugin.ts
+++ b/packages/platform/src/lib/router-plugin.ts
@@ -68,10 +68,10 @@ export function routerPlugin(options?: Options): Plugin[] {
               `${root}/src/app/pages/**/*.page.analog`,
               `${root}/src/app/pages/**/*.page.ag`,
               ...(options?.additionalPagesDirs || [])?.map(
-                (glob) => `${workspaceRoot}${glob}/**/*.page.{ts,analog,ag}`
+                (glob) => `${workspaceRoot}${glob}/**/*.page.{ts,analog,ag}`,
               ),
             ],
-            { dot: true }
+            { dot: true },
           );
 
           const contentRouteFiles: string[] = fg.sync(
@@ -80,10 +80,10 @@ export function routerPlugin(options?: Options): Plugin[] {
               `${root}/src/app/pages/**/*.md`,
               `${root}/src/content/**/*.md`,
               ...(options?.additionalContentDirs || [])?.map(
-                (glob) => `${workspaceRoot}${glob}/**/*.{md,agx}`
+                (glob) => `${workspaceRoot}${glob}/**/*.{md,agx}`,
               ),
             ],
-            { dot: true }
+            { dot: true },
           );
 
           let result = code.replace(
@@ -91,9 +91,9 @@ export function routerPlugin(options?: Options): Plugin[] {
             `
             ANALOG_ROUTE_FILES = {${routeFiles.map(
               (module) =>
-                `"${module.replace(root, '')}": () => import('${module}')`
+                `"${module.replace(root, '')}": () => import('${module}')`,
             )}};
-          `
+          `,
           );
 
           result = result.replace(
@@ -103,10 +103,10 @@ export function routerPlugin(options?: Options): Plugin[] {
             (module) =>
               `"${module.replace(
                 root,
-                ''
-              )}": () => import('${module}?analog-content-file=true').then(m => m.default)`
+                '',
+              )}": () => import('${module}?analog-content-file=true').then(m => m.default)`,
           )}};
-          `
+          `,
           );
 
           return {
@@ -126,10 +126,10 @@ export function routerPlugin(options?: Options): Plugin[] {
             [
               `${root}/src/app/pages/**/*.server.ts`,
               ...(options?.additionalPagesDirs || [])?.map(
-                (glob) => `${workspaceRoot}${glob}/**/*.server.ts`
+                (glob) => `${workspaceRoot}${glob}/**/*.server.ts`,
               ),
             ],
-            { dot: true }
+            { dot: true },
           );
 
           const result = code.replace(
@@ -137,9 +137,9 @@ export function routerPlugin(options?: Options): Plugin[] {
             `
             ANALOG_PAGE_ENDPOINTS = {${endpointFiles.map(
               (module) =>
-                `"${module.replace(root, '')}": () => import('${module}')`
+                `"${module.replace(root, '')}": () => import('${module}')`,
             )}};
-          `
+          `,
           );
 
           return {

--- a/packages/platform/src/lib/ssr/inject-html-plugin.ts
+++ b/packages/platform/src/lib/ssr/inject-html-plugin.ts
@@ -11,7 +11,7 @@ function eventReplayPlugin(): Plugin {
     async transformIndexHtml() {
       const eventReplayScript = await readFile(
         require.resolve('@angular/core/event-dispatch-contract.min.js'),
-        'utf-8'
+        'utf-8',
       );
 
       return [

--- a/packages/platform/src/lib/ssr/ssr-build-plugin.ts
+++ b/packages/platform/src/lib/ssr/ssr-build-plugin.ts
@@ -18,7 +18,7 @@ export function ssrBuildPlugin(): Plugin {
           code: code
             .replace(
               'new xhr2.XMLHttpRequest',
-              'new (xhr2.default.XMLHttpRequest || xhr2.default)'
+              'new (xhr2.default.XMLHttpRequest || xhr2.default)',
             )
             .replaceAll('global.', 'globalThis.')
             .replaceAll('global,', 'globalThis,')

--- a/packages/router/server/src/provide-server-context.ts
+++ b/packages/router/server/src/provide-server-context.ts
@@ -39,7 +39,7 @@ export function getBaseUrl(req: ServerRequest) {
       originalUrl.endsWith('/')
         ? originalUrl.substring(0, originalUrl.length - 1)
         : originalUrl
-    }`
+    }`,
   );
   const baseUrl = parsedUrl.origin;
 
@@ -48,7 +48,7 @@ export function getBaseUrl(req: ServerRequest) {
 
 export function getRequestProtocol(
   req: ServerRequest,
-  opts: { xForwardedProto?: boolean } = {}
+  opts: { xForwardedProto?: boolean } = {},
 ) {
   if (
     opts.xForwardedProto !== false &&

--- a/packages/router/server/src/render.ts
+++ b/packages/router/server/src/render.ts
@@ -30,7 +30,7 @@ if (import.meta.env.PROD) {
 export function render(
   rootComponent: Type<unknown>,
   config: ApplicationConfig,
-  platformProviders: Provider[] = []
+  platformProviders: Provider[] = [],
 ) {
   function bootstrap() {
     return bootstrapApplication(rootComponent, config);
@@ -39,7 +39,7 @@ export function render(
   return async function render(
     url: string,
     document: string,
-    serverContext: ServerContext
+    serverContext: ServerContext,
   ) {
     if (serverComponentRequest(serverContext)) {
       return await renderServerComponent(url, serverContext);

--- a/packages/router/server/src/server-component-render.ts
+++ b/packages/router/server/src/server-component-render.ts
@@ -20,7 +20,7 @@ type ComponentLoader = () => Promise<Type<unknown>>;
 export function serverComponentRequest(serverContext: ServerContext) {
   const serverComponentId = getHeader(
     createEvent(serverContext.req, serverContext.res),
-    'X-Analog-Component'
+    'X-Analog-Component',
   );
 
   if (
@@ -43,7 +43,7 @@ const components = import.meta.glob([
 export async function renderServerComponent(
   url: string,
   serverContext: ServerContext,
-  config?: ApplicationConfig
+  config?: ApplicationConfig,
 ) {
   const componentReqId = serverComponentRequest(serverContext) as string;
   const { componentLoader, componentId } = getComponentLoader(componentReqId);
@@ -139,10 +139,10 @@ function getComponentLoader(componentReqId: string): {
 
 function retrieveTransferredState(
   html: string,
-  appId: string
+  appId: string,
 ): Record<string, unknown | undefined> {
   const regex = new RegExp(
-    `<script id="${appId}-state" type="application/json">(.*?)<\/script>`
+    `<script id="${appId}-state" type="application/json">(.*?)<\/script>`,
   );
   const match = html.match(regex);
 

--- a/packages/router/server/src/tokens.ts
+++ b/packages/router/server/src/tokens.ts
@@ -8,11 +8,11 @@ import {
 } from '@angular/core';
 
 export const STATIC_PROPS = new InjectionToken<Record<string, any>>(
-  'Static Props'
+  'Static Props',
 );
 
 export function provideStaticProps<T = Record<string, any>>(
-  props: T
+  props: T,
 ): Provider {
   return {
     provide: STATIC_PROPS,

--- a/packages/router/src/lib/cache-key.ts
+++ b/packages/router/src/lib/cache-key.ts
@@ -10,7 +10,7 @@ function sortAndConcatParams(params: HttpParams | URLSearchParams): string {
 
 export function makeCacheKey(
   request: HttpRequest<any>,
-  mappedRequestUrl: string
+  mappedRequestUrl: string,
 ): StateKey<unknown> {
   // make the params encoded same as a url so it's easy to identify
   const { params, method, responseType } = request;

--- a/packages/router/src/lib/cookie-interceptor.ts
+++ b/packages/router/src/lib/cookie-interceptor.ts
@@ -7,7 +7,7 @@ export function cookieInterceptor(
   req: HttpRequest<unknown>,
   next: HttpHandlerFn,
   location = inject(PLATFORM_ID),
-  serverRequest = injectRequest()
+  serverRequest = injectRequest(),
 ) {
   if (isPlatformServer(location) && req.url.includes('/_analog/')) {
     let headers = new HttpHeaders();

--- a/packages/router/src/lib/debug/debug.page.ts
+++ b/packages/router/src/lib/debug/debug.page.ts
@@ -22,16 +22,19 @@ type CollectedRoute = {
         <div class="header-cell">Type</div>
       </div>
       <div class="table-body">
-        @for(collectedRoute of collectedRoutes; track collectedRoute.filename) {
-        <div class="table-row">
-          <div class="table-cell">{{ collectedRoute.path }}</div>
-          <div class="table-cell" [title]="collectedRoute.filename">
-            {{ collectedRoute.file }}
+        @for (
+          collectedRoute of collectedRoutes;
+          track collectedRoute.filename
+        ) {
+          <div class="table-row">
+            <div class="table-cell">{{ collectedRoute.path }}</div>
+            <div class="table-cell" [title]="collectedRoute.filename">
+              {{ collectedRoute.file }}
+            </div>
+            <div class="table-cell">
+              {{ collectedRoute.isLayout ? 'Layout' : 'Page' }}
+            </div>
           </div>
-          <div class="table-cell">
-            {{ collectedRoute.isLayout ? 'Layout' : 'Page' }}
-          </div>
-        </div>
         }
       </div>
     </div>

--- a/packages/router/src/lib/debug/routes.ts
+++ b/packages/router/src/lib/debug/routes.ts
@@ -17,12 +17,12 @@ export const DEBUG_ROUTES = new InjectionToken(
           ...ANALOG_ROUTE_FILES,
           ...ANALOG_CONTENT_ROUTE_FILES,
         },
-        true
+        true,
       );
 
       return debugRoutes as (Route & DebugRoute)[];
     },
-  }
+  },
 );
 
 export type DebugRoute = {

--- a/packages/router/src/lib/endpoints.ts
+++ b/packages/router/src/lib/endpoints.ts
@@ -1,5 +1,5 @@
 export const ANALOG_META_KEY = Symbol(
-  '@analogjs/router Analog Route Metadata Key'
+  '@analogjs/router Analog Route Metadata Key',
 );
 
 /**

--- a/packages/router/src/lib/form-action.directive.ts
+++ b/packages/router/src/lib/form-action.directive.ts
@@ -49,7 +49,7 @@ export class FormAction {
   private _handlePost(
     body: FormData,
     path: string,
-    $event: { target: HTMLFormElement } & Event
+    $event: { target: HTMLFormElement } & Event,
   ) {
     fetch(path, {
       method: $event.target.method,

--- a/packages/router/src/lib/get-load-resolver.ts
+++ b/packages/router/src/lib/get-load-resolver.ts
@@ -7,7 +7,7 @@ import { ActivatedRouteSnapshot } from '@angular/router';
  * @returns Returns server load resolver data for the route
  */
 export async function getLoadResolver<T>(
-  route: ActivatedRouteSnapshot
+  route: ActivatedRouteSnapshot,
 ): Promise<T> {
   return route.routeConfig?.resolve?.['load']?.(route);
 }

--- a/packages/router/src/lib/inject-load.ts
+++ b/packages/router/src/lib/inject-load.ts
@@ -5,12 +5,12 @@ import { Observable, map } from 'rxjs';
 import { PageServerLoad } from './route-types';
 
 export function injectLoad<
-  T extends (pageServerLoad: PageServerLoad) => Promise<any>
+  T extends (pageServerLoad: PageServerLoad) => Promise<any>,
 >(options?: { injector?: Injector }): Observable<Awaited<ReturnType<T>>> {
   const injector = options?.injector ?? inject(Injector);
   const route = injector.get(ActivatedRoute);
 
   return route.data.pipe(
-    map<Data, Awaited<ReturnType<T>>>((data) => data['load'])
+    map<Data, Awaited<ReturnType<T>>>((data) => data['load']),
   );
 }

--- a/packages/router/src/lib/inject-route-endpoint-url.ts
+++ b/packages/router/src/lib/inject-route-endpoint-url.ts
@@ -18,7 +18,7 @@ export function injectRouteEndpointURL(route: ActivatedRouteSnapshot) {
       baseUrl ||
       (typeof window !== 'undefined' && window.location.origin
         ? window.location.origin
-        : '')
+        : ''),
   );
   url.pathname = `${
     url.pathname.endsWith('/') ? url.pathname : url.pathname + '/'

--- a/packages/router/src/lib/markdown-helpers.ts
+++ b/packages/router/src/lib/markdown-helpers.ts
@@ -10,7 +10,7 @@ declare const Zone: any;
 const isNgZoneEnabled = typeof Zone !== 'undefined' && !!Zone.root;
 
 export function toMarkdownModule(
-  markdownFileFactory: () => Promise<string>
+  markdownFileFactory: () => Promise<string>,
 ): () => Promise<RouteExport> {
   return async () => {
     const createLoader = () =>

--- a/packages/router/src/lib/meta-tags.spec.ts
+++ b/packages/router/src/lib/meta-tags.spec.ts
@@ -87,8 +87,8 @@ describe('updateMetaTagsOnRouteChange', () => {
                           property: 'og:description',
                           content: childMetaTagValues.ogDescription,
                         },
-                      ] as MetaTag[]
-                  )
+                      ] as MetaTag[],
+                  ),
                 ),
             },
           },
@@ -113,26 +113,26 @@ describe('updateMetaTagsOnRouteChange', () => {
     const getMetaElements = () => ({
       charset: document.querySelector('meta[charset]') as HTMLMetaElement,
       httpEquivRefresh: document.querySelector(
-        'meta[http-equiv="refresh"]'
+        'meta[http-equiv="refresh"]',
       ) as HTMLMetaElement,
       httpEquivContentSec: document.querySelector(
-        'meta[http-equiv="content-security-policy"]'
+        'meta[http-equiv="content-security-policy"]',
       ) as HTMLMetaElement,
       description: document.querySelector(
-        'meta[name="description"]'
+        'meta[name="description"]',
       ) as HTMLMetaElement,
       keywords: document.querySelector(
-        'meta[name="keywords"]'
+        'meta[name="keywords"]',
       ) as HTMLMetaElement,
       author: document.querySelector('meta[name="author"]') as HTMLMetaElement,
       ogTitle: document.querySelector(
-        'meta[property="og:title"]'
+        'meta[property="og:title"]',
       ) as HTMLMetaElement,
       ogDescription: document.querySelector(
-        'meta[property="og:description"]'
+        'meta[property="og:description"]',
       ) as HTMLMetaElement,
       ogImage: document.querySelector(
-        'meta[property="og:image"]'
+        'meta[property="og:image"]',
       ) as HTMLMetaElement,
     });
 
@@ -147,13 +147,13 @@ describe('updateMetaTagsOnRouteChange', () => {
 
     const metaElements = getMetaElements();
     expect(metaElements.charset.getAttribute('charset')).toBe(
-      parentMetaTagValues.charset
+      parentMetaTagValues.charset,
     );
     expect(metaElements.httpEquivRefresh.content).toBe(
-      parentMetaTagValues.httpEquivRefresh
+      parentMetaTagValues.httpEquivRefresh,
     );
     expect(metaElements.description.content).toBe(
-      parentMetaTagValues.description
+      parentMetaTagValues.description,
     );
     expect(metaElements.keywords.content).toBe(parentMetaTagValues.keywords);
     expect(metaElements.ogTitle.content).toBe(parentMetaTagValues.ogTitle);
@@ -170,21 +170,21 @@ describe('updateMetaTagsOnRouteChange', () => {
 
     const metaElements = getMetaElements();
     expect(metaElements.charset.getAttribute('charset')).toBe(
-      childMetaTagValues.charset
+      childMetaTagValues.charset,
     );
     expect(metaElements.httpEquivRefresh.content).toBe(
-      childMetaTagValues.httpEquivRefresh
+      childMetaTagValues.httpEquivRefresh,
     );
     expect(metaElements.httpEquivContentSec.content).toBe(
-      childMetaTagValues.httpEquivContentSec
+      childMetaTagValues.httpEquivContentSec,
     );
     expect(metaElements.description.content).toBe(
-      childMetaTagValues.description
+      childMetaTagValues.description,
     );
     expect(metaElements.author.content).toBe(childMetaTagValues.author);
     expect(metaElements.ogTitle.content).toBe(childMetaTagValues.ogTitle);
     expect(metaElements.ogDescription.content).toBe(
-      childMetaTagValues.ogDescription
+      childMetaTagValues.ogDescription,
     );
     // meta tags inherited from parent route
     expect(metaElements.keywords.content).toBe(parentMetaTagValues.keywords);
@@ -203,24 +203,24 @@ describe('updateMetaTagsOnRouteChange', () => {
 
     const metaElements = getMetaElements();
     expect(metaElements.charset.getAttribute('charset')).toBe(
-      parentMetaTagValues.charset
+      parentMetaTagValues.charset,
     );
     expect(metaElements.description.content).toBe(
-      parentMetaTagValues.description
+      parentMetaTagValues.description,
     );
     expect(metaElements.keywords.content).toBe(parentMetaTagValues.keywords);
     expect(metaElements.httpEquivRefresh.content).toBe(
-      parentMetaTagValues.httpEquivRefresh
+      parentMetaTagValues.httpEquivRefresh,
     );
     expect(metaElements.ogTitle.content).toBe(parentMetaTagValues.ogTitle);
     expect(metaElements.ogImage.content).toBe(parentMetaTagValues.ogImage);
     // meta tags that are not changed
     expect(metaElements.httpEquivContentSec.content).toBe(
-      childMetaTagValues.httpEquivContentSec
+      childMetaTagValues.httpEquivContentSec,
     );
     expect(metaElements.author.content).toBe(childMetaTagValues.author);
     expect(metaElements.ogDescription.content).toBe(
-      childMetaTagValues.ogDescription
+      childMetaTagValues.ogDescription,
     );
   }));
 });

--- a/packages/router/src/lib/meta-tags.ts
+++ b/packages/router/src/lib/meta-tags.ts
@@ -4,7 +4,7 @@ import { ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
 
 export const ROUTE_META_TAGS_KEY = Symbol(
-  '@analogjs/router Route Meta Tags Key'
+  '@analogjs/router Route Meta Tags Key',
 );
 
 const CHARSET_KEY = 'charset';

--- a/packages/router/src/lib/request-context.ts
+++ b/packages/router/src/lib/request-context.ts
@@ -24,7 +24,7 @@ import { makeCacheKey } from './cache-key';
  */
 export function requestContextInterceptor(
   req: HttpRequest<unknown>,
-  next: HttpHandlerFn
+  next: HttpHandlerFn,
 ) {
   const apiPrefix = injectAPIPrefix();
   const baseUrl = injectBaseURL();
@@ -73,7 +73,7 @@ export function requestContextInterceptor(
 
           transferState.set(storeKey, cacheResponse);
           return transferResponse;
-        })
+        }),
     );
   }
 
@@ -98,7 +98,7 @@ export function requestContextInterceptor(
     return next(
       req.clone({
         url: requestUrl,
-      })
+      }),
     );
   }
 
@@ -112,7 +112,7 @@ export function requestContextInterceptor(
     return next(
       req.clone({
         url: requestUrl,
-      })
+      }),
     );
   }
 

--- a/packages/router/src/lib/route-config.ts
+++ b/packages/router/src/lib/route-config.ts
@@ -59,7 +59,7 @@ export function toRouteConfig(routeMeta: RouteMeta | undefined): RouteConfig {
 }
 
 function isRedirectRouteMeta(
-  routeMeta: RouteMeta
+  routeMeta: RouteMeta,
 ): routeMeta is RedirectRouteMeta {
   return !!routeMeta.redirectTo;
 }

--- a/packages/router/src/lib/route-types.ts
+++ b/packages/router/src/lib/route-types.ts
@@ -10,5 +10,5 @@ export type PageServerLoad = {
 };
 
 export type LoadResult<
-  A extends (pageServerLoad: PageServerLoad) => Promise<any>
+  A extends (pageServerLoad: PageServerLoad) => Promise<any>,
 > = Awaited<ReturnType<A>>;

--- a/packages/router/src/lib/routes.spec.ts
+++ b/packages/router/src/lib/routes.spec.ts
@@ -626,7 +626,7 @@ describe('routes', () => {
       await route.loadChildren?.();
 
       expect(spy).toHaveBeenCalledWith(
-        `[Analog] Missing default export at ${fileName}`
+        `[Analog] Missing default export at ${fileName}`,
       );
     });
 
@@ -647,7 +647,7 @@ describe('routes', () => {
       await route.loadChildren?.();
 
       expect(spy).not.toHaveBeenCalledWith(
-        `[Analog] Missing default export at ${fileName}`
+        `[Analog] Missing default export at ${fileName}`,
       );
     });
   });

--- a/packages/router/src/lib/routes.ts
+++ b/packages/router/src/lib/routes.ts
@@ -94,7 +94,7 @@ export function createRoutes(files: Files, debug = false): Route[] {
         rawSegment: parentRawSegment,
         ancestorRawSegments: rawRoute.ancestorRawSegments.slice(
           0,
-          parentRawSegmentIndex
+          parentRawSegmentIndex,
         ),
         segment: toSegment(parentRawSegment),
         level: level - 1,
@@ -109,7 +109,7 @@ export function createRoutes(files: Files, debug = false): Route[] {
   // since they already contain nested routes as their children
   const rootRawRoutesMap = rawRoutesByLevelMap[0];
   const rawRoutes = Object.keys(rootRawRoutesMap).map(
-    (segment) => rootRawRoutesMap[segment]
+    (segment) => rootRawRoutesMap[segment],
   );
   sortRawRoutes(rawRoutes);
 
@@ -121,7 +121,7 @@ function toRawPath(filename: string): string {
     .replace(
       // convert to relative path and remove file extension
       /^(?:[a-zA-Z]:[\\/])?(.*?)[\\/](?:routes|pages)[\\/]|(?:[\\/](?:app[\\/](?:routes|pages)[\\/]))|(\.page\.(js|ts|analog|ag)$)|(\.(ts|md|analog|ag)$)/g,
-      ''
+      '',
     )
     .replace(/\[\.{3}.+\]/, '**') // [...not-found] => **
     .replace(/\[([^\]]+)\]/g, ':$1'); // [id] => :id
@@ -157,7 +157,7 @@ function toRoutes(rawRoutes: RawRoute[], files: Files, debug = false): Route[] {
 
       const endpointKey = rawRoute.filename.replace(
         /\.page\.(ts|analog|ag)$/,
-        ENDPOINT_EXTENSION
+        ENDPOINT_EXTENSION,
       );
 
       // get endpoint path
@@ -193,7 +193,7 @@ function toRoutes(rawRoutes: RawRoute[], files: Files, debug = false): Route[] {
 
                 if (!hasModuleDefault && !hasRedirect) {
                   console.warn(
-                    `[Analog] Missing default export at ${rawRoute.filename}`
+                    `[Analog] Missing default export at ${rawRoute.filename}`,
                   );
                 }
               }

--- a/packages/router/src/lib/server.component.ts
+++ b/packages/router/src/lib/server.component.ts
@@ -60,7 +60,7 @@ export class ServerOnly {
         new Headers({
           'Content-type': 'application/json',
           'X-Analog-Component': componentId,
-        })
+        }),
       );
 
       const componentUrl = this.getComponentUrl(componentId);
@@ -69,10 +69,10 @@ export class ServerOnly {
       });
       const cacheKey = makeCacheKey(
         httpRequest,
-        new URL(componentUrl).pathname
+        new URL(componentUrl).pathname,
       );
       const storeKey = makeStateKey<{ html: string; outputs: ServerOutputs }>(
-        cacheKey
+        cacheKey,
       );
       const componentState = this.transferState.get<{
         html: string;
@@ -98,7 +98,7 @@ export class ServerOnly {
                 };
               }
               return throwError(
-                () => ({} as { html: string; outputs: ServerOutputs })
+                () => ({}) as { html: string; outputs: ServerOutputs },
               );
             }),
             catchError((error: unknown) => {
@@ -107,12 +107,12 @@ export class ServerOnly {
                 html: '',
                 outputs: {} as ServerOutputs,
               });
-            })
+            }),
           )
           .subscribe((content) =>
             this.updateContent(
-              content as { html: string; outputs: ServerOutputs }
-            )
+              content as { html: string; outputs: ServerOutputs },
+            ),
           );
       }
     });

--- a/packages/router/src/test-setup.ts
+++ b/packages/router/src/test-setup.ts
@@ -12,5 +12,5 @@ import {
 
 TestBed.initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/packages/router/tokens/src/index.ts
+++ b/packages/router/tokens/src/index.ts
@@ -9,15 +9,15 @@ export type ServerResponse = NodeServerResponse;
 export type ServerContext = { req: ServerRequest; res: ServerResponse };
 
 export const REQUEST = new InjectionToken<ServerRequest>(
-  '@analogjs/router Server Request'
+  '@analogjs/router Server Request',
 );
 export const RESPONSE = new InjectionToken<ServerResponse>(
-  '@analogjs/router Server Response'
+  '@analogjs/router Server Response',
 );
 export const BASE_URL = new InjectionToken<string>('@analogjs/router Base URL');
 
 export const API_PREFIX = new InjectionToken<string>(
-  '@analogjs/router API Prefix'
+  '@analogjs/router API Prefix',
 );
 
 export function injectRequest() {

--- a/packages/trpc/server/src/lib/server.ts
+++ b/packages/trpc/server/src/lib/server.ts
@@ -21,7 +21,7 @@ import type { TRPCResponse } from '@trpc/server/rpc';
 type MaybePromise<T> = T | Promise<T>;
 
 export type CreateContextFn<TRouter extends AnyRouter> = (
-  event: H3Event
+  event: H3Event,
 ) => MaybePromise<inferRouterContext<TRouter>>;
 
 export interface ResponseMetaFnPayload<TRouter extends AnyRouter> {
@@ -33,7 +33,7 @@ export interface ResponseMetaFnPayload<TRouter extends AnyRouter> {
 }
 
 export type ResponseMetaFn<TRouter extends AnyRouter> = (
-  opts: ResponseMetaFnPayload<TRouter>
+  opts: ResponseMetaFnPayload<TRouter>,
 ) => ResponseMeta;
 
 export interface OnErrorPayload<TRouter extends AnyRouter> {
@@ -46,7 +46,7 @@ export interface OnErrorPayload<TRouter extends AnyRouter> {
 }
 
 export type OnErrorFn<TRouter extends AnyRouter> = (
-  opts: OnErrorPayload<TRouter>
+  opts: OnErrorPayload<TRouter>,
 ) => void;
 
 export interface ResolveHTTPRequestOptions<TRouter extends AnyRouter> {

--- a/packages/trpc/src/lib/client/client.ts
+++ b/packages/trpc/src/lib/client/client.ts
@@ -26,12 +26,12 @@ export type TrpcClient<AppRouter extends AnyRouter> = ReturnType<
   typeof createTRPCRxJSProxyClient<AppRouter>
 >;
 const tRPC_INJECTION_TOKEN = new InjectionToken<unknown>(
-  '@analogjs/trpc proxy client'
+  '@analogjs/trpc proxy client',
 );
 
 function customFetch(
   input: RequestInfo | URL,
-  init?: RequestInit & { method: 'GET' }
+  init?: RequestInit & { method: 'GET' },
 ) {
   if ((globalThis as any).$fetch) {
     return (globalThis as any).$fetch

--- a/packages/trpc/src/lib/client/links/transfer-state-link.ts
+++ b/packages/trpc/src/lib/client/links/transfer-state-link.ts
@@ -9,7 +9,7 @@ function makeCacheKey(request: Operation<unknown>): StateKey<string> {
   const { type, path, input } = request;
   const encodedParams = Object.entries(input ?? {}).reduce(
     (prev, [key, value]) => prev + `${key}=${JSON.stringify(value)}`,
-    ''
+    '',
   );
   const key = type + '.' + path + '?' + encodedParams;
   const hash = generateHash(key);
@@ -61,7 +61,7 @@ export const transferStateLink =
         // use superjson to parse our superjson string and retrieve our
         // data return it instead of calling next trpc link
         return observable((observer) =>
-          observer.next(superjson.parse(storeValue))
+          observer.next(superjson.parse(storeValue)),
         );
       }
 

--- a/packages/trpc/src/lib/client/shared-internal.ts
+++ b/packages/trpc/src/lib/client/shared-internal.ts
@@ -44,7 +44,7 @@ export interface TRPCRequestOptions {
 export function createChain<
   TRouter extends AnyRouter,
   TInput = unknown,
-  TOutput = unknown
+  TOutput = unknown,
 >(opts: {
   links: OperationLink<TRouter, TInput, TOutput>[];
   op: Operation<TInput>;
@@ -54,7 +54,7 @@ export function createChain<
       const next = opts.links[index];
       if (!next) {
         throw new Error(
-          'No more links to execute - did you forget to add an ending link?'
+          'No more links to execute - did you forget to add an ending link?',
         );
       }
       const subscription = next({
@@ -74,9 +74,9 @@ export function createChain<
 }
 
 export type CreateTRPCClientOptions<TRouter extends AnyRouter> =
-  | CreateTRPCClientBaseOptions<TRouter> & {
-      links: TRPCLink<TRouter>[];
-    };
+  CreateTRPCClientBaseOptions<TRouter> & {
+    links: TRPCLink<TRouter>[];
+  };
 
 export type CreateTRPCClientBaseOptions<TRouter extends AnyRouter> =
   TRouter['_def']['_config']['transformer'] extends DefaultDataTransformer
@@ -90,25 +90,25 @@ export type CreateTRPCClientBaseOptions<TRouter extends AnyRouter> =
         transformer?: 'You must set a transformer on the backend router';
       }
     : TRouter['_def']['_config']['transformer'] extends DataTransformerOptions
-    ? {
-        /**
-         * Data transformer
-         *
-         * You must use the same transformer on the backend and frontend
-         * @link https://trpc.io/docs/data-transformers
-         **/
-        transformer: TRouter['_def']['_config']['transformer'] extends CombinedDataTransformer
-          ? DataTransformerOptions
-          : TRouter['_def']['_config']['transformer'];
-      }
-    : {
-        /**
-         * Data transformer
-         *
-         * You must use the same transformer on the backend and frontend
-         * @link https://trpc.io/docs/data-transformers
-         **/
-        transformer?:
-          | /** @deprecated **/ ClientDataTransformerOptions
-          | CombinedDataTransformer;
-      };
+      ? {
+          /**
+           * Data transformer
+           *
+           * You must use the same transformer on the backend and frontend
+           * @link https://trpc.io/docs/data-transformers
+           **/
+          transformer: TRouter['_def']['_config']['transformer'] extends CombinedDataTransformer
+            ? DataTransformerOptions
+            : TRouter['_def']['_config']['transformer'];
+        }
+      : {
+          /**
+           * Data transformer
+           *
+           * You must use the same transformer on the backend and frontend
+           * @link https://trpc.io/docs/data-transformers
+           **/
+          transformer?:
+            | /** @deprecated **/ ClientDataTransformerOptions
+            | CombinedDataTransformer;
+        };

--- a/packages/trpc/src/lib/client/trpc-rxjs-proxy.ts
+++ b/packages/trpc/src/lib/client/trpc-rxjs-proxy.ts
@@ -44,21 +44,21 @@ type Resolver<TProcedure extends AnyProcedure> = (
 // Removed subscription and using new type
 type DecorateProcedure<
   TProcedure extends AnyProcedure,
-  TRouter extends AnyRouter
+  TRouter extends AnyRouter,
 > = TProcedure extends AnyQueryProcedure
   ? {
       query: Resolver<TProcedure>;
     }
   : TProcedure extends AnyMutationProcedure
-  ? {
-      mutate: Resolver<TProcedure>;
-    }
-  : never;
+    ? {
+        mutate: Resolver<TProcedure>;
+      }
+    : never;
 
 // Removed subscription and using new type
 type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
-  TRouter extends AnyRouter
+  TRouter extends AnyRouter,
 > = {
   [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
     ? DecoratedProcedureRecord<
@@ -66,8 +66,8 @@ type DecoratedProcedureRecord<
         TProcedures[TKey]
       >
     : TProcedures[TKey] extends AnyProcedure
-    ? DecorateProcedure<TProcedures[TKey], TRouter>
-    : never;
+      ? DecorateProcedure<TProcedures[TKey], TRouter>
+      : never;
 };
 
 // Removed subscription and using new type
@@ -101,7 +101,7 @@ export type CreateTrpcProxyClient<TRouter extends AnyRouter> =
 
 // Nothing changed, only using new types
 function createTRPCRxJSClientProxy<TRouter extends AnyRouter>(
-  client: TRPCClient<TRouter>
+  client: TRPCClient<TRouter>,
 ) {
   return createFlatProxy<CreateTrpcProxyClient<TRouter>>((key) => {
     // eslint-disable-next-line no-prototype-builtins
@@ -126,7 +126,7 @@ function createTRPCRxJSClientProxy<TRouter extends AnyRouter>(
 }
 
 export function createTRPCRxJSProxyClient<TRouter extends AnyRouter>(
-  opts: CreateTRPCClientOptions<TRouter>
+  opts: CreateTRPCClientOptions<TRouter>,
 ) {
   const client = new TRPCClient<TRouter>(opts);
   const proxy = createTRPCRxJSClientProxy(client as TRPCClient<TRouter>);
@@ -212,7 +212,7 @@ class TRPCClient<TRouter extends AnyRouter> {
   public query<
     TQueries extends TRouter['_def']['queries'],
     TPath extends string & keyof TQueries,
-    TInput extends inferProcedureInput<TQueries[TPath]>
+    TInput extends inferProcedureInput<TQueries[TPath]>,
   >(path: TPath, input?: TInput, opts?: TRPCRequestOptions) {
     type TOutput = inferProcedureOutput<TQueries[TPath]>;
     return this.$request<TInput, TOutput>({
@@ -226,7 +226,7 @@ class TRPCClient<TRouter extends AnyRouter> {
   public mutation<
     TMutations extends TRouter['_def']['mutations'],
     TPath extends string & keyof TMutations,
-    TInput extends inferProcedureInput<TMutations[TPath]>
+    TInput extends inferProcedureInput<TMutations[TPath]>,
   >(path: TPath, input?: TInput, opts?: TRPCRequestOptions) {
     type TOutput = inferTransformedProcedureOutput<TMutations[TPath]>;
     return this.$request<TInput, TOutput>({
@@ -239,7 +239,7 @@ class TRPCClient<TRouter extends AnyRouter> {
 }
 
 function trpcObservableToRxJsObservable<TValue>(
-  observable: TrpcObservable<TValue, unknown>
+  observable: TrpcObservable<TValue, unknown>,
 ) {
   return new RxJSObservable<TValue>((subscriber) => {
     const sub = observable.subscribe({

--- a/packages/trpc/src/lib/utils/wait-for.ts
+++ b/packages/trpc/src/lib/utils/wait-for.ts
@@ -15,7 +15,7 @@ export async function waitFor<T>(prom: Promise<T> | Observable<T>): Promise<T> {
     `AnalogContentResolve-${Math.random()}`,
     () => {},
     {},
-    () => {}
+    () => {},
   );
   return prom.then((p: T) => {
     macroTask.invoke();

--- a/packages/trpc/src/test-setup.ts
+++ b/packages/trpc/src/test-setup.ts
@@ -12,5 +12,5 @@ import {
 
 TestBed.initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/packages/vite-plugin-angular/esbuild.ts
+++ b/packages/vite-plugin-angular/esbuild.ts
@@ -3,7 +3,7 @@ import type * as esbuild from 'esbuild';
 import { PluginOptions } from './src';
 
 export const analogSFC: (options?: PluginOptions) => esbuild.Plugin = (
-  options
+  options,
 ) => ({
   name: 'analog-sfc-esbuild-plugin',
   async setup(build) {

--- a/packages/vite-plugin-angular/setup-vitest.ts
+++ b/packages/vite-plugin-angular/setup-vitest.ts
@@ -83,7 +83,7 @@ const customSnapshotSerializer = () => {
     indentation: any,
     depth: any,
     refs: any,
-    printer: any
+    printer: any,
   ): string {
     // `printer` is a function that serializes a value using existing plugins.
     return `${printer(
@@ -91,7 +91,7 @@ const customSnapshotSerializer = () => {
       config,
       indentation,
       depth,
-      refs
+      refs,
     )}`;
   }
   function test(val: any): boolean {
@@ -180,7 +180,7 @@ function fixtureVitestSerializer(fixture: any) {
 
   const selector = Reflect.getOwnPropertyDescriptor(
     componentType,
-    '__annotations__'
+    '__annotations__',
   )?.value[0].selector;
 
   if (componentType && componentType.propDecorators) {
@@ -198,7 +198,7 @@ function fixtureVitestSerializer(fixture: any) {
   // * Convert string data to HTML data
   const doc = new DOMParser().parseFromString(
     `<${selector} ${inputsData}>${divElement.innerHTML}</${selector}>`,
-    'text/html'
+    'text/html',
   );
 
   return doc.body.childNodes[0];
@@ -212,13 +212,13 @@ const bindDescribe = (
   originalVitestFn: {
     apply: (
       arg0: any,
-      arg1: any[]
+      arg1: any[],
     ) => {
       (): any;
       new (): any;
       apply: { (arg0: any, arg1: any[]): any; new (): any };
     };
-  }
+  },
 ) =>
   function (...eachArgs: any) {
     return function (...args: any[]) {
@@ -237,13 +237,13 @@ const bindTest = (
   originalVitestFn: {
     apply: (
       arg0: any,
-      arg1: any[]
+      arg1: any[],
     ) => {
       (): any;
       new (): any;
       apply: { (arg0: any, arg1: any[]): any; new (): any };
     };
-  }
+  },
 ) =>
   function (...eachArgs: any) {
     return function (...args: any[]) {
@@ -265,11 +265,11 @@ const bindTest = (
   if (methodName === 'describe') {
     env[methodName].only = bindDescribe(
       originalvitestFn,
-      originalvitestFn.only
+      originalvitestFn.only,
     );
     env[methodName].skip = bindDescribe(
       originalvitestFn,
-      originalvitestFn.skip
+      originalvitestFn.skip,
     );
   }
 });

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -15,7 +15,7 @@ export function buildOptimizerPlugin({
       advancedOptimizations: true,
       jit: true,
     },
-    1
+    1,
   );
   let isProd = false;
 
@@ -69,7 +69,7 @@ export function buildOptimizerPlugin({
           id,
           code,
           false,
-          sideEffects
+          sideEffects,
         );
 
         return {

--- a/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
@@ -25,7 +25,7 @@ export function jitPlugin({
 
         const decodedStyles = Buffer.from(
           decodeURIComponent(styleId),
-          'base64'
+          'base64',
         ).toString();
 
         let styles: string | undefined = '';
@@ -34,7 +34,7 @@ export function jitPlugin({
           const compiled = await preprocessCSS(
             decodedStyles,
             `${styleId}.${inlineStylesExtension}?direct`,
-            config
+            config,
           );
           styles = compiled?.code;
         } catch (e) {

--- a/packages/vite-plugin-angular/src/lib/angular-storybook-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-storybook-plugin.ts
@@ -5,13 +5,13 @@ export function angularStorybookPlugin() {
       if (code.includes('"@storybook/angular"')) {
         return code.replace(
           /\"@storybook\/angular\"/g,
-          '"@storybook/angular/dist/client"'
+          '"@storybook/angular/dist/client"',
         );
       }
       if (code.includes("'@storybook/angular'")) {
         return code.replace(
           /\'@storybook\/angular\'/g,
-          "'@storybook/angular/dist/client'"
+          "'@storybook/angular/dist/client'",
         );
       }
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -94,7 +94,7 @@ interface EmitFileResult {
 }
 type FileEmitter = (
   file: string,
-  source?: ts.SourceFile
+  source?: ts.SourceFile,
 ) => Promise<EmitFileResult | undefined>;
 
 /**
@@ -169,7 +169,7 @@ export function angular(options?: PluginOptions): Plugin[] {
   let viteServer: ViteDevServer | undefined;
   let styleTransform: (
     code: string,
-    filename: string
+    filename: string,
   ) => ReturnType<typeof preprocessCSS> | undefined;
 
   const styleUrlsResolver = new StyleUrlsResolver();
@@ -200,7 +200,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             config.root || '.',
             process.env['NODE_ENV'] === 'test'
               ? './tsconfig.spec.json'
-              : './tsconfig.app.json'
+              : './tsconfig.app.json',
           );
 
         return {
@@ -219,7 +219,7 @@ export function angular(options?: PluginOptions): Plugin[] {
                     incremental: watchMode,
                   },
                   isTest,
-                  !isAstroIntegration
+                  !isAstroIntegration,
                 ),
               ],
               define: {
@@ -262,7 +262,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           const angularComponentMiddleware: Connect.HandleFunction = async (
             req: Connect.IncomingMessage,
             res: ServerResponse<Connect.IncomingMessage>,
-            next: Connect.NextFunction
+            next: Connect.NextFunction,
           ) => {
             if (req.url === undefined || res.writableEnded) {
               return;
@@ -349,7 +349,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           ) {
             const relativeFileId = `${relative(
               process.cwd(),
-              fileId
+              fileId,
             )}@${classNames.get(fileId)}`;
 
             sendHMRComponentUpdate(ctx.server, relativeFileId);
@@ -370,7 +370,7 @@ export function angular(options?: PluginOptions): Plugin[] {
            * for an external resource (styles, html).
            */
           const isDirect = ctx.modules.find(
-            (mod) => ctx.file === mod.file && mod.id?.includes('?direct')
+            (mod) => ctx.file === mod.file && mod.id?.includes('?direct'),
           );
           if (isDirect) {
             if (pluginOptions.liveReload && isDirect?.id && isDirect.file) {
@@ -378,7 +378,7 @@ export function angular(options?: PluginOptions): Plugin[] {
                 isDirect.type === 'css' && isComponentStyleSheet(isDirect.id);
               if (isComponentStyle) {
                 const { encapsulation } = getComponentStyleSheetMeta(
-                  isDirect.id
+                  isDirect.id,
                 );
 
                 // Track if the component uses ShadowDOM encapsulation
@@ -436,7 +436,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             updates.forEach((updateId) => {
               const impRelativeFileId = `${relative(
                 process.cwd(),
-                updateId
+                updateId,
               )}@${classNames.get(updateId)}`;
 
               sendHMRComponentUpdate(ctx.server, impRelativeFileId);
@@ -462,14 +462,14 @@ export function angular(options?: PluginOptions): Plugin[] {
         if (id.startsWith('angular:jit:')) {
           const path = id.split(';')[1];
           return `${normalizePath(
-            resolve(dirname(importer as string), path)
+            resolve(dirname(importer as string), path),
           )}?raw`;
         }
 
         // Map angular external styleUrls to the source file
         if (isComponentStyleSheet(id)) {
           const componentStyles = externalComponentStyles?.get(
-            getFilenameFromPath(id)
+            getFilenameFromPath(id),
           );
           if (componentStyles) {
             return componentStyles + new URL(id, 'http://localhost').search;
@@ -482,7 +482,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         // Map angular inline styles to the source text
         if (isComponentStyleSheet(id)) {
           const componentStyles = inlineComponentStyles?.get(
-            getFilenameFromPath(id)
+            getFilenameFromPath(id),
           );
           if (componentStyles) {
             return componentStyles;
@@ -504,8 +504,8 @@ export function angular(options?: PluginOptions): Plugin[] {
           const result = await fileEmitter?.(
             resolve(
               process.cwd(),
-              decodeURIComponent(componentId).split('@')[0]
-            )
+              decodeURIComponent(componentId).split('@')[0],
+            ),
           );
 
           return result?.hmrUpdateCode || '';
@@ -618,7 +618,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           if (jit && data.includes('angular:jit:')) {
             data = data.replace(
               /angular:jit:style:inline;/g,
-              'virtual:angular:jit:style:inline;'
+              'virtual:angular:jit:style:inline;',
             );
 
             templateUrls.forEach((templateUrlSet) => {
@@ -626,7 +626,7 @@ export function angular(options?: PluginOptions): Plugin[] {
                 templateUrlSet.split('|');
               data = data.replace(
                 `angular:jit:template:file;${templateFile}`,
-                `${resolvedTemplateUrl}?raw`
+                `${resolvedTemplateUrl}?raw`,
               );
             });
 
@@ -634,7 +634,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               const [styleFile, resolvedStyleUrl] = styleUrlSet.split('|');
               data = data.replace(
                 `angular:jit:style:file;${styleFile}`,
-                `${resolvedStyleUrl}?inline`
+                `${resolvedStyleUrl}?inline`,
               );
             });
           }
@@ -661,7 +661,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               const metadata = await getFrontmatterMetadata(
                 code,
                 id,
-                pluginOptions.markdownTemplateTransforms || []
+                pluginOptions.markdownTemplateTransforms || [],
               );
               data += metadata;
             }
@@ -710,7 +710,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
     const fg = require('fast-glob');
     const appRoot = normalizePath(
-      resolve(pluginOptions.workspaceRoot, config.root || '.')
+      resolve(pluginOptions.workspaceRoot, config.root || '.'),
     );
     const workspaceRoot = normalizePath(resolve(pluginOptions.workspaceRoot));
 
@@ -718,10 +718,10 @@ export function angular(options?: PluginOptions): Plugin[] {
       `${appRoot}/**/*.{analog,agx,ag}`,
       ...extraGlobs.map((glob) => `${workspaceRoot}${glob}.{analog,agx,ag}`),
       ...(pluginOptions.additionalContentDirs || [])?.map(
-        (glob) => `${workspaceRoot}${glob}/**/*.agx`
+        (glob) => `${workspaceRoot}${glob}/**/*.agx`,
       ),
       ...pluginOptions.include.map((glob) =>
-        `${workspaceRoot}${glob}`.replace(/\.ts$/, '.analog')
+        `${workspaceRoot}${glob}`.replace(/\.ts$/, '.analog'),
       ),
     ];
 
@@ -828,7 +828,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         rootNames,
         compilerOptions,
         host as CompilerHost,
-        nextProgram as any
+        nextProgram as any,
       );
       angularCompiler = angularProgram.compiler;
       typeScriptProgram = angularProgram.getTsProgram();
@@ -838,7 +838,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         ts.createEmitAndSemanticDiagnosticsBuilderProgram(
           typeScriptProgram,
           host,
-          builderProgram
+          builderProgram,
         );
 
       await angularCompiler.analyzeAsync();
@@ -850,7 +850,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           rootNames,
           compilerOptions,
           host,
-          nextProgram as any
+          nextProgram as any,
         );
 
       typeScriptProgram = builder.getProgram();
@@ -872,7 +872,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             ...(jit
               ? [
                   compilerCli.constructorParametersDownlevelTransform(
-                    builder.getProgram()
+                    builder.getProgram(),
                   ),
                   createJitResourceTransformer(getTypeChecker),
                 ]
@@ -883,12 +883,12 @@ export function angular(options?: PluginOptions): Plugin[] {
           afterDeclarations:
             pluginOptions.advanced.tsTransformers.afterDeclarations,
         },
-        jit ? {} : angularCompiler!.prepareEmit().transformers
+        jit ? {} : angularCompiler!.prepareEmit().transformers,
       ),
       () => [],
       angularCompiler!,
       pluginOptions.liveReload,
-      pluginOptions.disableTypeChecking
+      pluginOptions.disableTypeChecking,
     );
   }
 }
@@ -908,7 +908,7 @@ export function createFileEmitter(
   onAfterEmit?: (sourceFile: ts.SourceFile) => void,
   angularCompiler?: NgtscProgram['compiler'],
   liveReload?: boolean,
-  disableTypeChecking?: boolean
+  disableTypeChecking?: boolean,
 ): FileEmitter {
   return async (file: string, stale?: ts.SourceFile) => {
     const sourceFile = program.getSourceFile(file);
@@ -920,7 +920,7 @@ export function createFileEmitter(
       const hmrEligible = !!analyzeFileUpdates(
         stale,
         sourceFile,
-        angularCompiler!
+        angularCompiler!,
       );
       return { dependencies: [], hmrEligible };
     }
@@ -929,7 +929,7 @@ export function createFileEmitter(
       sourceFile,
       !!disableTypeChecking,
       program,
-      angularCompiler
+      angularCompiler,
     );
 
     const errors = diagnostics
@@ -937,7 +937,7 @@ export function createFileEmitter(
       .map((d) =>
         typeof d.messageText === 'object'
           ? d.messageText.messageText
-          : d.messageText
+          : d.messageText,
       );
 
     const warnings = diagnostics
@@ -965,7 +965,7 @@ export function createFileEmitter(
       },
       undefined /* cancellationToken */,
       undefined /* emitOnlyDtsFiles */,
-      transformers
+      transformers,
     );
 
     onAfterEmit?.(sourceFile);
@@ -978,7 +978,7 @@ function getDiagnosticsForSourceFile(
   sourceFile: ts.SourceFile,
   disableTypeChecking: boolean,
   program: ts.BuilderProgram,
-  angularCompiler?: NgtscProgram['compiler']
+  angularCompiler?: NgtscProgram['compiler'],
 ) {
   const syntacticDiagnostics = program.getSyntacticDiagnostics(sourceFile);
 
@@ -1048,7 +1048,7 @@ function getFilenameFromPath(id: string): string {
  */
 export function isTestWatchMode(
   command = process.env['_'],
-  args = process.argv
+  args = process.argv,
 ) {
   const isVitestCommand = command?.includes('vitest');
 

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.spec.ts
@@ -13,7 +13,7 @@ describe(angularVitestPlugin.name, () => {
       defineConfig({
         plugins: [angularVitestPlugin()],
       }),
-      'serve'
+      'serve',
     );
     expect(config.test?.pool).toBe('vmThreads');
   });
@@ -26,7 +26,7 @@ describe(angularVitestPlugin.name, () => {
           pool: 'threads',
         },
       }),
-      'serve'
+      'serve',
     );
     expect(config.test?.pool).toBe('threads');
   });

--- a/packages/vite-plugin-angular/src/lib/authoring/analog.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/analog.ts
@@ -32,7 +32,7 @@ import {
 export function compileAnalogFile(
   filePath: string,
   fileContent: string,
-  shouldFormat = false
+  shouldFormat = false,
 ) {
   const componentName = filePath.split('/').pop()?.split('.')[0];
   if (!componentName) {
@@ -77,7 +77,7 @@ export function compileAnalogFile(
 
       if (isMarkdown) {
         items.push(
-          `templateUrl: \`virtual-analog:${filePath.replace('.ts', '')}\``
+          `templateUrl: \`virtual-analog:${filePath.replace('.ts', '')}\``,
         );
       } else if (templateContent) {
         items.push(`template: \`${templateContent}\``);
@@ -120,7 +120,7 @@ export default class ${entityName} {
       project.createSourceFile(`${filePath}.virtual.ts`, source),
       ngType,
       entityName,
-      shouldFormat
+      shouldFormat,
     );
   }
 
@@ -141,10 +141,10 @@ function processAnalogScript(
   targetSourceFile: SourceFile,
   ngType: 'Component' | 'Directive',
   entityName: string,
-  isProd?: boolean
+  isProd?: boolean,
 ) {
   const targetClass = targetSourceFile.getClass(
-    (classDeclaration) => classDeclaration.getName() === entityName
+    (classDeclaration) => classDeclaration.getName() === entityName,
   );
 
   if (!targetClass) {
@@ -202,7 +202,7 @@ function processAnalogScript(
       ) {
         const generatedName = importStruct.moduleSpecifier.replace(
           /[^a-zA-Z]/g,
-          ''
+          '',
         );
         node.setDefaultImport(generatedName);
         importStruct = node.getStructure();
@@ -218,7 +218,7 @@ function processAnalogScript(
           const value = attribute.value.replaceAll("'", '').replaceAll('"', '');
           if (!(value in importAttributes)) {
             throw new Error(
-              `[Analog] Invalid Analog import attribute ${value} in ${fileName}`
+              `[Analog] Invalid Analog import attribute ${value} in ${fileName}`,
             );
           }
           foundAttribute = value;
@@ -234,12 +234,12 @@ function processAnalogScript(
         if (namedImports && Array.isArray(namedImports)) {
           const namedImportStructures = namedImports.filter(
             (
-              namedImport
+              namedImport,
             ): namedImport is OptionalKind<ImportSpecifierStructure> =>
-              typeof namedImport === 'object'
+              typeof namedImport === 'object',
           );
           const importNames = namedImportStructures.map(
-            (namedImport) => namedImport.alias ?? namedImport.name
+            (namedImport) => namedImport.alias ?? namedImport.name,
           );
           importAttributes[foundAttribute].push(...importNames);
         }
@@ -283,7 +283,7 @@ function processAnalogScript(
 
         // this also gets rid of OmittedExpression (i.e: skipped elements in array destructuring)
         const bindingElements = nameNode.getDescendantsOfKind(
-          SyntaxKind.BindingElement
+          SyntaxKind.BindingElement,
         );
 
         // nothing to do here
@@ -340,7 +340,7 @@ function processAnalogScript(
               // using `=== undefined` to strictly follow destructuring rule
               if (bindingInitializer) {
                 writer.write(
-                  `${propertyAccess} === undefined ? ${bindingInitializer.getText()} : ${propertyAccess}`
+                  `${propertyAccess} === undefined ? ${bindingInitializer.getText()} : ${propertyAccess}`,
                 );
               } else {
                 writer.write(propertyAccess);
@@ -408,7 +408,7 @@ function processAnalogScript(
           .filter(
             (property): property is PropertyAssignment =>
               Node.isPropertyAssignment(property) &&
-              !INVALID_METADATA_PROPERTIES.includes(property.getName())
+              !INVALID_METADATA_PROPERTIES.includes(property.getName()),
           );
 
         if (metadataProperties.length === 0) continue;
@@ -416,7 +416,7 @@ function processAnalogScript(
         processMetadata(
           metadataProperties,
           targetMetadataArguments,
-          targetClass
+          targetClass,
         );
 
         continue;
@@ -429,7 +429,7 @@ function processAnalogScript(
         pendingOperations.push(() => {
           // add the function to constructor
           targetConstructor.addStatements(
-            `this.${fnName} = ${initFunction.getText()}`
+            `this.${fnName} = ${initFunction.getText()}`,
           );
 
           // add life-cycle method to class
@@ -444,7 +444,7 @@ function processAnalogScript(
 
       // other function calls
       pendingOperations.push(() =>
-        targetConstructor.addStatements(nodeFullText)
+        targetConstructor.addStatements(nodeFullText),
       );
     }
   }
@@ -504,8 +504,8 @@ function processAnalogScript(
         scope: hasExportKeyword
           ? Scope.Protected
           : isVirtual
-          ? Scope.Private
-          : undefined,
+            ? Scope.Private
+            : undefined,
       });
       if (name !== ROUTE_META && !isVirtual) {
         targetConstructor.addStatements((writer) => {
@@ -524,7 +524,7 @@ function processAnalogScript(
       processArrayLiteralMetadata(
         targetMetadataArguments,
         'viewProviders',
-        importAttributes['viewProviders']
+        importAttributes['viewProviders'],
       );
     }
 
@@ -532,7 +532,7 @@ function processAnalogScript(
       processArrayLiteralMetadata(
         targetMetadataArguments,
         'imports',
-        importAttributes['imports']
+        importAttributes['imports'],
       );
     }
 
@@ -552,7 +552,7 @@ function processAnalogScript(
     processArrayLiteralMetadata(
       targetMetadataArguments,
       'providers',
-      importAttributes['providers']
+      importAttributes['providers'],
     );
   }
 
@@ -584,7 +584,7 @@ function processInitializer(
   writer: CodeBlockWriter,
   name: string,
   memberRegistry: Map<string, ClassMember>,
-  initializer?: Expression
+  initializer?: Expression,
 ) {
   if (!initializer) {
     console.warn(`[Analog] const variable must have an initializer: ${name}`);
@@ -600,8 +600,8 @@ function processInitializer(
         writer.write(
           processCallExpressionOrPropertyAccessExpressionForClassMember(
             initializer,
-            memberRegistry
-          )
+            memberRegistry,
+          ),
         );
         return;
       }
@@ -614,14 +614,14 @@ function processInitializer(
   writer.write(
     processCallExpressionOrPropertyAccessExpressionForClassMember(
       initializer,
-      memberRegistry
-    )
+      memberRegistry,
+    ),
   );
 }
 
 function processCallExpressionOrPropertyAccessExpressionForClassMember(
   initializer: Expression,
-  memberRegistry: Map<string, ClassMember>
+  memberRegistry: Map<string, ClassMember>,
 ) {
   if (Node.isCallExpression(initializer)) {
     const currentExpression = initializer.getExpression();
@@ -653,7 +653,7 @@ function processCallExpressionOrPropertyAccessExpressionForClassMember(
       if (Node.isPropertyAccessExpression(arg) || Node.isCallExpression(arg)) {
         return processCallExpressionOrPropertyAccessExpressionForClassMember(
           arg,
-          memberRegistry
+          memberRegistry,
         );
       }
 
@@ -689,7 +689,7 @@ function processCallExpressionOrPropertyAccessExpressionForClassMember(
 function processArrayLiteralMetadata(
   targetMetadataArguments: ObjectLiteralExpression,
   metadataName: string,
-  items: string[]
+  items: string[],
 ) {
   let metadata = targetMetadataArguments.getProperty(metadataName);
 
@@ -711,7 +711,7 @@ function processArrayLiteralMetadata(
 function processMetadata(
   metadataProperties: PropertyAssignment[],
   targetMetadataArguments: ObjectLiteralExpression,
-  targetClass: ClassDeclaration
+  targetClass: ClassDeclaration,
 ) {
   metadataProperties.forEach((property) => {
     const propertyInitializer = property.getInitializer();
@@ -764,7 +764,7 @@ function toClassName(str: string) {
 function toPropertyName(str: string) {
   return str
     .replace(/([^a-zA-Z0-9])+(.)?/g, (_, __, chr) =>
-      chr ? chr.toUpperCase() : ''
+      chr ? chr.toUpperCase() : '',
     )
     .replace(/[^a-zA-Z\d]/g, '')
     .replace(/^([A-Z])/, (m) => m.toLowerCase())

--- a/packages/vite-plugin-angular/src/lib/authoring/frontmatter.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/frontmatter.ts
@@ -4,7 +4,7 @@ import { type VFile } from 'vfile';
 export async function getFrontmatterMetadata(
   content: string,
   id: string,
-  transforms: MarkdownTemplateTransform[]
+  transforms: MarkdownTemplateTransform[],
 ) {
   const fm: any = await import('front-matter');
   // The `default` property will be available in CommonJS environment, for instance,

--- a/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/markdown-transform.ts
@@ -4,7 +4,7 @@ import { type MarkedSetupService } from './marked-setup.service.js';
 
 export type MarkdownTemplateTransform = (
   content: string,
-  fileName: string
+  fileName: string,
 ) => string | Promise<string> | Promise<VFile>;
 
 let markedSetupServicePromise: undefined | Promise<MarkedSetupService>;
@@ -15,7 +15,7 @@ export const defaultMarkdownTemplateTransform: MarkdownTemplateTransform =
       // set immediately to prevent other calls from seeing markedSetupServicePromise as
       // undefined - can't use await here
       markedSetupServicePromise = import('./marked-setup.service.js').then(
-        ({ MarkedSetupService }) => new MarkedSetupService()
+        ({ MarkedSetupService }) => new MarkedSetupService(),
       );
     }
     // read template sections, parse markdown
@@ -24,7 +24,7 @@ export const defaultMarkdownTemplateTransform: MarkdownTemplateTransform =
     const mdContent = markedSetupService
       .getMarkedInstance()
       .parse(
-        content.replace(FRONTMATTER_REGEX, '')
+        content.replace(FRONTMATTER_REGEX, ''),
       ) as unknown as Promise<string>;
 
     return mdContent;

--- a/packages/vite-plugin-angular/src/lib/authoring/marked-setup.service.ts
+++ b/packages/vite-plugin-angular/src/lib/authoring/marked-setup.service.ts
@@ -96,7 +96,7 @@ export class MarkedSetupService {
           return Prism.highlight(
             code,
             diff ? Prism.languages['diff'] : Prism.languages[lang],
-            lang
+            lang,
           );
         },
       }),
@@ -107,7 +107,7 @@ export class MarkedSetupService {
         gfm: true,
         breaks: false,
         mangle: false,
-      }
+      },
     );
 
     this.marked = marked;

--- a/packages/vite-plugin-angular/src/lib/compiler-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler-plugin.ts
@@ -19,11 +19,11 @@ type EsbuildPlugin = NonNullable<EsbuildOptions['plugins']>[number];
 export function createCompilerPlugin(
   pluginOptions: CompilerPluginOptions,
   isTest: boolean,
-  closeTransformer: boolean
+  closeTransformer: boolean,
 ): EsbuildPlugin {
   const javascriptTransformer = new JavaScriptTransformer(
     { ...pluginOptions, jit: true },
-    1
+    1,
   );
 
   return {

--- a/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
@@ -304,7 +304,7 @@ describe('component-resolvers', () => {
         const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
 
         expect(
-          thePathsAreEqual(resolvedTemplateUrls, [actualUrl1, actualUrl2])
+          thePathsAreEqual(resolvedTemplateUrls, [actualUrl1, actualUrl2]),
         ).toBe(true);
       });
 

--- a/packages/vite-plugin-angular/src/lib/component-resolvers.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.ts
@@ -39,7 +39,7 @@ export class StyleUrlsResolver {
 
     const styleUrls = matchedStyleUrls.map((styleUrlPath) => {
       return `${styleUrlPath}|${normalizePath(
-        resolve(dirname(id), styleUrlPath)
+        resolve(dirname(id), styleUrlPath),
       )}`;
     });
 
@@ -52,7 +52,7 @@ function getTextByProperty(name: string, properties: PropertyAssignment[]) {
   return properties
     .filter((property) => property.getName() === name)
     .map((property) =>
-      property.getInitializer()?.getText().replace(/['"`]/g, '')
+      property.getInitializer()?.getText().replace(/['"`]/g, ''),
     )
     .filter((url): url is string => url !== undefined);
 }
@@ -61,14 +61,14 @@ export function getStyleUrls(code: string) {
   const project = new Project({ useInMemoryFileSystem: true });
   const sourceFile = project.createSourceFile('cmp.ts', code);
   const properties = sourceFile.getDescendantsOfKind(
-    SyntaxKind.PropertyAssignment
+    SyntaxKind.PropertyAssignment,
   );
   const styleUrl = getTextByProperty('styleUrl', properties);
   const styleUrls = properties
     .filter((property) => property.getName() === 'styleUrls')
     .map((property) => property.getInitializer() as ArrayLiteralExpression)
     .flatMap((array) =>
-      array.getElements().map((el) => el.getText().replace(/['"`]/g, ''))
+      array.getElements().map((el) => el.getText().replace(/['"`]/g, '')),
     );
 
   return [...styleUrls, ...styleUrl];
@@ -78,7 +78,7 @@ export function getTemplateUrls(code: string) {
   const project = new Project({ useInMemoryFileSystem: true });
   const sourceFile = project.createSourceFile('cmp.ts', code);
   const properties = sourceFile.getDescendantsOfKind(
-    SyntaxKind.PropertyAssignment
+    SyntaxKind.PropertyAssignment,
   );
   return getTextByProperty('templateUrl', properties);
 }
@@ -102,7 +102,7 @@ export class TemplateUrlsResolver {
 
     const templateUrlPaths = getTemplateUrls(code).map(
       (url) =>
-        `${url}|${normalizePath(resolve(dirname(id), url).replace(/\\/g, '/'))}`
+        `${url}|${normalizePath(resolve(dirname(id), url).replace(/\\/g, '/'))}`,
     );
 
     this.templateUrlsCache.set(id, { code, templateUrlPaths });

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -21,7 +21,7 @@ export function augmentHostWithResources(
   transform: (
     code: string,
     id: string,
-    options?: { ssr?: boolean }
+    options?: { ssr?: boolean },
   ) => ReturnType<any> | null,
   options: {
     inlineStylesExtension: string;
@@ -35,7 +35,7 @@ export function augmentHostWithResources(
     markdownTemplateTransforms?: MarkdownTemplateTransform[];
     inlineComponentStyles?: Map<string, string>;
     externalComponentStyles?: Map<string, string>;
-  }
+  },
 ) {
   const ts = require('typescript');
   const resourceHost = host as CompilerHost;
@@ -62,7 +62,7 @@ export function augmentHostWithResources(
             .replace('.analog.ts', '.analog')
             .replace('.agx.ts', '.agx')
             .replace('.ag.ts', '.ag'),
-          'utf-8'
+          'utf-8',
         );
         const source = compileAnalogFile(fileName, contents, options.isProd);
 
@@ -71,7 +71,7 @@ export function augmentHostWithResources(
           source,
           languageVersionOrOptions,
           onError as any,
-          ...(parameters as any)
+          ...(parameters as any),
         );
       }
 
@@ -80,7 +80,7 @@ export function augmentHostWithResources(
         fileName,
         languageVersionOrOptions,
         onError,
-        ...parameters
+        ...parameters,
       );
     };
 
@@ -202,7 +202,7 @@ export function augmentHostWithResources(
 
   resourceHost.resourceNameToFileName = function (
     resourceName,
-    containingFile
+    containingFile,
   ) {
     const resolvedPath = path.join(path.dirname(containingFile), resourceName);
 
@@ -243,7 +243,7 @@ export function augmentProgramWithVersioning(program: ts.Program): void {
 
 export function augmentHostWithCaching(
   host: ts.CompilerHost,
-  cache: Map<string, ts.SourceFile>
+  cache: Map<string, ts.SourceFile>,
 ): void {
   const baseGetSourceFile = host.getSourceFile;
   host.getSourceFile = function (
@@ -263,7 +263,7 @@ export function augmentHostWithCaching(
       languageVersion,
       onError,
       true,
-      ...parameters
+      ...parameters,
     );
 
     if (file) {
@@ -276,7 +276,7 @@ export function augmentHostWithCaching(
 
 export function mergeTransformers(
   first: ts.CustomTransformers,
-  second: ts.CustomTransformers
+  second: ts.CustomTransformers,
 ): ts.CustomTransformers {
   const result: ts.CustomTransformers = {};
 

--- a/packages/vite-plugin-angular/src/lib/utils/hmr-candidates.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/hmr-candidates.ts
@@ -25,7 +25,7 @@ import ts from 'typescript';
 export function collectHmrCandidates(
   modifiedFiles: Set<string>,
   { compiler }: ng.NgtscProgram,
-  staleSourceFiles: Map<string, ts.SourceFile> | undefined
+  staleSourceFiles: Map<string, ts.SourceFile> | undefined,
 ): Set<ts.ClassDeclaration> {
   const candidates = new Set<ts.ClassDeclaration>();
 
@@ -34,7 +34,7 @@ export function collectHmrCandidates(
     const templateFileNodes = compiler.getComponentsWithTemplateFile(file);
     if (templateFileNodes.size) {
       templateFileNodes.forEach((node) =>
-        candidates.add(node as ts.ClassDeclaration)
+        candidates.add(node as ts.ClassDeclaration),
       );
       continue;
     }
@@ -43,7 +43,7 @@ export function collectHmrCandidates(
     const styleFileNodes = compiler.getComponentsWithStyleFile(file);
     if (styleFileNodes.size) {
       styleFileNodes.forEach((node) =>
-        candidates.add(node as ts.ClassDeclaration)
+        candidates.add(node as ts.ClassDeclaration),
       );
       continue;
     }
@@ -66,7 +66,7 @@ export function collectHmrCandidates(
     const fileCandidates = analyzeFileUpdates(
       staleSource,
       updatedSource,
-      compiler
+      compiler,
     );
     if (fileCandidates) {
       fileCandidates.forEach((node) => candidates.add(node));
@@ -93,7 +93,7 @@ export function collectHmrCandidates(
 export function analyzeFileUpdates(
   stale: ts.SourceFile,
   updated: ts.SourceFile,
-  compiler: ng.NgtscProgram['compiler']
+  compiler: ng.NgtscProgram['compiler'],
 ): ts.ClassDeclaration[] | null {
   if (stale.statements.length !== updated.statements.length) {
     return null;
@@ -119,7 +119,7 @@ export function analyzeFileUpdates(
           updatedNode.heritageClauses,
           updated,
           staleNode.heritageClauses,
-          stale
+          stale,
         )
       ) {
         return null;
@@ -130,8 +130,8 @@ export function analyzeFileUpdates(
         updatedModifiers?.length !== staleModifiers?.length ||
         !updatedModifiers?.every((updatedModifier) =>
           staleModifiers?.some(
-            (staleModifier) => updatedModifier.kind === staleModifier.kind
-          )
+            (staleModifier) => updatedModifier.kind === staleModifier.kind,
+          ),
         )
       ) {
         return null;
@@ -161,13 +161,13 @@ export function analyzeFileUpdates(
         const metaDecoratorIndex = updatedDecorators?.indexOf(meta.decorator);
         assert(
           metaDecoratorIndex !== undefined,
-          'Component metadata decorator should always be present on component class.'
+          'Component metadata decorator should always be present on component class.',
         );
         const updatedDecoratorExpression = meta.decorator.expression;
         assert(
           ts.isCallExpression(updatedDecoratorExpression) &&
             updatedDecoratorExpression.arguments.length === 1,
-          'Component metadata decorator should contain a call expression with a single argument.'
+          'Component metadata decorator should contain a call expression with a single argument.',
         );
 
         // Check the matching stale index for the component decorator
@@ -193,7 +193,7 @@ export function analyzeFileUpdates(
             updatedDecoratorExpression.expression,
             updated,
             staleDecoratorExpression.expression,
-            stale
+            stale,
           )
         ) {
           return null;
@@ -205,7 +205,7 @@ export function analyzeFileUpdates(
             staleDecoratorExpression,
             stale,
             updatedDecoratorExpression,
-            updated
+            updated,
           )
         ) {
           return null;
@@ -217,7 +217,7 @@ export function analyzeFileUpdates(
             updatedNode.members,
             updated,
             staleNode.members,
-            stale
+            stale,
           )
         ) {
           // A change to a member outside a component's metadata is unsupported
@@ -265,7 +265,7 @@ function hasUnsupportedMetaUpdates(
   staleCall: ts.CallExpression,
   staleSource: ts.SourceFile,
   updatedCall: ts.CallExpression,
-  updatedSource: ts.SourceFile
+  updatedSource: ts.SourceFile,
 ): boolean {
   const staleObject = staleCall.arguments[0];
   const updatedObject = updatedCall.arguments[0];
@@ -317,7 +317,7 @@ function hasUnsupportedMetaUpdates(
         property.initializer,
         updatedSource,
         unsupportedFields[i++],
-        staleSource
+        staleSource,
       )
     ) {
       return true;
@@ -340,7 +340,7 @@ function equalRangeText(
   firstRange: ts.ReadonlyTextRange | undefined,
   firstSource: ts.SourceFile,
   secondRange: ts.ReadonlyTextRange | undefined,
-  secondSource: ts.SourceFile
+  secondSource: ts.SourceFile,
 ): boolean {
   // Check matching undefined values
   if (!firstRange || !secondRange) {

--- a/packages/vite-plugin-angular/src/test-setup.ts
+++ b/packages/vite-plugin-angular/src/test-setup.ts
@@ -12,5 +12,5 @@ import {
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/packages/vite-plugin-nitro/src/lib/build-server.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-server.ts
@@ -7,7 +7,7 @@ import { addPostRenderingHooks } from './hooks/post-rendering-hook.js';
 
 export async function buildServer(
   options?: Options,
-  nitroConfig?: NitroConfig
+  nitroConfig?: NitroConfig,
 ) {
   const nitro = await createNitro({
     dev: false,

--- a/packages/vite-plugin-nitro/src/lib/build-sitemap.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-sitemap.ts
@@ -14,7 +14,7 @@ export async function buildSitemap(
   config: UserConfig,
   sitemapConfig: SitemapConfig,
   routes: (string | undefined)[] | (() => Promise<(string | undefined)[]>),
-  outputDir: string
+  outputDir: string,
 ) {
   const routeList: string[] = await optionHasRoutes(routes);
 
@@ -57,7 +57,7 @@ function checkSlash(host: string): string {
 }
 
 async function optionHasRoutes(
-  routes: (string | undefined)[] | (() => Promise<(string | undefined)[]>)
+  routes: (string | undefined)[] | (() => Promise<(string | undefined)[]>),
 ): Promise<string[]> {
   let routeList: (string | undefined)[];
 

--- a/packages/vite-plugin-nitro/src/lib/hooks/post-rendering-hook.ts
+++ b/packages/vite-plugin-nitro/src/lib/hooks/post-rendering-hook.ts
@@ -2,7 +2,7 @@ import { Nitro, PrerenderRoute } from 'nitropack';
 
 export function addPostRenderingHooks(
   nitro: Nitro,
-  hooks: ((pr: PrerenderRoute) => Promise<void>)[]
+  hooks: ((pr: PrerenderRoute) => Promise<void>)[],
 ): void {
   hooks.forEach((hook: (preRoute: PrerenderRoute) => void) => {
     nitro.hooks.hook('prerender:generate', (route: PrerenderRoute) => {

--- a/packages/vite-plugin-nitro/src/lib/hooks/post-rendering-hooks.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/hooks/post-rendering-hooks.spec.ts
@@ -12,7 +12,7 @@ describe('postRenderingHook', () => {
   const nitroMock = {
     hooks: {
       hook: vi.fn((name: string, callback: (route: any) => void) =>
-        callback(genRoute)
+        callback(genRoute),
       ),
     },
   } as unknown as Nitro;

--- a/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
+++ b/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
@@ -44,12 +44,12 @@ export function devServerPlugin(options: Options): Plugin {
         viteServer.middlewares.use(async (req, res) => {
           let template = readFileSync(
             resolve(viteServer.config.root, index),
-            'utf-8'
+            'utf-8',
           );
 
           template = await viteServer.transformIndexHtml(
             req.originalUrl as string,
-            template
+            template,
           );
 
           try {
@@ -62,7 +62,7 @@ export function devServerPlugin(options: Options): Plugin {
               {
                 req,
                 res,
-              }
+              },
             );
 
             if (result instanceof Response) {
@@ -84,7 +84,7 @@ export function devServerPlugin(options: Options): Plugin {
                   <script type="module">
                     import { ErrorOverlay } from '/@vite/client'
                     document.body.appendChild(new ErrorOverlay(${JSON.stringify(
-                      prepareError(req, e)
+                      prepareError(req, e),
                     ).replace(/</g, '\\u003c')}))
                   </script>
                 </head>

--- a/packages/vite-plugin-nitro/src/lib/utils/get-content-files.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-content-files.ts
@@ -10,7 +10,7 @@ const require = createRequire(import.meta.url);
 export function getMatchingContentFilesWithFrontMatter(
   workspaceRoot: string,
   rootDir: string,
-  glob: string
+  glob: string,
 ): PrerenderContentFile[] {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const fg = require('fast-glob');

--- a/packages/vite-plugin-nitro/src/lib/utils/get-page-handlers.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-page-handlers.ts
@@ -21,10 +21,10 @@ export function getPageHandlers({
     [
       `${root}/src/app/pages/**/*.server.ts`,
       ...(additionalPagesDirs || []).map(
-        (dir) => `${workspaceRoot}${dir}/**/*.server.ts`
+        (dir) => `${workspaceRoot}${dir}/**/*.server.ts`,
       ),
     ],
-    { dot: true }
+    { dot: true },
   );
 
   const handlers: NitroEventHandler[] = endpointFiles.map((endpointFile) => {

--- a/packages/vite-plugin-nitro/src/lib/utils/load-esm.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/load-esm.ts
@@ -22,6 +22,6 @@ import { URL } from 'node:url';
  */
 export function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
   return new Function('modulePath', `return import(modulePath);`)(
-    modulePath
+    modulePath,
   ) as Promise<T>;
 }

--- a/packages/vite-plugin-nitro/src/lib/utils/register-dev-middleware.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/register-dev-middleware.ts
@@ -4,7 +4,7 @@ import fg from 'fast-glob';
 
 export async function registerDevServerMiddleware(
   root: string,
-  viteServer: ViteDevServer
+  viteServer: ViteDevServer,
 ) {
   const middlewareFiles = fg.sync([`${root}/src/server/middleware/**/*.ts`]);
 

--- a/packages/vite-plugin-nitro/src/lib/vite-nitro-plugin.spec.data.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-nitro-plugin.spec.data.ts
@@ -66,7 +66,7 @@ export async function runConfigAndCloseBundle(plugin: Plugin[]): Promise<void> {
   await (
     plugin[1].config as (
       config: UserConfig,
-      env: ConfigEnv
+      env: ConfigEnv,
     ) => Promise<UserConfig>
   )({}, { command: 'build' } as ConfigEnv);
   await (plugin[1].closeBundle as () => Promise<void>)();

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.spec.ts
@@ -63,7 +63,7 @@ describe('nitro', () => {
           handlers: expect.anything(),
           publicAssets: expect.anything(),
           serverAssets: expect.anything(),
-        }
+        },
       );
     });
 
@@ -95,7 +95,7 @@ describe('nitro', () => {
           handlers: expect.anything(),
           publicAssets: expect.anything(),
           serverAssets: expect.anything(),
-        }
+        },
       );
     });
 
@@ -123,7 +123,7 @@ describe('nitro', () => {
       // Assert
       expect(buildSSRAppImportSpy).toHaveBeenCalledWith(
         {},
-        { ssr: true, ...prerenderRoutes }
+        { ssr: true, ...prerenderRoutes },
       );
       expect(buildServerImportSpy).toHaveBeenCalledWith(
         { ssr: true, ...prerenderRoutes },
@@ -140,7 +140,7 @@ describe('nitro', () => {
           },
           publicAssets: expect.anything(),
           serverAssets: expect.anything(),
-        }
+        },
       );
       expect(buildSitemapImportSpy).not.toHaveBeenCalled();
     });
@@ -169,7 +169,7 @@ describe('nitro', () => {
       // Assert
       expect(buildSSRAppImportSpy).toHaveBeenCalledWith(
         {},
-        { ssr: true, ...prerenderRoutes }
+        { ssr: true, ...prerenderRoutes },
       );
 
       expect(buildServerImportSpy).toHaveBeenCalledWith(
@@ -185,14 +185,14 @@ describe('nitro', () => {
           handlers: expect.anything(),
           publicAssets: expect.anything(),
           serverAssets: expect.anything(),
-        }
+        },
       );
 
       expect(buildSitemapImportSpy).toHaveBeenCalledWith(
         {},
         { host: 'example.com' },
         prerenderRoutes.prerender.routes,
-        expect.anything()
+        expect.anything(),
       );
     });
 
@@ -238,7 +238,7 @@ describe('nitro', () => {
           // Assert
           expect(buildSSRAppImportSpy).toHaveBeenCalledWith(
             {},
-            { ssr: true, ...prerenderRoutes }
+            { ssr: true, ...prerenderRoutes },
           );
 
           expect(buildServerImportSpy).toHaveBeenCalledWith(
@@ -255,14 +255,14 @@ describe('nitro', () => {
               renderer: expect.anything(),
               handlers: expect.anything(),
               serverAssets: expect.anything(),
-            }
+            },
           );
 
           expect(buildSitemapImportSpy).toHaveBeenCalledWith(
             {},
             { host: 'example.com' },
             ['/blog', '/about', '/blog/first', '/blog/02-second'],
-            expect.anything()
+            expect.anything(),
           );
         });
       });
@@ -289,7 +289,7 @@ describe('nitro', () => {
             dir: '/custom-root-directory/dist/analog',
             publicDir: '/custom-root-directory/dist/analog/public',
           },
-        })
+        }),
       );
     });
 
@@ -313,7 +313,7 @@ describe('nitro', () => {
             publicDir:
               '/custom-root-directory/some-other-root-directory/analog/public',
           },
-        })
+        }),
       );
     });
 
@@ -336,7 +336,7 @@ describe('nitro', () => {
             dir: '/custom-root-directory/.vercel/output',
             publicDir: '/custom-root-directory/.vercel/output/static',
           },
-        })
+        }),
       );
     });
 
@@ -359,7 +359,7 @@ describe('nitro', () => {
             dir: '/custom-root-directory/.vercel/output',
             publicDir: '/custom-root-directory/.vercel/output/static',
           },
-        })
+        }),
       );
     });
 
@@ -383,7 +383,7 @@ describe('nitro', () => {
             dir: '/custom-root-directory/.vercel/output',
             publicDir: '/custom-root-directory/.vercel/output/static',
           },
-        })
+        }),
       );
     });
   });

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -65,7 +65,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
         const ssrEntryPath = resolve(
           options?.ssrBuildDir ||
             resolve(workspaceRoot, 'dist', rootDir, `ssr`),
-          `main.server${filePrefix ? '.js' : ''}`
+          `main.server${filePrefix ? '.js' : ''}`,
         );
         const ssrEntry = normalizePath(filePrefix + ssrEntryPath);
         const rendererEntry =
@@ -75,8 +75,8 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
               __dirname,
               `runtime/renderer${!options?.ssr ? '-client' : ''}${
                 filePrefix ? '.mjs' : ''
-              }`
-            )
+              }`,
+            ),
           );
 
         nitroConfig = {
@@ -88,19 +88,19 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
           scanDirs: [
             normalizePath(`${rootDir}/src/server`),
             ...(options?.additionalAPIDirs || []).map((dir) =>
-              normalizePath(`${workspaceRoot}${dir}`)
+              normalizePath(`${workspaceRoot}${dir}`),
             ),
           ],
           output: {
             dir: normalizePath(
-              resolve(workspaceRoot, 'dist', rootDir, 'analog')
+              resolve(workspaceRoot, 'dist', rootDir, 'analog'),
             ),
             publicDir: normalizePath(
-              resolve(workspaceRoot, 'dist', rootDir, 'analog/public')
+              resolve(workspaceRoot, 'dist', rootDir, 'analog/public'),
             ),
           },
           buildDir: normalizePath(
-            resolve(workspaceRoot, 'dist', rootDir, '.nitro')
+            resolve(workspaceRoot, 'dist', rootDir, '.nitro'),
           ),
           typescript: {
             generateTsConfig: false,
@@ -183,12 +183,12 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
           clientOutputPath = resolve(
             workspaceRoot,
             rootDir,
-            config.build?.outDir || 'dist/client'
+            config.build?.outDir || 'dist/client',
           );
         }
 
         const indexEntry = normalizePath(
-          resolve(clientOutputPath, 'index.html')
+          resolve(clientOutputPath, 'index.html'),
         );
 
         nitroConfig.alias = {
@@ -239,7 +239,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                   getMatchingContentFilesWithFrontMatter(
                     workspaceRoot,
                     rootDir,
-                    current.contentDir
+                    current.contentDir,
                   );
 
                 affectedFiles.forEach((f) => {
@@ -251,7 +251,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
 
                 return prev;
               },
-              []
+              [],
             );
           }
 
@@ -259,7 +259,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
             if (isWindows) {
               const indexContents = readFileSync(
                 normalizePath(join(clientOutputPath, 'index.html')),
-                'utf-8'
+                'utf-8',
               );
 
               // Write out the renderer manually because
@@ -286,7 +286,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                 });
                 return html;
               });
-              `
+              `,
               );
 
               nitroConfig.externals = {
@@ -318,7 +318,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
 
         nitroConfig = mergeConfig(
           nitroConfig,
-          nitroOptions as Record<string, any>
+          nitroOptions as Record<string, any>,
         );
       },
       async configureServer(viteServer: ViteDevServer) {
@@ -331,7 +331,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
           await build(nitro);
           viteServer.middlewares.use(
             apiPrefix,
-            toNodeListener(server.app as unknown as App)
+            toNodeListener(server.app as unknown as App),
           );
 
           viteServer.httpServer?.once('listening', () => {
@@ -347,7 +347,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
           }
 
           console.log(
-            `\n\nThe server endpoints are accessible under the "${apiPrefix}" path.`
+            `\n\nThe server endpoints are accessible under the "${apiPrefix}" path.`,
           );
         }
       },
@@ -373,14 +373,14 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
               config,
               options.prerender.sitemap,
               nitroConfig.prerender.routes,
-              clientOutputPath
+              clientOutputPath,
             );
           }
 
           await buildServer(options, nitroConfig);
 
           console.log(
-            `\n\nThe '@analogjs/platform' server has been successfully built.`
+            `\n\nThe '@analogjs/platform' server has been successfully built.`,
           );
         }
       },
@@ -415,14 +415,14 @@ const isVercelPreset = (buildPreset: string | undefined) =>
 
 const withVercelOutputAPI = (
   nitroConfig: NitroConfig | undefined,
-  workspaceRoot: string
+  workspaceRoot: string,
 ) => ({
   ...nitroConfig,
   output: {
     ...nitroConfig?.output,
     dir: normalizePath(resolve(workspaceRoot, '.vercel', 'output')),
     publicDir: normalizePath(
-      resolve(workspaceRoot, '.vercel', 'output/static')
+      resolve(workspaceRoot, '.vercel', 'output/static'),
     ),
   },
 });

--- a/packages/vitest-angular/README.md
+++ b/packages/vitest-angular/README.md
@@ -95,7 +95,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -112,7 +112,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 ```
 
@@ -188,7 +188,7 @@ describe('CardComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [CardComponent],
-    })
+    }),
   );
 
   beforeEach(() => {

--- a/packages/vitest-angular/setup-snapshots.ts
+++ b/packages/vitest-angular/setup-snapshots.ts
@@ -14,7 +14,7 @@ const customSnapshotSerializer = () => {
     indentation: any,
     depth: any,
     refs: any,
-    printer: any
+    printer: any,
   ): string {
     // `printer` is a function that serializes a value using existing plugins.
     return `${printer(
@@ -22,7 +22,7 @@ const customSnapshotSerializer = () => {
       config,
       indentation,
       depth,
-      refs
+      refs,
     )}`;
   }
   function test(val: any): boolean {
@@ -111,7 +111,7 @@ function fixtureVitestSerializer(fixture: any) {
 
   const selector = Reflect.getOwnPropertyDescriptor(
     componentType,
-    '__annotations__'
+    '__annotations__',
   )?.value[0].selector;
 
   if (componentType && componentType.propDecorators) {
@@ -129,7 +129,7 @@ function fixtureVitestSerializer(fixture: any) {
   // * Convert string data to HTML data
   const doc = new DOMParser().parseFromString(
     `<${selector} ${inputsData}>${divElement.innerHTML}</${selector}>`,
-    'text/html'
+    'text/html',
   );
 
   return doc.body.childNodes[0];

--- a/packages/vitest-angular/setup-zone.ts
+++ b/packages/vitest-angular/setup-zone.ts
@@ -78,13 +78,13 @@ const bindDescribe = (
   originalVitestFn: {
     apply: (
       arg0: any,
-      arg1: any[]
+      arg1: any[],
     ) => {
       (): any;
       new (): any;
       apply: { (arg0: any, arg1: any[]): any; new (): any };
     };
-  }
+  },
 ) =>
   function (...eachArgs: any) {
     return function (...args: any[]) {
@@ -103,13 +103,13 @@ const bindTest = (
   originalVitestFn: {
     apply: (
       arg0: any,
-      arg1: any[]
+      arg1: any[],
     ) => {
       (): any;
       new (): any;
       apply: { (arg0: any, arg1: any[]): any; new (): any };
     };
-  }
+  },
 ) =>
   function (...eachArgs: any) {
     return function (...args: any[]) {
@@ -131,11 +131,11 @@ const bindTest = (
   if (methodName === 'describe') {
     env[methodName].only = bindDescribe(
       originalvitestFn,
-      originalvitestFn.only
+      originalvitestFn.only,
     );
     env[methodName].skip = bindDescribe(
       originalvitestFn,
-      originalvitestFn.skip
+      originalvitestFn.skip,
     );
   }
 });

--- a/packages/vitest-angular/src/lib/builders/build/devkit.ts
+++ b/packages/vitest-angular/src/lib/builders/build/devkit.ts
@@ -1,6 +1,6 @@
 export async function getBuildApplicationFunction() {
   const { VERSION } = await (Function(
-    'return import("@angular/compiler-cli")'
+    'return import("@angular/compiler-cli")',
   )() as Promise<{ VERSION: { major: string; minor: string } }>);
 
   const angularVersion = Number(VERSION.major);
@@ -9,7 +9,7 @@ export async function getBuildApplicationFunction() {
 
   if (angularVersion < 16 || (angularVersion === 16 && angularMinor <= 2)) {
     throw new Error(
-      'This builder is not supported with versions earlier than Angular v16.2'
+      'This builder is not supported with versions earlier than Angular v16.2',
     );
   } else if (angularVersion >= 16 && angularVersion < 18) {
     const {

--- a/packages/vitest-angular/src/lib/builders/build/plugins/angular-memory-plugin.ts
+++ b/packages/vitest-angular/src/lib/builders/build/plugins/angular-memory-plugin.ts
@@ -19,10 +19,10 @@ interface AngularMemoryPluginOptions {
 }
 
 export async function createAngularMemoryPlugin(
-  options: AngularMemoryPluginOptions
+  options: AngularMemoryPluginOptions,
 ) {
   const { normalizePath } = await (Function(
-    'return import("vite")'
+    'return import("vite")',
   )() as Promise<typeof import('vite')>);
   const { outputFiles, external } = options;
   let config;

--- a/packages/vitest-angular/src/lib/builders/build/plugins/esbuild-downlevel-plugin.ts
+++ b/packages/vitest-angular/src/lib/builders/build/plugins/esbuild-downlevel-plugin.ts
@@ -1,6 +1,6 @@
 export async function esbuildDownlevelPlugin() {
   const { transformWithEsbuild } = await (Function(
-    'return import("vite")'
+    'return import("vite")',
   )() as Promise<typeof import('vite')>);
   return {
     name: 'analogs-vitest-esbuild-downlevel-plugin',

--- a/packages/vitest-angular/src/lib/builders/build/vitest.impl.ts
+++ b/packages/vitest-angular/src/lib/builders/build/vitest.impl.ts
@@ -20,7 +20,7 @@ process.env['VITE_CJS_IGNORE_WARNING'] = 'true';
 
 async function* vitestApplicationBuilder(
   options: VitestSchema,
-  context: any
+  context: any,
 ): AsyncIterable<{ success: boolean }> {
   process.env['TEST'] = 'true';
   process.env['VITEST'] = 'true';
@@ -28,7 +28,7 @@ async function* vitestApplicationBuilder(
   const { buildApplicationInternal, angularVersion } =
     await getBuildApplicationFunction();
   const { startVitest } = await (Function(
-    'return import("vitest/node")'
+    'return import("vitest/node")',
   )() as Promise<typeof import('vitest/node')>);
 
   const projectConfig = await context.getProjectMetadata(context.target);
@@ -103,7 +103,7 @@ async function* vitestApplicationBuilder(
         vendor: false,
       },
     },
-    context
+    context,
   )) {
     if (buildOutput.kind === ResultKind.Failure) {
       return { success: false };
@@ -144,7 +144,7 @@ async function* vitestApplicationBuilder(
 }
 
 export async function getExtraArgs(
-  options: VitestSchema
+  options: VitestSchema,
 ): Promise<Record<string, any>> {
   // support passing extra args to Vitest CLI
   const schema = await import('./schema.json');
@@ -168,7 +168,7 @@ function findIncludes(options: {
   const { normalizePath } = require('vite');
 
   const projectRoot = normalizePath(
-    path.resolve(options.workspaceRoot, options.projectRoot)
+    path.resolve(options.workspaceRoot, options.projectRoot),
   );
   const globs = [...options.include.map((glob) => `${projectRoot}/${glob}`)];
 
@@ -202,14 +202,14 @@ function generateEntryPoints({
           testFile.startsWith(projectRoot)
             ? projectRoot
             : context.workspaceRoot,
-          testFile
+          testFile,
         )
         .replace(/^[./]+/, '_')
         .replace(/\//g, '-');
 
       let uniqueName = `spec-${path.basename(
         relativePath,
-        path.extname(relativePath)
+        path.extname(relativePath),
       )}`;
       let suffix = 2;
       while (seen.has(uniqueName)) {
@@ -219,7 +219,7 @@ function generateEntryPoints({
       seen.add(uniqueName);
 
       return [uniqueName, testFile];
-    })
+    }),
   );
 }
 

--- a/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
+++ b/packages/vitest-angular/src/lib/builders/test/vitest.impl.ts
@@ -8,17 +8,17 @@ import { VitestSchema } from './schema';
 
 async function vitestBuilder(
   options: VitestSchema,
-  context: BuilderContext
+  context: BuilderContext,
 ): Promise<BuilderOutput> {
   process.env['TEST'] = 'true';
   process.env['VITEST'] = 'true';
 
   const { startVitest } = await (Function(
-    'return import("vitest/node")'
+    'return import("vitest/node")',
   )() as Promise<typeof import('vitest/node')>);
 
   const projectConfig = await context.getProjectMetadata(
-    context.target as unknown as string
+    context.target as unknown as string,
   );
   const { coverageArgs, ...extraArgs } = await getExtraArgs(options);
   const watch = options.watch === true;
@@ -66,7 +66,7 @@ async function vitestBuilder(
 }
 
 export async function getExtraArgs(
-  options: VitestSchema
+  options: VitestSchema,
 ): Promise<Record<string, any>> {
   // support passing extra args to Vitest CLI
   const schema = await import('./schema.json');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
         specifier: ~10.1.3
         version: 10.1.3(postcss@8.4.38)
       prettier:
-        specifier: ^2.8.3
-        version: 2.8.3
+        specifier: ^3.4.2
+        version: 3.4.2
       prismjs:
         specifier: ^1.29.0
         version: 1.29.0
@@ -359,7 +359,7 @@ importers:
         version: 6.0.1
       rollup-plugin-visualizer:
         specifier: ^5.9.0
-        version: 5.9.0(rollup@4.26.0)
+        version: 5.9.0(rollup@4.24.4)
       satori:
         specifier: ^0.10.14
         version: 0.10.14
@@ -407,7 +407,7 @@ importers:
         version: 1.8.1(eslint@8.57.0)(vite@6.0.11(@types/node@18.19.15)(jiti@2.4.0)(less@4.1.3)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0)(yaml@2.5.1))
       vite-plugin-inspect:
         specifier: ~0.8
-        version: 0.8.9(rollup@4.26.0)(vite@6.0.11(@types/node@18.19.15)(jiti@2.4.0)(less@4.1.3)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0)(yaml@2.5.1))
+        version: 0.8.9(rollup@4.24.4)(vite@6.0.11(@types/node@18.19.15)(jiti@2.4.0)(less@4.1.3)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0)(yaml@2.5.1))
       vite-tsconfig-paths:
         specifier: 4.2.0
         version: 4.2.0(typescript@5.5.4)(vite@6.0.11(@types/node@18.19.15)(jiti@2.4.0)(less@4.1.3)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0)(yaml@2.5.1))
@@ -9687,6 +9687,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isfunction@3.0.9:
     resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
@@ -11908,9 +11909,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@2.8.3:
-    resolution: {integrity: sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==}
-    engines: {node: '>=10.13.0'}
+  prettier@3.4.2:
+    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-bytes@5.6.0:
@@ -29833,7 +29834,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@2.8.3: {}
+  prettier@3.4.2: {}
 
   pretty-bytes@5.6.0: {}
 
@@ -30574,14 +30575,14 @@ snapshots:
     optionalDependencies:
       rollup: 4.26.0
 
-  rollup-plugin-visualizer@5.9.0(rollup@4.26.0):
+  rollup-plugin-visualizer@5.9.0(rollup@4.24.4):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
-      rollup: 4.26.0
+      rollup: 4.24.4
 
   rollup@2.79.1:
     optionalDependencies:
@@ -32365,10 +32366,10 @@ snapshots:
       rollup: 2.79.1
       vite: 6.0.11(@types/node@18.19.15)(jiti@2.4.0)(less@4.1.3)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0)(yaml@2.5.1)
 
-  vite-plugin-inspect@0.8.9(rollup@4.26.0)(vite@6.0.11(@types/node@18.19.15)(jiti@2.4.0)(less@4.1.3)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0)(yaml@2.5.1)):
+  vite-plugin-inspect@0.8.9(rollup@4.24.4)(vite@6.0.11(@types/node@18.19.15)(jiti@2.4.0)(less@4.1.3)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0)(yaml@2.5.1)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.4(rollup@4.26.0)
+      '@rollup/pluginutils': 5.1.4(rollup@4.24.4)
       debug: 4.4.0(supports-color@9.4.0)
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0

--- a/server.mjs
+++ b/server.mjs
@@ -18,14 +18,14 @@ async function createServer() {
       resolve('dist/apps/analog-app/client'),
       {
         index: false,
-      }
-    )
+      },
+    ),
   );
 
   app.use(
     '/api',
     (await import(resolve('dist/apps/analog-app/server/server/index.mjs')))
-      .listener
+      .listener,
   );
 
   app.use('*', async (req, res, next) => {
@@ -34,7 +34,7 @@ async function createServer() {
     try {
       const template = fs.readFileSync(
         path.resolve(__dirname, 'dist/apps/analog-app/client/index.html'),
-        'utf-8'
+        'utf-8',
       );
 
       const render = (

--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -27,7 +27,7 @@ const [, , name, version, tag = 'next'] = process.argv;
 const validVersion = /^\d+\.\d+\.\d+(-\w+\.\d+)?/;
 invariant(
   version && validVersion.test(version),
-  `No version provided or version did not match Semantic Versioning, expected: #.#.#-tag.# or #.#.#, got ${version}.`
+  `No version provided or version did not match Semantic Versioning, expected: #.#.#-tag.# or #.#.#, got ${version}.`,
 );
 
 const graph = readCachedProjectGraph();
@@ -35,13 +35,13 @@ const project = graph.nodes[name];
 
 invariant(
   project,
-  `Could not find project "${name}" in the workspace. Is the project.json configured correctly?`
+  `Could not find project "${name}" in the workspace. Is the project.json configured correctly?`,
 );
 
 const outputPath = project.data?.targets?.build?.options?.outputPath;
 invariant(
   outputPath,
-  `Could not find "build.options.outputPath" of project "${name}". Is project.json configured  correctly?`
+  `Could not find "build.options.outputPath" of project "${name}". Is project.json configured  correctly?`,
 );
 
 process.chdir(outputPath);
@@ -53,7 +53,9 @@ try {
   writeFileSync(`package.json`, JSON.stringify(json, null, 2));
 } catch (e) {
   console.error(
-    chalk.bold.red(`Error reading package.json file from library build output.`)
+    chalk.bold.red(
+      `Error reading package.json file from library build output.`,
+    ),
   );
 }
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

For reviewers, the 4th commit includes the automated prettier changes. Please review commits except the 4th to avoid loading all changes.
- Upgrade prettier to support new Angular syntax of `@if`, `@for`, and `@let`.
- Other changes seem to be with Prettier changing some default configs of printWidth, always adding a comma at the end, and supporting semicolon insertion at the end of `import .. as { type: 'analog' }`
- I decreased `printWidth` for markdown files to `80` for a better viewing experience in the docs. I've seen this commonly done in many other docs websites, and since the Prettier upgrade was modifying them anyway, I thought this would be a good time to introduce this change.
- Updated broken profile URL (mine) in the allcontributers file 😅

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

![image](https://github.com/user-attachments/assets/017b4d77-ca1f-49e2-8e99-fc6f6966e808)
