### PR TITLE
fix(vite-plugin-angular): update angular-storybook-plugin with @storybook/angular v8.6.8+

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-storybook-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-storybook-plugin.ts
@@ -5,13 +5,13 @@ export function angularStorybookPlugin() {
       if (code.includes('"@storybook/angular"')) {
         return code.replace(
           /\"@storybook\/angular\"/g,
-          '"@storybook/angular/dist/client"',
+          '"@storybook/angular/dist/client/index.js"',
         );
       }
       if (code.includes("'@storybook/angular'")) {
         return code.replace(
           /\'@storybook\/angular\'/g,
-          "'@storybook/angular/dist/client'",
+          "'@storybook/angular/dist/client/index.js'",
         );
       }
 


### PR DESCRIPTION
## PR Checklist

Updates angular-storybook-plugin to work with the new package.json exports introduced in @storybook/angular v8.6.9

Closes #1657

## What is the new behavior?

None

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
