### PR TITLE
fix(vite-plugin-nitro): check for custom apiPrefix with api directory

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -73,7 +73,11 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
 
         const rootDir = relative(workspaceRoot, config.root || '.') || '.';
         hasAPIDir = existsSync(
-          resolve(workspaceRoot, rootDir, `${sourceRoot}/server/routes/api`),
+          resolve(
+            workspaceRoot,
+            rootDir,
+            `${sourceRoot}/server/routes/${options?.apiPrefix || 'api'}`,
+          ),
         );
         const buildPreset =
           process.env['BUILD_PRESET'] ??


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When an `apiPrefix` is used, it should match the API route defined in that directory.

Example: An `apiPrefix` of `services` should contain API routes in the `src/server/routes/services` directory.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMTFjc3pjbHVmcWFnZm10bXlwbDh0ZjJ5amM1aTB1bTlmOXd6ZWRzdSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/4x00JqyQxFtnLxbQZt/giphy-downsized-medium.gif"/>