### PR TITLE
ci: remove legacy nx-cloud overrides

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,13 +6,6 @@
   "cli": {
     "packageManager": "pnpm"
   },
-  "tasksRunnerOptions": {
-    "default": {
-      "options": {
-        "useLightClient": true
-      }
-    }
-  },
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"],
@@ -67,6 +60,5 @@
     "projectSpecificFiles": []
   },
   "nxCloudAccessToken": "NDRkYzdkYmMtNDI3NS00MDI0LWFkMGQtMmI0Zjc2MTY2YzU0fHJlYWQtb25seQ==",
-  "defaultBase": "beta",
-  "useLegacyCache": true
+  "defaultBase": "beta"
 }


### PR DESCRIPTION
## PR Checklist

This PR removes the two outdated overrides for the Nx task runner:
- light client - This flag was used during the transition to the light client and is only applicable when used with an explicitly installed `nx-cloud` client npm package. In modern Nx CLI, the nx-cloud client is automatically downloaded/updated from the API and is always a `light` client.
- legacy cache - From v21 there will no longer be legacy cache. This flag made sense during the early days of new database caching when there were some instabilities. It's now safe to use the new, faster caching logic.

Closes #

## What is the new behavior?

The behavior should remain the same, with Nx caching being slightly faster and future-proof.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
