### PR TITLE
feat(vite-plugin-nitro): allow customization of sitemap definition for prerendered routes

### DIFF
--- a/apps/blog-app/vite.config.ts
+++ b/apps/blog-app/vite.config.ts
@@ -3,6 +3,7 @@
 import analog, { type PrerenderContentFile } from '@analogjs/platform';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { defineConfig } from 'vite';
+import fs from 'node:fs';
 
 // Only run in Netlify CI
 let base = process.env['URL'] || 'http://localhost:3000';
@@ -52,7 +53,14 @@ export default defineConfig(() => {
               '/blog',
               '/about',
               '/api/rss.xml',
-              '/blog/2022-12-27-my-first-post',
+              {
+                route: '/blog/2022-12-27-my-first-post',
+                sitemap: () => {
+                  return {
+                    lastmod: '2022-12-27',
+                  };
+                },
+              },
               '/blog/my-second-post',
               '/about-me',
               '/about-you',
@@ -63,6 +71,12 @@ export default defineConfig(() => {
                     return false;
                   }
                   return `/archived/${file.attributes.slug || file.name}`;
+                },
+                sitemap: (file: PrerenderContentFile) => {
+                  console.log(file.name);
+                  return {
+                    changefreq: 'never',
+                  };
                 },
               },
             ];

--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -1,6 +1,11 @@
 import type { PluginOptions } from '@analogjs/vite-plugin-angular';
 import type { NitroConfig, PrerenderRoute } from 'nitropack';
-import type { SitemapConfig } from '@analogjs/vite-plugin-nitro';
+import type {
+  SitemapConfig,
+  PrerenderContentDir,
+  PrerenderContentFile,
+  PrerenderRouteConfig,
+} from '@analogjs/vite-plugin-nitro';
 
 import { ContentPluginOptions } from './content-plugin.js';
 
