### PR TITLE
fix(vite-plugin-nitro): remove compressed index files for SSR-only rendering

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/build-server.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-server.ts
@@ -28,10 +28,16 @@ export async function buildServer(
     (nitroConfig?.prerender?.routes.find((route) => route === '/') ||
       nitroConfig?.prerender?.routes?.length === 0)
   ) {
-    // Remove the root index.html
-    if (existsSync(`${nitroConfig?.output?.publicDir}/index.html`)) {
-      unlinkSync(`${nitroConfig?.output?.publicDir}/index.html`);
-    }
+    const indexFileExts = ['', '.br', '.gz'];
+
+    indexFileExts.forEach((fileExt) => {
+      // Remove the root index.html(.br|.gz) files
+      const indexFilePath = `${nitroConfig?.output?.publicDir}/index.html${fileExt ? `${fileExt}` : ''}`;
+
+      if (existsSync(indexFilePath)) {
+        unlinkSync(indexFilePath);
+      }
+    });
   }
 
   if (


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1360

## What is the new behavior?

When all prerendering is disabled, remove the compressed root index.html(.br|.gz) from the public assets.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNnFsbG54dWlqdGptNGVybnBseDg2aHU4cHRkanY5OXdhcDE3eWQ2biZlcD12MV9naWZzX3NlYXJjaCZjdD1n/duXkd6NG5MwOKomroU/giphy.gif"/>