### PR TITLE
perf(vite-plugin-angular): optimize memory usage in large workspaces

### DIFF
--- a/apps/analog-app/vite.config.ts
+++ b/apps/analog-app/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(({ mode, isSsrBuild }) => {
         vite: {
           inlineStylesExtension: 'scss',
         },
-        liveReload: true,
+        liveReload: false,
         nitro: {
           routeRules: {
             '/cart/**': {

--- a/apps/analog-app/vite.config.ts
+++ b/apps/analog-app/vite.config.ts
@@ -40,9 +40,6 @@ export default defineConfig(({ mode, isSsrBuild }) => {
         },
         vite: {
           inlineStylesExtension: 'scss',
-          experimental: {
-            supportAnalogFormat: true,
-          },
         },
         liveReload: true,
         nitro: {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1704 

## What is the new behavior?

When running Vitest/Vitest VSCode plugin in a large workspace, the process does not run out of memory.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbjA3eGFvNXA2b2Y3bGlkcjR6d3N2cHl3bmtkbnU3ZTI0aTFkZ3o1ZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xstzYTN3334GCZgyj7/giphy.gif"/>