### PR TITLE
fix(vite-plugin-angular): allow the plugin to be imported with commonjs/require

### DIFF
--- a/packages/vite-plugin-angular/package.json
+++ b/packages/vite-plugin-angular/package.json
@@ -50,5 +50,16 @@
       "@analogjs/vitest-angular"
     ],
     "migrations": "./migrations/migration.json"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./src/index.d.ts",
+      "import": "./src/index.js",
+      "require": "./src/index.js",
+      "default": "./src/index.js"
+    },
+    "./esbuild": "./esbuild.js",
+    "./setup-vitest": "./setup-vitest.js"
   }
 }

--- a/packages/vite-plugin-angular/project.json
+++ b/packages/vite-plugin-angular/project.json
@@ -21,7 +21,7 @@
           "packages/vite-plugin-angular/esbuild.ts",
           "packages/vite-plugin-angular/setup-vitest.ts"
         ],
-        "generateExportsField": true
+        "generateExportsField": false
       }
     },
     "test": {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When using the `@analogjs/storybook-angular` package to a Storybook project in an Nx workspace, it fails to import the package when used with `require` internally because the generated `package.json` exports does not list `require`. The package manager was `pnpm`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
