### PR TITLE
fix(router): set full parent path for route path on debug page

### DIFF
--- a/packages/router/src/lib/debug/debug.page.ts
+++ b/packages/router/src/lib/debug/debug.page.ts
@@ -131,7 +131,10 @@ export default class DebugRoutesComponent {
       });
 
       if (route.children) {
-        this.traverseRoutes(route.children, route.path || '');
+        const parentSegments = [parent, route.path];
+
+        const fullParentPath = parentSegments.filter((s) => !!s).join('/');
+        this.traverseRoutes(route.children, fullParentPath);
       }
     });
   }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On the route debug page, nested route paths are displayed with incorrect parent paths. When nesting routes using folders instead of dot notation in filenames (e.g., `foo.bar.baz.page.ts`), the Route Path column in the debug page does not reflect the correct structure.

### Expected Behavior
If `baz.page.ts` is placed inside the `foo/bar/` directory, the expected route should be `/foo/bar/baz`, which works correctly when accessed.

### Actual Behavior
The route is accessible as expected, but the debug page incorrectly displays it as `/bar/baz`, as if it is missing its full parent path:

<img width="936" alt="Screenshot 2025-03-03 at 12 24 16" src="https://github.com/user-attachments/assets/1d36aa59-1452-46c4-a842-0b823620d4e0" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
