### PR TITLE
fix(nx-plugin): overwrite files array when setting up Vitest

### DIFF
--- a/packages/nx-plugin/src/generators/init/lib/update-test-tsconfig.ts
+++ b/packages/nx-plugin/src/generators/init/lib/update-test-tsconfig.ts
@@ -33,7 +33,7 @@ export function updateTestTsConfig(
         json.compilerOptions.module = undefined;
         json.compilerOptions.target ??= 'es2016';
         json.compilerOptions.types = ['vitest/globals', 'node'];
-        json.files ??= ['src/test-setup.ts'];
+        json.files = ['src/test-setup.ts'];
 
         return json;
       },

--- a/packages/nx-plugin/src/generators/setup-vitest/lib/update-tsconfig.ts
+++ b/packages/nx-plugin/src/generators/setup-vitest/lib/update-tsconfig.ts
@@ -29,7 +29,7 @@ export function updateTsConfig(tree: Tree, schema: SetupVitestGeneratorSchema) {
         json.compilerOptions ??= {};
         json.compilerOptions.module = undefined;
         json.compilerOptions.target ??= 'es2016';
-        json.files ??= ['src/test-setup.ts'];
+        json.files = ['src/test-setup.ts'];
         json.compilerOptions.types = (json.compilerOptions.types ?? ['node'])
           .filter((type) => type !== 'jest')
           .concat(['vitest/globals']);


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1645 

## What is the new behavior?

When running the schematic to setup Vitest or migrate to Analog w/Vitest, the `files` array in the `tsconfig.spec.json` is set to the new `src/test-setup.ts` file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
