### PR TITLE
fix(vitest-angular): expand semver range of @angular-devkit/architect

### DIFF
--- a/packages/vitest-angular/package.json
+++ b/packages/vitest-angular/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@analogjs/vite-plugin-angular": "*",
-    "@angular-devkit/architect": "^0.1500.0 || ^0.1600.0 || ^0.1700.0 || ^0.1800.0 || ^0.1900.0 || next",
+    "@angular-devkit/architect": ">=0.1500.0 < 0.2000.0",
     "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0"
   },
   "ng-update": {


### PR DESCRIPTION
## PR Checklist

Closes #1609 

## What is the new behavior?

Expand version range of @angular-devkit/architect to include 0.1901.x

## Does this PR introduce a breaking change?

- [x] No
