### PR TITLE
docs: update setup guide for Angular Material w/note on zone.js

### DIFF
--- a/apps/docs-app/docs/integrations/angular-material/index.md
+++ b/apps/docs-app/docs/integrations/angular-material/index.md
@@ -39,16 +39,22 @@ pnpm install @angular/cdk @angular/material
   </TabItem>
 </Tabs>
 
-> Make sure you have installed `sass` version 1.85.1 or higher.
-
 ## Step 2: Configuring the Angular Material library
 
-1. Rename the file `styles.css` to `styles.scss`.
-2. Set the `inlineStylesExtension` property to `'scss'` in the `vite.config.ts` file:
+1. Rename the `src/styles.css` file to `src/styles.scss`.
+2. If you're using `zone.js`, configure the `scss` preprocessorOptions to use the `legacy` api.
+3. Set the `inlineStylesExtension` property to `'scss'` in the `vite.config.ts` file:
 
 ```ts
 export default defineConfig(({ mode }) => {
   return {
+    css: {
+      preprocessorOptions: {
+        scss: {
+          api: 'legacy',
+        },
+      },
+    },
     plugins: [
       analog({
         vite: {
@@ -60,7 +66,7 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-3. Update the `index.html` file to reference the SCSS file:
+4. Update the `index.html` file to reference the SCSS file:
 
 ```html
 <head>
@@ -81,7 +87,7 @@ export default defineConfig(({ mode }) => {
 </body>
 ```
 
-4. Update the `styles.scss` file to import the Angular Material styles and define your custom theme:
+5. Update the `styles.scss` file to import the Angular Material styles and define your custom theme:
 
 ```scss
 @use '@angular/material' as mat;


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1631 

## What is the new behavior?

Added instructions on using legacy sass compiler API when using Angular Material.
importing `zone.js/node` causes issues with the modern sass compiler API due to `zone.js` patching the global `Promise` used inside the `sass-embedded` package. 

Issue filed in Angular repo: https://github.com/angular/angular/issues/61090

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYzZxM3Y0c2J3dXphc3VtOGFtODFjaGFxbWpmbmppdnVoNDZvMDY4eSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Kdk1Q8Ikvuwm9xVg0U/giphy.gif"/>