### PR TITLE
fix(platform): align logic for determining client only rendering

### DIFF
--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -31,7 +31,8 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
               ...config[curr],
               headers: {
                 ...config[curr].headers,
-                'x-analog-no-ssr': !config[curr].ssr ? 'true' : undefined,
+                'x-analog-no-ssr':
+                  config[curr]?.ssr === false ? 'true' : undefined,
               } as any,
             },
           };

--- a/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
+++ b/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
@@ -74,11 +74,8 @@ export function devServerPlugin(options: ServerOptions): Plugin {
 
           try {
             let result: string | Response;
-            // Check for route rules explicitly disabling prerender
-            if (
-              _getRouteRules(req.originalUrl as string).prerender === false ||
-              _getRouteRules(req.originalUrl as string).ssr === false
-            ) {
+            // Check for route rules explicitly disabling SSR
+            if (_getRouteRules(req.originalUrl as string).ssr === false) {
               result = template;
             } else {
               const entryServer = (


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When using `routeRules` to `ssr: false`, client only rendering is consistent across dev/prod.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
