### PR TITLE
chore: add storybook-angular option to github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -32,6 +32,7 @@ body:
         - platform
         - trpc
         - astro-angular
+        - storybook-angular
         - Docs
         - Don't know / other
     validations:

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -23,6 +23,7 @@ body:
         - platform
         - trpc
         - astro-angular
+        - storybook-angular
         - Docs
         - Don't know / other
     validations:


### PR DESCRIPTION
## PR Checklist

Closes #

## What is the new behavior?

Adds `storybook-angular` as an option to the bug reporting and feature request GitHub issue templates

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