@@ -24,8 +29,10 @@ export interface PrerenderOptions {
    * List of routes to prerender resolved statically or dynamically.
    */
   routes?:
-    | (string | PrerenderContentDir)[]
-    | (() => Promise<(string | PrerenderContentDir | undefined)[]>);
+    | (string | PrerenderContentDir | PrerenderRouteConfig)[]
+    | (() => Promise<
+        (string | PrerenderContentDir | PrerenderRouteConfig | undefined)[]
+      >);
   sitemap?: SitemapConfig;
   /** List of functions that run for each route after pre-rendering is complete. */
   postRenderingHooks?: ((routes: PrerenderRoute) => Promise<void>)[];
@@ -81,31 +88,4 @@ export interface Options {
   disableTypeChecking?: boolean;
 }
 
-export interface PrerenderContentDir {
-  /**
-   * The directory or glob pattern where the files should be grabbed from.
-   * @example `/src/contents/blog`
-   */
-  contentDir: string;
-  /**
-   * Transform the matching content files path into a route.
-   * The function is called for each matching content file within the specified contentDir.
-   * @param file information of the matching file (`path`, `name`, `extension`, `attributes`)
-   * @returns a string with the route should be returned (e. g. `/blog/<slug>`) or the value `false`, when the route should not be prerendered.
-   */
-  transform: (file: PrerenderContentFile) => string | false;
-}
-
-/**
- * @param path the path to the content file
- * @param name the basename of the matching content file without the file extension
- * @param extension the file extension
- * @param attributes the frontmatter attributes extracted from the frontmatter section of the file
- * @returns a string with the route should be returned (e. g. `/blog/<slug>`) or the value `false`, when the route should not be prerendered.
- */
-export interface PrerenderContentFile {
-  path: string;
-  attributes: Record<string, any>;
-  name: string;
-  extension: string;
-}
+export { PrerenderContentDir, PrerenderContentFile };

--- a/packages/vite-plugin-nitro/src/index.ts
+++ b/packages/vite-plugin-nitro/src/index.ts
@@ -1,5 +1,11 @@
 import { nitro } from './lib/vite-plugin-nitro.js';
-export { Options, SitemapConfig } from './lib/options.js';
+export {
+  Options,
+  SitemapConfig,
+  PrerenderRouteConfig,
+  PrerenderContentDir,
+  PrerenderContentFile,
+} from './lib/options.js';
 
 declare module 'nitropack' {
   interface NitroRouteConfig {

--- a/packages/vite-plugin-nitro/src/lib/options.ts
+++ b/packages/vite-plugin-nitro/src/lib/options.ts
@@ -43,8 +43,10 @@ export interface PrerenderOptions {
    * List of routes to prerender resolved statically or dynamically.
    */
   routes?:
-    | (string | PrerenderContentDir)[]
-    | (() => Promise<(string | PrerenderContentDir | undefined)[]>);
+    | (string | PrerenderContentDir | PrerenderRouteConfig)[]
+    | (() => Promise<
+        (string | PrerenderContentDir | PrerenderRouteConfig | undefined)[]
+      >);
   sitemap?: SitemapConfig;
   /** List of functions that run for each route after pre-rendering is complete. */
   postRenderingHooks?: ((routes: PrerenderRoute) => Promise<void>)[];
@@ -67,6 +69,15 @@ export interface PrerenderContentDir {
    * @returns a string with the route should be returned (e. g. `/blog/<slug>`) or the value `false`, when the route should not be prerendered.
    */
   transform: (file: PrerenderContentFile) => string | false;
+
+  /**
+   * Customize the sitemap definition for the prerendered route
+   *
+   * https://www.sitemaps.org/protocol.html#xmlTagDefinitions
+   */
+  sitemap?:
+    | PrerenderSitemapConfig
+    | ((file: PrerenderContentFile) => PrerenderSitemapConfig);
 }
 
 /**
@@ -81,4 +92,27 @@ export interface PrerenderContentFile {
   attributes: Record<string, any>;
   name: string;
   extension: string;
+}
+
+export interface PrerenderSitemapConfig {
+  lastmod?: string;
+  changefreq?:
+    | 'always'
+    | 'hourly'
+    | 'daily'
+    | 'weekly'
+    | 'monthly'
+    | 'yearly'
+    | 'never';
+  priority?: string;
+}
+
+export interface PrerenderRouteConfig {
+  route: string;
+  /**
+   * Customize the sitemap definition for the prerendered route
+   *
+   * https://www.sitemaps.org/protocol.html#xmlTagDefinitions
+   */
+  sitemap?: PrerenderSitemapConfig | (() => PrerenderSitemapConfig);
 }

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -13,6 +13,8 @@ import {
   Options,
   PrerenderContentDir,
   PrerenderContentFile,
+  PrerenderRouteConfig,
+  PrerenderSitemapConfig,
 } from './options.js';
 import { pageEndpointsPlugin } from './plugins/page-endpoints.js';
 import { getPageHandlers } from './utils/get-page-handlers.js';
@@ -44,6 +46,10 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
   let nitroConfig: NitroConfig;
   let environmentBuild = false;
   let hasAPIDir = false;
+  let routeSitemaps: Record<
+    string,
+    PrerenderSitemapConfig | (() => PrerenderSitemapConfig)
+  > = {};
 
   return [
     (options?.ssr
@@ -236,7 +242,12 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
             nitroConfig.prerender = nitroConfig.prerender ?? {};
             nitroConfig.prerender.crawlLinks = options?.prerender?.discover;
 
-            let routes: (string | PrerenderContentDir | undefined)[] = [];
+            let routes: (
+              | string
+              | PrerenderContentDir
+              | PrerenderRouteConfig
+              | undefined
+            )[] = [];
 
             const prerenderRoutes = options?.prerender?.routes;
             if (
@@ -256,6 +267,16 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                   prev.push(current);
                   return prev;
                 }
+
+                if ('route' in current) {
+                  if (current.sitemap) {
+                    routeSitemaps[current.route] = current.sitemap;
+                  }
+
+                  prev.push(current.route);
+                  return prev;
+                }
+
                 const affectedFiles: PrerenderContentFile[] =
                   getMatchingContentFilesWithFrontMatter(
                     workspaceRoot,
@@ -265,7 +286,15 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
 
                 affectedFiles.forEach((f) => {
                   const result = current.transform(f);
+
                   if (result) {
+                    if (current.sitemap) {
+                      routeSitemaps[result] =
+                        current.sitemap && typeof current.sitemap === 'function'
+                          ? current.sitemap?.(f)
+                          : current.sitemap;
+                    }
+
                     prev.push(result);
                   }
                 });
@@ -388,6 +417,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                   options.prerender.sitemap,
                   nitroConfig.prerender.routes,
                   nitroConfig.output?.publicDir!,
+                  routeSitemaps,
                 );
               }
 
@@ -468,6 +498,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
               options.prerender.sitemap,
               nitroConfig.prerender.routes,
               clientOutputPath,
+              routeSitemaps,
             );
           }
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1525
Closes #1599 

## What is the new behavior?

The `prerender.routes` array can include an object that defines the `route` and `sitemap` properties for customizing the sitemap definition for the prerendered route.

```ts
import { defineConfig } from 'vite';
import analog from '@analogjs/platform';
import fs from 'node:fs';

// https://vitejs.dev/config/
export default defineConfig(({ mode }) => ({
  plugins: [
    analog({
      prerender: {
        sitemap: {
          host: 'https://analogjs.org/',
        },
        routes: async () => [
          '/',
          '/blog',
          {
            route: '/blog/2022-12-27-my-first-post',
            sitemap: {
              lastmod: '2022-12-27',
            },
          },
          {
            contentDir: '/src/content/archived',
            transform: (file: PrerenderContentFile) => {
              return `/archived/${file.attributes.slug || file.name}`;
            },
            sitemap: (file: PrerenderContentFile) => {
              return {
                lastmod: 'read last modified date for content file',
                changefreq: 'never',
              };
            },
          },
        ],
      },
    }),
  ],
}));
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcjZvZGN6NHU5Ym8wZGI5bno5cHE1MDdpYWM2MHprOTIzdWhoZnNxbSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/m9jfWpENWq5dZ2L5W9/giphy.gif"/>