### PR TITLE
docs: Fixed typo, `server-side-rendering.md`

### DIFF
--- a/apps/docs-app/docs/features/server/server-side-rendering.md
+++ b/apps/docs-app/docs/features/server/server-side-rendering.md
@@ -29,7 +29,7 @@ For more information about externals with SSR, check out the [Vite documentation
 
 ## Hybrid Rendering with Client-Only Routes
 
-SSR is enabled by default. For a hybrid approach, you can specific some routes to only be rendered client-side, and not be server side rendered. This is done through the `routeRules` configuration object by specifying an `ssr` option.
+SSR is enabled by default. For a hybrid approach, you can specify certain routes to only be rendered client-side, and not be server side rendered. This is done through the `routeRules` configuration object by specifying an `ssr` option.
 
 ```ts
 import { defineConfig } from 'vite';


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There was a typo in the documentation at [Hybrid Rendering with Client-Only Routes](https://analogjs.org/docs/features/server/server-side-rendering#hybrid-rendering-with-client-only-routes) .
... you can **specific some** routes to ...
Closes #---

## What is the new behavior?
The typo is now fixed.
.. you can **specify certain** routes to ...
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

