### PR TITLE
feat(content): add ability to pass extensions to marked instance

### DIFF
--- a/packages/platform/src/lib/content/marked/index.ts
+++ b/packages/platform/src/lib/content/marked/index.ts
@@ -1,3 +1,6 @@
+import { MarkedExtension } from 'marked';
+
 export type WithMarkedOptions = {
   mangle?: boolean;
+  extensions?: MarkedExtension[];
 };

--- a/packages/platform/src/lib/content/marked/marked-setup.service.ts
+++ b/packages/platform/src/lib/content/marked/marked-setup.service.ts
@@ -39,7 +39,7 @@ export class MarkedSetupService {
       return `<p>${text}</p>`;
     };
 
-    const extensions = [gfmHeadingId()];
+    const extensions = [gfmHeadingId(), ...(options?.extensions || [])];
 
     if (this.options?.mangle) {
       extensions.push(mangle());


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The platform plugin for content accepts an array of extensions that can be passed to marked for markdown rendering.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
