### PR TITLE
fix(vite-plugin-nitro): disable internal autoImports by default

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ pnpm-lock.yaml
 /.nx/workspace-data
 /packages/create-analog/template-*
 .vite-inspect
+.all-contributorsrc

--- a/packages/vite-plugin-nitro/src/lib/vite-nitro-plugin.spec.data.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-nitro-plugin.spec.data.ts
@@ -29,6 +29,9 @@ export const mockNitroConfig: NitroConfig = {
   typescript: {
     generateTsConfig: false,
   },
+  imports: {
+    autoImport: false,
+  },
   rollupConfig: {
     plugins: [
       {

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -132,6 +132,10 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
             apiPrefix: apiPrefix.substring(1),
             prefix,
           },
+          // Fixes support for Rolldown
+          imports: {
+            autoImport: false,
+          },
           rollupConfig: {
             onwarn(warning) {
               if (


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The internal `autoImports` flag is disabled, as we do not expose auto-imports by default. This also helps with compatibility when using Rolldown with Vite. 

To enable manually:

```ts
/// <reference types="vitest" />

import { defineConfig } from 'vite';
import analog from '@analogjs/platform';

// https://vitejs.dev/config/
export default defineConfig(({ mode }) => ({
  build: {
    target: ['es2020']
  },
  resolve: {
    mainFields: ['module'],
  },
  plugins: [
    analog({
      nitro: {
        imports: {
          autoImport: true
        },        
      }
    })
  ],
  test: {
    globals: true,
    environment: 'jsdom',
    setupFiles: ['src/test-setup.ts'],
    include: ['**/*.spec.ts'],
    reporters: ['default'],
  },
  define: {
    'import.meta.vitest': mode !== 'production',
  },
}));
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMHNqZzZoeWRwbXE2MTF1NDgxY3N1cDd3bXdndGtueXF5azZrZDJ5aCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/lcySndwSDLxC4eOU86/giphy.gif"/>
