### PR TITLE
Fix vitest watch mode

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -8,50 +8,44 @@ describe('angularVitePlugin', () => {
 });
 
 describe('isTestWatchMode', () => {
-  it('should return false if vitest command not included in the command', () => {
-    const result = isTestWatchMode('vite');
-
-    expect(result).toBeFalsy();
-  });
-
   it('should return false for vitest --run', () => {
-    const result = isTestWatchMode('vitest', ['--run']);
+    const result = isTestWatchMode(['--run']);
 
     expect(result).toBeFalsy();
   });
 
   it('should return true for vitest --no-run', () => {
-    const result = isTestWatchMode('vitest', ['--no-run']);
+    const result = isTestWatchMode(['--no-run']);
 
     expect(result).toBeTruthy();
   });
 
   it('should return true for vitest --watch', () => {
-    const result = isTestWatchMode('vitest', ['--watch']);
+    const result = isTestWatchMode(['--watch']);
 
     expect(result).toBeTruthy();
   });
 
   it('should return true for vitest watch', () => {
-    const result = isTestWatchMode('vitest', ['watch']);
+    const result = isTestWatchMode(['watch']);
 
     expect(result).toBeTruthy();
   });
 
   it('should return false for vitest --no-watch', () => {
-    const result = isTestWatchMode('vitest', ['--no-watch']);
+    const result = isTestWatchMode(['--no-watch']);
 
     expect(result).toBeFalsy();
   });
 
   it('should return false for vitest --watch=false', () => {
-    const result = isTestWatchMode('vitest', ['--watch=false']);
+    const result = isTestWatchMode(['--watch=false']);
 
     expect(result).toBeFalsy();
   });
 
   it('should return false for vitest --watch false', () => {
-    const result = isTestWatchMode('vitest', ['--watch', 'false']);
+    const result = isTestWatchMode(['--watch', 'false']);
 
     expect(result).toBeFalsy();
   });

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -94,7 +94,7 @@ interface EmitFileResult {
 }
 type FileEmitter = (
   file: string,
-  source?: ts.SourceFile,
+  source?: ts.SourceFile
 ) => Promise<EmitFileResult | undefined>;
 
 /**
@@ -169,7 +169,7 @@ export function angular(options?: PluginOptions): Plugin[] {
   let viteServer: ViteDevServer | undefined;
   let styleTransform: (
     code: string,
-    filename: string,
+    filename: string
   ) => ReturnType<typeof preprocessCSS> | undefined;
 
   const styleUrlsResolver = new StyleUrlsResolver();
@@ -200,7 +200,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             config.root || '.',
             process.env['NODE_ENV'] === 'test'
               ? './tsconfig.spec.json'
-              : './tsconfig.app.json',
+              : './tsconfig.app.json'
           );
 
         return {
@@ -219,7 +219,7 @@ export function angular(options?: PluginOptions): Plugin[] {
                     incremental: watchMode,
                   },
                   isTest,
-                  !isAstroIntegration,
+                  !isAstroIntegration
                 ),
               ],
               define: {
@@ -237,15 +237,17 @@ export function angular(options?: PluginOptions): Plugin[] {
       configResolved(config) {
         resolvedConfig = config;
 
-        // set test watch mode
-        // - vite override from vitest-angular
-        // - @nx/vite executor set server.watch explicitly to undefined (watch)/null (watch=false)
-        // - vite config for test.watch variable
-        // - vitest watch mode detected from the command line
-        testWatchMode =
-          !(config.server.watch === null) ||
-          config.test?.watch === true ||
-          testWatchMode;
+        if (isTest) {
+          // set test watch mode
+          // - vite override from vitest-angular
+          // - @nx/vite executor set server.watch explicitly to undefined (watch)/null (watch=false)
+          // - vite config for test.watch variable
+          // - vitest watch mode detected from the command line
+          testWatchMode =
+            !(config.server.watch === null) ||
+            config.test?.watch === true ||
+            testWatchMode;
+        }
       },
       configureServer(server) {
         viteServer = server;
@@ -262,7 +264,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           const angularComponentMiddleware: Connect.HandleFunction = async (
             req: Connect.IncomingMessage,
             res: ServerResponse<Connect.IncomingMessage>,
-            next: Connect.NextFunction,
+            next: Connect.NextFunction
           ) => {
             if (req.url === undefined || res.writableEnded) {
               return;
@@ -349,7 +351,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           ) {
             const relativeFileId = `${relative(
               process.cwd(),
-              fileId,
+              fileId
             )}@${classNames.get(fileId)}`;
 
             sendHMRComponentUpdate(ctx.server, relativeFileId);
@@ -370,7 +372,7 @@ export function angular(options?: PluginOptions): Plugin[] {
            * for an external resource (styles, html).
            */
           const isDirect = ctx.modules.find(
-            (mod) => ctx.file === mod.file && mod.id?.includes('?direct'),
+            (mod) => ctx.file === mod.file && mod.id?.includes('?direct')
           );
           if (isDirect) {
             if (pluginOptions.liveReload && isDirect?.id && isDirect.file) {
@@ -378,7 +380,7 @@ export function angular(options?: PluginOptions): Plugin[] {
                 isDirect.type === 'css' && isComponentStyleSheet(isDirect.id);
               if (isComponentStyle) {
                 const { encapsulation } = getComponentStyleSheetMeta(
-                  isDirect.id,
+                  isDirect.id
                 );
 
                 // Track if the component uses ShadowDOM encapsulation
@@ -436,7 +438,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             updates.forEach((updateId) => {
               const impRelativeFileId = `${relative(
                 process.cwd(),
-                updateId,
+                updateId
               )}@${classNames.get(updateId)}`;
 
               sendHMRComponentUpdate(ctx.server, impRelativeFileId);
@@ -462,14 +464,14 @@ export function angular(options?: PluginOptions): Plugin[] {
         if (id.startsWith('angular:jit:')) {
           const path = id.split(';')[1];
           return `${normalizePath(
-            resolve(dirname(importer as string), path),
+            resolve(dirname(importer as string), path)
           )}?raw`;
         }
 
         // Map angular external styleUrls to the source file
         if (isComponentStyleSheet(id)) {
           const componentStyles = externalComponentStyles?.get(
-            getFilenameFromPath(id),
+            getFilenameFromPath(id)
           );
           if (componentStyles) {
             return componentStyles + new URL(id, 'http://localhost').search;
@@ -482,7 +484,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         // Map angular inline styles to the source text
         if (isComponentStyleSheet(id)) {
           const componentStyles = inlineComponentStyles?.get(
-            getFilenameFromPath(id),
+            getFilenameFromPath(id)
           );
           if (componentStyles) {
             return componentStyles;
@@ -504,8 +506,8 @@ export function angular(options?: PluginOptions): Plugin[] {
           const result = await fileEmitter?.(
             resolve(
               process.cwd(),
-              decodeURIComponent(componentId).split('@')[0],
-            ),
+              decodeURIComponent(componentId).split('@')[0]
+            )
           );
 
           return result?.hmrUpdateCode || '';
@@ -618,7 +620,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           if (jit && data.includes('angular:jit:')) {
             data = data.replace(
               /angular:jit:style:inline;/g,
-              'virtual:angular:jit:style:inline;',
+              'virtual:angular:jit:style:inline;'
             );
 
             templateUrls.forEach((templateUrlSet) => {
@@ -626,7 +628,7 @@ export function angular(options?: PluginOptions): Plugin[] {
                 templateUrlSet.split('|');
               data = data.replace(
                 `angular:jit:template:file;${templateFile}`,
-                `${resolvedTemplateUrl}?raw`,
+                `${resolvedTemplateUrl}?raw`
               );
             });
 
@@ -634,7 +636,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               const [styleFile, resolvedStyleUrl] = styleUrlSet.split('|');
               data = data.replace(
                 `angular:jit:style:file;${styleFile}`,
-                `${resolvedStyleUrl}?inline`,
+                `${resolvedStyleUrl}?inline`
               );
             });
           }
@@ -661,7 +663,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               const metadata = await getFrontmatterMetadata(
                 code,
                 id,
-                pluginOptions.markdownTemplateTransforms || [],
+                pluginOptions.markdownTemplateTransforms || []
               );
               data += metadata;
             }
@@ -710,7 +712,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
     const fg = require('fast-glob');
     const appRoot = normalizePath(
-      resolve(pluginOptions.workspaceRoot, config.root || '.'),
+      resolve(pluginOptions.workspaceRoot, config.root || '.')
     );
     const workspaceRoot = normalizePath(resolve(pluginOptions.workspaceRoot));
 
@@ -718,10 +720,10 @@ export function angular(options?: PluginOptions): Plugin[] {
       `${appRoot}/**/*.{analog,agx,ag}`,
       ...extraGlobs.map((glob) => `${workspaceRoot}${glob}.{analog,agx,ag}`),
       ...(pluginOptions.additionalContentDirs || [])?.map(
-        (glob) => `${workspaceRoot}${glob}/**/*.agx`,
+        (glob) => `${workspaceRoot}${glob}/**/*.agx`
       ),
       ...pluginOptions.include.map((glob) =>
-        `${workspaceRoot}${glob}`.replace(/\.ts$/, '.analog'),
+        `${workspaceRoot}${glob}`.replace(/\.ts$/, '.analog')
       ),
     ];
 
@@ -828,7 +830,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         rootNames,
         compilerOptions,
         host as CompilerHost,
-        nextProgram as any,
+        nextProgram as any
       );
       angularCompiler = angularProgram.compiler;
       typeScriptProgram = angularProgram.getTsProgram();
@@ -838,7 +840,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         ts.createEmitAndSemanticDiagnosticsBuilderProgram(
           typeScriptProgram,
           host,
-          builderProgram,
+          builderProgram
         );
 
       await angularCompiler.analyzeAsync();
@@ -850,7 +852,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           rootNames,
           compilerOptions,
           host,
-          nextProgram as any,
+          nextProgram as any
         );
 
       typeScriptProgram = builder.getProgram();
@@ -872,7 +874,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             ...(jit
               ? [
                   compilerCli.constructorParametersDownlevelTransform(
-                    builder.getProgram(),
+                    builder.getProgram()
                   ),
                   createJitResourceTransformer(getTypeChecker),
                 ]
@@ -883,12 +885,12 @@ export function angular(options?: PluginOptions): Plugin[] {
           afterDeclarations:
             pluginOptions.advanced.tsTransformers.afterDeclarations,
         },
-        jit ? {} : angularCompiler!.prepareEmit().transformers,
+        jit ? {} : angularCompiler!.prepareEmit().transformers
       ),
       () => [],
       angularCompiler!,
       pluginOptions.liveReload,
-      pluginOptions.disableTypeChecking,
+      pluginOptions.disableTypeChecking
     );
   }
 }
@@ -908,7 +910,7 @@ export function createFileEmitter(
   onAfterEmit?: (sourceFile: ts.SourceFile) => void,
   angularCompiler?: NgtscProgram['compiler'],
   liveReload?: boolean,
-  disableTypeChecking?: boolean,
+  disableTypeChecking?: boolean
 ): FileEmitter {
   return async (file: string, stale?: ts.SourceFile) => {
     const sourceFile = program.getSourceFile(file);
@@ -920,7 +922,7 @@ export function createFileEmitter(
       const hmrEligible = !!analyzeFileUpdates(
         stale,
         sourceFile,
-        angularCompiler!,
+        angularCompiler!
       );
       return { dependencies: [], hmrEligible };
     }
@@ -929,7 +931,7 @@ export function createFileEmitter(
       sourceFile,
       !!disableTypeChecking,
       program,
-      angularCompiler,
+      angularCompiler
     );
 
     const errors = diagnostics
@@ -937,7 +939,7 @@ export function createFileEmitter(
       .map((d) =>
         typeof d.messageText === 'object'
           ? d.messageText.messageText
-          : d.messageText,
+          : d.messageText
       );
 
     const warnings = diagnostics
@@ -965,7 +967,7 @@ export function createFileEmitter(
       },
       undefined /* cancellationToken */,
       undefined /* emitOnlyDtsFiles */,
-      transformers,
+      transformers
     );
 
     onAfterEmit?.(sourceFile);
@@ -978,7 +980,7 @@ function getDiagnosticsForSourceFile(
   sourceFile: ts.SourceFile,
   disableTypeChecking: boolean,
   program: ts.BuilderProgram,
-  angularCompiler?: NgtscProgram['compiler'],
+  angularCompiler?: NgtscProgram['compiler']
 ) {
   const syntacticDiagnostics = program.getSyntacticDiagnostics(sourceFile);
 
@@ -1046,17 +1048,7 @@ function getFilenameFromPath(id: string): string {
  * Checks for vitest run from the command line
  * @returns boolean
  */
-export function isTestWatchMode(
-  command = process.env['_'],
-  args = process.argv,
-) {
-  const isVitestCommand = command?.includes('vitest');
-
-  // vitest command was not used
-  if (!isVitestCommand) {
-    return false;
-  }
-
+export function isTestWatchMode(args = process.argv) {
   // vitest --run
   const hasRun = args.find((arg) => arg.includes('--run'));
   if (hasRun) {

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -94,7 +94,7 @@ interface EmitFileResult {
 }
 type FileEmitter = (
   file: string,
-  source?: ts.SourceFile
+  source?: ts.SourceFile,
 ) => Promise<EmitFileResult | undefined>;
 
 /**
@@ -169,7 +169,7 @@ export function angular(options?: PluginOptions): Plugin[] {
   let viteServer: ViteDevServer | undefined;
   let styleTransform: (
     code: string,
-    filename: string
+    filename: string,
   ) => ReturnType<typeof preprocessCSS> | undefined;
 
   const styleUrlsResolver = new StyleUrlsResolver();
@@ -200,7 +200,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             config.root || '.',
             process.env['NODE_ENV'] === 'test'
               ? './tsconfig.spec.json'
-              : './tsconfig.app.json'
+              : './tsconfig.app.json',
           );
 
         return {
@@ -219,7 +219,7 @@ export function angular(options?: PluginOptions): Plugin[] {
                     incremental: watchMode,
                   },
                   isTest,
-                  !isAstroIntegration
+                  !isAstroIntegration,
                 ),
               ],
               define: {
@@ -264,7 +264,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           const angularComponentMiddleware: Connect.HandleFunction = async (
             req: Connect.IncomingMessage,
             res: ServerResponse<Connect.IncomingMessage>,
-            next: Connect.NextFunction
+            next: Connect.NextFunction,
           ) => {
             if (req.url === undefined || res.writableEnded) {
               return;
@@ -351,7 +351,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           ) {
             const relativeFileId = `${relative(
               process.cwd(),
-              fileId
+              fileId,
             )}@${classNames.get(fileId)}`;
 
             sendHMRComponentUpdate(ctx.server, relativeFileId);
@@ -372,7 +372,7 @@ export function angular(options?: PluginOptions): Plugin[] {
            * for an external resource (styles, html).
            */
           const isDirect = ctx.modules.find(
-            (mod) => ctx.file === mod.file && mod.id?.includes('?direct')
+            (mod) => ctx.file === mod.file && mod.id?.includes('?direct'),
           );
           if (isDirect) {
             if (pluginOptions.liveReload && isDirect?.id && isDirect.file) {
@@ -380,7 +380,7 @@ export function angular(options?: PluginOptions): Plugin[] {
                 isDirect.type === 'css' && isComponentStyleSheet(isDirect.id);
               if (isComponentStyle) {
                 const { encapsulation } = getComponentStyleSheetMeta(
-                  isDirect.id
+                  isDirect.id,
                 );
 
                 // Track if the component uses ShadowDOM encapsulation
@@ -438,7 +438,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             updates.forEach((updateId) => {
               const impRelativeFileId = `${relative(
                 process.cwd(),
-                updateId
+                updateId,
               )}@${classNames.get(updateId)}`;
 
               sendHMRComponentUpdate(ctx.server, impRelativeFileId);
@@ -464,14 +464,14 @@ export function angular(options?: PluginOptions): Plugin[] {
         if (id.startsWith('angular:jit:')) {
           const path = id.split(';')[1];
           return `${normalizePath(
-            resolve(dirname(importer as string), path)
+            resolve(dirname(importer as string), path),
           )}?raw`;
         }
 
         // Map angular external styleUrls to the source file
         if (isComponentStyleSheet(id)) {
           const componentStyles = externalComponentStyles?.get(
-            getFilenameFromPath(id)
+            getFilenameFromPath(id),
           );
           if (componentStyles) {
             return componentStyles + new URL(id, 'http://localhost').search;
@@ -484,7 +484,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         // Map angular inline styles to the source text
         if (isComponentStyleSheet(id)) {
           const componentStyles = inlineComponentStyles?.get(
-            getFilenameFromPath(id)
+            getFilenameFromPath(id),
           );
           if (componentStyles) {
             return componentStyles;
@@ -506,8 +506,8 @@ export function angular(options?: PluginOptions): Plugin[] {
           const result = await fileEmitter?.(
             resolve(
               process.cwd(),
-              decodeURIComponent(componentId).split('@')[0]
-            )
+              decodeURIComponent(componentId).split('@')[0],
+            ),
           );
 
           return result?.hmrUpdateCode || '';
@@ -620,7 +620,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           if (jit && data.includes('angular:jit:')) {
             data = data.replace(
               /angular:jit:style:inline;/g,
-              'virtual:angular:jit:style:inline;'
+              'virtual:angular:jit:style:inline;',
             );
 
             templateUrls.forEach((templateUrlSet) => {
@@ -628,7 +628,7 @@ export function angular(options?: PluginOptions): Plugin[] {
                 templateUrlSet.split('|');
               data = data.replace(
                 `angular:jit:template:file;${templateFile}`,
-                `${resolvedTemplateUrl}?raw`
+                `${resolvedTemplateUrl}?raw`,
               );
             });
 
@@ -636,7 +636,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               const [styleFile, resolvedStyleUrl] = styleUrlSet.split('|');
               data = data.replace(
                 `angular:jit:style:file;${styleFile}`,
-                `${resolvedStyleUrl}?inline`
+                `${resolvedStyleUrl}?inline`,
               );
             });
           }
@@ -663,7 +663,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               const metadata = await getFrontmatterMetadata(
                 code,
                 id,
-                pluginOptions.markdownTemplateTransforms || []
+                pluginOptions.markdownTemplateTransforms || [],
               );
               data += metadata;
             }
@@ -712,7 +712,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
     const fg = require('fast-glob');
     const appRoot = normalizePath(
-      resolve(pluginOptions.workspaceRoot, config.root || '.')
+      resolve(pluginOptions.workspaceRoot, config.root || '.'),
     );
     const workspaceRoot = normalizePath(resolve(pluginOptions.workspaceRoot));
 
@@ -720,10 +720,10 @@ export function angular(options?: PluginOptions): Plugin[] {
       `${appRoot}/**/*.{analog,agx,ag}`,
       ...extraGlobs.map((glob) => `${workspaceRoot}${glob}.{analog,agx,ag}`),
       ...(pluginOptions.additionalContentDirs || [])?.map(
-        (glob) => `${workspaceRoot}${glob}/**/*.agx`
+        (glob) => `${workspaceRoot}${glob}/**/*.agx`,
       ),
       ...pluginOptions.include.map((glob) =>
-        `${workspaceRoot}${glob}`.replace(/\.ts$/, '.analog')
+        `${workspaceRoot}${glob}`.replace(/\.ts$/, '.analog'),
       ),
     ];
 
@@ -830,7 +830,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         rootNames,
         compilerOptions,
         host as CompilerHost,
-        nextProgram as any
+        nextProgram as any,
       );
       angularCompiler = angularProgram.compiler;
       typeScriptProgram = angularProgram.getTsProgram();
@@ -840,7 +840,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         ts.createEmitAndSemanticDiagnosticsBuilderProgram(
           typeScriptProgram,
           host,
-          builderProgram
+          builderProgram,
         );
 
       await angularCompiler.analyzeAsync();
@@ -852,7 +852,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           rootNames,
           compilerOptions,
           host,
-          nextProgram as any
+          nextProgram as any,
         );
 
       typeScriptProgram = builder.getProgram();
@@ -874,7 +874,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             ...(jit
               ? [
                   compilerCli.constructorParametersDownlevelTransform(
-                    builder.getProgram()
+                    builder.getProgram(),
                   ),
                   createJitResourceTransformer(getTypeChecker),
                 ]
@@ -885,12 +885,12 @@ export function angular(options?: PluginOptions): Plugin[] {
           afterDeclarations:
             pluginOptions.advanced.tsTransformers.afterDeclarations,
         },
-        jit ? {} : angularCompiler!.prepareEmit().transformers
+        jit ? {} : angularCompiler!.prepareEmit().transformers,
       ),
       () => [],
       angularCompiler!,
       pluginOptions.liveReload,
-      pluginOptions.disableTypeChecking
+      pluginOptions.disableTypeChecking,
     );
   }
 }
@@ -910,7 +910,7 @@ export function createFileEmitter(
   onAfterEmit?: (sourceFile: ts.SourceFile) => void,
   angularCompiler?: NgtscProgram['compiler'],
   liveReload?: boolean,
-  disableTypeChecking?: boolean
+  disableTypeChecking?: boolean,
 ): FileEmitter {
   return async (file: string, stale?: ts.SourceFile) => {
     const sourceFile = program.getSourceFile(file);
@@ -922,7 +922,7 @@ export function createFileEmitter(
       const hmrEligible = !!analyzeFileUpdates(
         stale,
         sourceFile,
-        angularCompiler!
+        angularCompiler!,
       );
       return { dependencies: [], hmrEligible };
     }
@@ -931,7 +931,7 @@ export function createFileEmitter(
       sourceFile,
       !!disableTypeChecking,
       program,
-      angularCompiler
+      angularCompiler,
     );
 
     const errors = diagnostics
@@ -939,7 +939,7 @@ export function createFileEmitter(
       .map((d) =>
         typeof d.messageText === 'object'
           ? d.messageText.messageText
-          : d.messageText
+          : d.messageText,
       );
 
     const warnings = diagnostics
@@ -967,7 +967,7 @@ export function createFileEmitter(
       },
       undefined /* cancellationToken */,
       undefined /* emitOnlyDtsFiles */,
-      transformers
+      transformers,
     );
 
     onAfterEmit?.(sourceFile);
@@ -980,7 +980,7 @@ function getDiagnosticsForSourceFile(
   sourceFile: ts.SourceFile,
   disableTypeChecking: boolean,
   program: ts.BuilderProgram,
-  angularCompiler?: NgtscProgram['compiler']
+  angularCompiler?: NgtscProgram['compiler'],
 ) {
   const syntacticDiagnostics = program.getSyntacticDiagnostics(sourceFile);
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Instead of checking for the `vitest` command when executed, check for the `isTest` which checks the proper environment variables already being set when running Vitest.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
