### PR TITLE
fix(vite-plugin-nitro): fix behavior when opting out of prerendering

### DIFF
--- a/apps/docs-app/docs/features/server/server-side-rendering.md
+++ b/apps/docs-app/docs/features/server/server-side-rendering.md
@@ -29,7 +29,7 @@ For more information about externals with SSR, check out the [Vite documentation
 
 ## Hybrid Rendering with Client-Only Routes
 
-SSR is enabled by default. For a hybrid approach, you can specific some routes to only be rendered client-side, and not be server side rendered. This is done through the `routeRules` configuration object by specifying an `ssr` option.
+SSR is enabled by default. For a hybrid approach, you can specify some routes to only be rendered client-side, and not be server side rendered. This is done through the `routeRules` configuration object by specifying an `ssr` option.
 
 ```ts
 import { defineConfig } from 'vite';
@@ -94,24 +94,18 @@ export default defineConfig(({ mode }) => ({
 }));
 ```
 
-You can opt out of prerendering by passing an empty array of routes and disabling prerender on the root route.
+You can opt-out of prerendering altogether by passing an empty array of routes.
 
 ```js
 import { defineConfig } from 'vite';
 import analog from '@analogjs/platform';
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   // ...other config
   plugins: [
     analog({
       ssr: true,
-      nitro: {
-        routeRules: {
-          '/': {
-            prerender: false,
-          },
-        },
-      },
       prerender: {
         routes: async () => {
           return [];

--- a/packages/vite-plugin-nitro/src/lib/build-server.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-server.ts
@@ -25,9 +25,10 @@ export async function buildServer(
   if (
     options?.ssr &&
     nitroConfig?.prerender?.routes &&
-    nitroConfig?.prerender?.routes.find((route) => route === '/')
+    (nitroConfig?.prerender?.routes.find((route) => route === '/') ||
+      nitroConfig?.prerender?.routes?.length === 0)
   ) {
-    // Remove the root index.html so it can be replaced with the prerendered version
+    // Remove the root index.html
     if (existsSync(`${nitroConfig?.output?.publicDir}/index.html`)) {
       unlinkSync(`${nitroConfig?.output?.publicDir}/index.html`);
     }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1686
Closes #1687

## What is the new behavior?

- If `ssr` is enabled, and the prerender routes array is empty, the root `index.html` is removed from the built static assets. This allows SSR to be used as the default for all requests.
- Docs have been updated on opting-out of prerendering.

Previously, the root `index.html` would still be included from the client build even if the routes array was empty with `ssr` enabled. The default behavior still prerenders the `/` route.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOHI0YXQwMGI4ZjYzbWJxNm1mMXA1a3I0d2xyaG5mbnB3amt5NmNyZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Ih6f3JK5YkZCY9azoQ/giphy-downsized-medium.gif"/>