### PR TITLE
fix(vite-plugin-angular): reenables test bed and jit mode for partial compilations

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -787,6 +787,12 @@ export function angular(options?: PluginOptions): Plugin[] {
       tsCompilerOptions['supportTestBed'] = true;
     }
 
+    if (tsCompilerOptions.compilationMode === 'partial') {
+      // These options can't be false in partial mode
+      tsCompilerOptions.supportTestBed = true;
+      tsCompilerOptions.supportJitMode = true;
+    }
+
     rootNames = rn.concat(analogFiles, includeFiles);
     compilerOptions = tsCompilerOptions;
     host = ts.createIncrementalCompilerHost(compilerOptions);

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -789,8 +789,8 @@ export function angular(options?: PluginOptions): Plugin[] {
 
     if (tsCompilerOptions.compilationMode === 'partial') {
       // These options can't be false in partial mode
-      tsCompilerOptions.supportTestBed = true;
-      tsCompilerOptions.supportJitMode = true;
+      tsCompilerOptions['supportTestBed'] = true;
+      tsCompilerOptions['supportJitMode'] = true;
     }
 
     rootNames = rn.concat(analogFiles, includeFiles);


### PR DESCRIPTION
## PR Checklist

When trying to build with `"complationMode": "partial"` set in `tsconfig.json`, the following errors occur:

```
vite v6.2.5 building for production...
✓ 0 modules transformed.
✗ Build failed in 1.19s
error during build:
[@analogjs/vite-plugin-angular] TestBed support ("supportTestBed" option) cannot be disabled in partial compilation mode.
    at NgCompiler.makeCompilation (file:///Users/.../node_modules/@angular/compiler-cli/bundles/chunk-UJU2GLGZ.js:4224:13)
    at file:///Users/.../node_modules/@angular/compiler-cli/bundles/chunk-UJU2GLGZ.js:3838:31
    at ActivePerfRecorder.inPhase (file:///Users/.../node_modules/@angular/compiler-cli/bundles/chunk-Q2WE7ECN.js:142:14)
    at NgCompiler.analyzeAsync (file:///Users/.../node_modules/@angular/compiler-cli/bundles/chunk-UJU2GLGZ.js:3837:29)
    at buildAndAnalyze (file:///Users/.../node_modules/@analogjs/vite-plugin-angular/src/lib/angular-vite-plugin.js:593:35)
    at Object.buildStart (file:///Users/.../node_modules/@analogjs/vite-plugin-angular/src/lib/angular-vite-plugin.js:200:23)
    at Object.handler (file:///Users/.../node_modules/vite/dist/node/chunks/dep-Pj_jxEzN.js:51802:15)
    at file:///Users/.../node_modules/rollup/dist/es/shared/node-entry.js:21835:40
    at async Promise.all (index 5)
    at async PluginDriver.hookParallel (file:///Users/.../node_modules/rollup/dist/es/shared/node-entry.js:21763:9)
```

```
vite v6.2.5 building for production...
✓ 0 modules transformed.
✗ Build failed in 1.07s
error during build:
[@analogjs/vite-plugin-angular] JIT mode support ("supportJitMode" option) cannot be disabled in partial compilation mode.
    at NgCompiler.makeCompilation (file:///Users/.../node_modules/@angular/compiler-cli/bundles/chunk-UJU2GLGZ.js:4227:13)
    at file:///Users/.../node_modules/@angular/compiler-cli/bundles/chunk-UJU2GLGZ.js:3838:31
    at ActivePerfRecorder.inPhase (file:///Users/.../node_modules/@angular/compiler-cli/bundles/chunk-Q2WE7ECN.js:142:14)
    at NgCompiler.analyzeAsync (file:///Users/.../node_modules/@angular/compiler-cli/bundles/chunk-UJU2GLGZ.js:3837:29)
    at buildAndAnalyze (file:///Users/.../node_modules/@analogjs/vite-plugin-angular/src/lib/angular-vite-plugin.js:593:35)
    at Object.buildStart (file:///Users/.../node_modules/@analogjs/vite-plugin-angular/src/lib/angular-vite-plugin.js:200:23)
    at Object.handler (file:///Users/.../node_modules/vite/dist/node/chunks/dep-Pj_jxEzN.js:51802:15)
    at file:///Users/.../node_modules/rollup/dist/es/shared/node-entry.js:21835:40
    at async Promise.all (index 5)
    at async PluginDriver.hookParallel (file:///Users/.../node_modules/rollup/dist/es/shared/node-entry.js:21763:9)
```

## What is the new behavior?

This PR ensures these options are enabled when the `tsCompilerOptions.compilationMode` is resolved to `partial`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This change is useful when building component libraries you wish to share via npm that should support a range of Angular versions.

## What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

![glorious-purpose](https://github.com/user-attachments/assets/13934cf6-5a92-4f06-a588-4bc731ace375)
