### PR TITLE
perf(vite-plugin-nitro): remove server assets from build process

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -229,12 +229,6 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
 
         if (isBuild) {
           nitroConfig.publicAssets = [{ dir: clientOutputPath }];
-          nitroConfig.serverAssets = [
-            {
-              baseName: 'public',
-              dir: clientOutputPath,
-            },
-          ];
           nitroConfig.renderer = rendererEntry;
 
           if (isEmptyPrerenderRoutes(options)) {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Public assets were being bundled into the server build through the `nitro.serverAssets` build option, but were never exposed through storage. This removes server assets from the build process, decreasing the bundle size and overall build time. The public assets are still served when static file servers such as node are used.

analog-app build before was 4.77MB 1.1MB gzipped, and is now 3.1MB 685kb gzipped.

This should decrease memory usage also as the files are no longer bundled.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdleHpqNGd4Z3JzaDJkczBieTM1d3FxamQ2N3lhcnB1bTE4Z3E2cnA3ZSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/a1LKL1ytUKKiUAx3HR/giphy.gif"/>