### PR TITLE
feat(vite-plugin-nitro): make source root configurable/optional

### DIFF
--- a/packages/vite-plugin-nitro/README.md
+++ b/packages/vite-plugin-nitro/README.md
@@ -6,6 +6,7 @@ A lightweight [Vite](https://vite.dev) plugin for integrating with [Nitro](https
 - Build-time Pre-rendering
 - Static Site Generation
 - API routes
+- Sitemaps
 
 ## Install
 
@@ -86,6 +87,29 @@ export default defineEventHandler(() => ({ message: 'Hello World' }));
 ```
 
 The API route can be accessed as `/api/v1/hello`.
+
+## Custom Source Root Directory
+
+By default, the `src` folder is used as the path for the discovery of server files and API routes. You can customize the folder with the `sourceRoot` option.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import nitro from '@analogjs/vite-plugin-nitro';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    nitro({
+      ssr: true,
+      entryServer: 'app/main.server.tsx',
+      sourceRoot: 'app',
+    }),
+  ],
+});
+```
+
+With this configuration, API routes are discovered under the `app/server/routes/api` directory. You can also make the it optional by setting the `sourceRoot` to `'.'`;
 
 ## Examples
 

--- a/packages/vite-plugin-nitro/src/lib/build-ssr.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-ssr.ts
@@ -5,6 +5,7 @@ import { Options } from './options.js';
 
 export async function buildSSRApp(config: UserConfig, options?: Options) {
   const workspaceRoot = options?.workspaceRoot ?? process.cwd();
+  const sourceRoot = options?.sourceRoot ?? 'src';
   const rootDir = relative(workspaceRoot, config.root || '.') || '.';
   const ssrBuildConfig = mergeConfig(config, {
     build: {
@@ -12,7 +13,7 @@ export async function buildSSRApp(config: UserConfig, options?: Options) {
       rollupOptions: {
         input:
           options?.entryServer ||
-          resolve(workspaceRoot, rootDir, 'src/main.server.ts'),
+          resolve(workspaceRoot, rootDir, `${sourceRoot}/main.server.ts`),
       },
       outDir:
         options?.ssrBuildDir || resolve(workspaceRoot, 'dist', rootDir, 'ssr'),

--- a/packages/vite-plugin-nitro/src/lib/options.ts
+++ b/packages/vite-plugin-nitro/src/lib/options.ts
@@ -10,6 +10,13 @@ export interface Options {
   prerender?: PrerenderOptions;
   entryServer?: string;
   index?: string;
+  /**
+   * Relative path to source files. Default is 'src'.
+   */
+  sourceRoot?: string;
+  /**
+   * Absolute path to workspace root. Default is 'process.cwd()'
+   */
   workspaceRoot?: string;
   /**
    * Additional page paths to include

--- a/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
+++ b/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
@@ -22,7 +22,8 @@ type ServerOptions = Options & { routeRules?: Record<string, any> | undefined };
 
 export function devServerPlugin(options: ServerOptions): Plugin {
   const workspaceRoot = options?.workspaceRoot || process.cwd();
-  const entryServer = options.entryServer || 'src/main.server.ts';
+  const sourceRoot = options?.sourceRoot ?? 'src';
+  const entryServer = options.entryServer || `${sourceRoot}/main.server.ts`;
   const index = options.index || 'index.html';
   let config: UserConfig;
   let root: string;
@@ -49,7 +50,7 @@ export function devServerPlugin(options: ServerOptions): Plugin {
 
       return async () => {
         remove_html_middlewares(viteServer.middlewares);
-        registerDevServerMiddleware(root, viteServer);
+        registerDevServerMiddleware(root, sourceRoot, viteServer);
 
         viteServer.middlewares.use(async (req, res) => {
           let template = readFileSync(

--- a/packages/vite-plugin-nitro/src/lib/utils/get-page-handlers.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-page-handlers.ts
@@ -6,6 +6,7 @@ import { normalizePath } from 'vite';
 
 type GetHandlersArgs = {
   workspaceRoot: string;
+  sourceRoot: string;
   rootDir: string;
   additionalPagesDirs?: string[];
   hasAPIDir?: boolean;
@@ -13,6 +14,7 @@ type GetHandlersArgs = {
 
 export function getPageHandlers({
   workspaceRoot,
+  sourceRoot,
   rootDir,
   additionalPagesDirs,
   hasAPIDir,
@@ -21,7 +23,7 @@ export function getPageHandlers({
 
   const endpointFiles: string[] = fg.sync(
     [
-      `${root}/src/app/pages/**/*.server.ts`,
+      `${root}/${sourceRoot}/app/pages/**/*.server.ts`,
       ...(additionalPagesDirs || []).map(
         (dir) => `${workspaceRoot}${dir}/**/*.server.ts`,
       ),

--- a/packages/vite-plugin-nitro/src/lib/utils/register-dev-middleware.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/register-dev-middleware.ts
@@ -4,9 +4,12 @@ import fg from 'fast-glob';
 
 export async function registerDevServerMiddleware(
   root: string,
+  sourceRoot: string,
   viteServer: ViteDevServer,
 ) {
-  const middlewareFiles = fg.sync([`${root}/src/server/middleware/**/*.ts`]);
+  const middlewareFiles = fg.sync([
+    `${root}/${sourceRoot}/server/middleware/**/*.ts`,
+  ]);
 
   middlewareFiles.forEach((file) => {
     viteServer.middlewares.use(async (req, res, next) => {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1672 

## What is the new behavior?

- By default, the Nitro plugin looks at the `src` directory for server API routes. This adds the `sourceRoot` option to make this configurable to a different directory, or optional by setting it to `.`.
- Added docs for the new option.
- Fixes a bug where it throws an error when using `vite build` with SSR disabled and no server entry file setup, as it still tried to build the ssr environment.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/YPzvV7N0Cnlbbrigvp/giphy.gif?cid=bd3ea57evp9t6dotglkxucml4r027xx4piy2869e3t1gmygp&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>