### PR TITLE
fix(vite-plugin-angular): improve support for building Angular libraries

### DIFF
--- a/apps/analog-app/src/app/pages/package.page.ts
+++ b/apps/analog-app/src/app/pages/package.page.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+import { MyPackageComponent } from 'my-package';
+
+@Component({
+  imports: [MyPackageComponent],
+  template: ` <lib-my-package /> `,
+})
+export default class PackagePageComponent {}

--- a/apps/docs-app/docs/guides/libraries.md
+++ b/apps/docs-app/docs/guides/libraries.md
@@ -1,0 +1,194 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Building an Angular Library
+
+Angular libraries are built for supporting many different services and functionality. Angular libraries can be built using Vite that can be published to npm.
+
+## Creating a Library
+
+If you are creating a new package, use the `library` schematic:
+
+```sh
+ng generate lib my-lib
+```
+
+For an existing library, follow the setup instructions.
+
+## Setup
+
+Install the `@analogjs/platform` package:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm">
+
+```shell
+npm install @analogjs/platform --save-dev
+```
+
+  </TabItem>
+
+  <TabItem label="Yarn" value="yarn">
+
+```shell
+yarn add @analogjs/platform --dev
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```shell
+pnpm install -w @analogjs/platform
+```
+
+  </TabItem>
+</Tabs>
+
+Next, create a `vite.config.ts` at the root of the project, and configure it to build the library.
+
+> Update the references to `my-lib` to match the library project name.
+
+```ts
+import { defineConfig } from 'vite';
+import angular from '@analogjs/vite-plugin-angular';
+
+export default defineConfig(({ mode }) => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/libs/my-lib',
+  plugins: [angular()],
+  resolve: {
+    mainFields: ['module'],
+  },
+  build: {
+    target: ['esnext'],
+    sourcemap: true,
+    lib: {
+      // Library entry point
+      entry: 'src/public-api.ts',
+
+      // Package output path, must contain fesm2022
+      fileName: `fesm2022/my-lib`,
+
+      // Publish as ESM package
+      formats: ['es'],
+    },
+    rollupOptions: {
+      // Add external libraries that should be excluded from the bundle
+      external: [/^@angular\/.*/, 'rxjs', 'rxjs/operators'],
+      output: {
+        // Produce a single file bundle
+        preserveModules: false,
+      },
+    },
+    minify: false,
+  },
+}));
+```
+
+Next, update the project configuration to use the `@analogjs/platform:vite` builder to build the library.
+
+```json
+{
+  "name": "my-lib",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "projects/my-lib/src",
+  "prefix": "lib",
+  "projectType": "library",
+  "architect": {
+    "build": {
+      "builder": "@analogjs/platform:vite",
+      "options": {
+        "configFile": "projects/my-lib/vite.config.ts",
+        "outputPath": "dist/projects/my-lib"
+      },
+      "defaultConfiguration": "production",
+      "configurations": {
+        "development": {
+          "mode": "development"
+        },
+        "production": {
+          "sourcemap": true,
+          "mode": "production"
+        }
+      }
+    }
+  }
+}
+```
+
+Adjust the `package.json` at the root of the project to point to the built output. Include any necessary `dependencies` or `peerDependencies` that are needed when installing the package.
+
+```json
+{
+  "name": "my-lib",
+  "description": "A description of the Angular library",
+  "type": "module",
+  "peerDependencies": {
+    "@angular/common": "^19.0.0",
+    "@angular/core": "^19.0.0"
+  },
+  "dependencies": {
+    "tslib": "^2.0.0"
+  },
+  "types": "./src/public-api.d.ts",
+  "exports": {
+    "./package.json": {
+      "default": "./package.json"
+    },
+    ".": {
+      "import": "./fesm2022/my-lib.mjs",
+      "require": "./fesm2022/my-lib.mjs",
+      "default": "./fesm2022/my-lib.mjs"
+    }
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  }
+}
+```
+
+## Copying Assets
+
+Static assets in the `public` directory are copied to the build output directory by default. If you want to copy additional assets outside of that directory, use the `nxCopyAssetsPlugin` Vite plugin.
+
+Import the plugin and set it up:
+
+```ts
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite';
+import analog from '@analogjs/vite-plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => ({
+  // ...
+  plugins: [angular(), nxCopyAssetsPlugin(['*.md', 'package.json'])],
+}));
+```
+
+## Building the Library
+
+Run the build command:
+
+```sh
+ng build my-lib
+```
+
+## Publishing the Library
+
+After logging using `npm login`, use the `npm publish` command to publish the package.
+
+To see the output without publishing, use the `--dry-run` flag.
+
+```sh
+npm publish dist/projects/my-lib --dry-run
+```
+
+To publish the library to npm:
+
+```sh
+npm publish dist/projects/my-lib
+```

--- a/apps/docs-app/sidebars.js
+++ b/apps/docs-app/sidebars.js
@@ -187,6 +187,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'guides/libraries',
+          label: 'Building an Angular library',
+        },
+        {
+          type: 'doc',
           id: 'guides/compatibility',
           label: 'Version Compatibilty',
         },

--- a/libs/my-package/.eslintrc.json
+++ b/libs/my-package/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "lib",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "lib",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/my-package/README.md
+++ b/libs/my-package/README.md
@@ -1,0 +1,7 @@
+# my-package
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test my-package` to execute the unit tests.

--- a/libs/my-package/package.json
+++ b/libs/my-package/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@analogjs/my-package",
+  "type": "module",
+  "private": true,
+  "peerDependencies": {
+    "@angular/core": "^19.0.0"
+  },
+  "dependencies": {
+    "tslib": "^2.0.0"
+  },
+  "exports": {
+    "./package.json": {
+      "default": "./package.json"
+    },
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./fesm2022/my-package.js",
+      "require": "./fesm2022/my-package.js",
+      "default": "./fesm2022/my-package.js"
+    }
+  }
+}

--- a/libs/my-package/project.json
+++ b/libs/my-package/project.json
@@ -1,0 +1,35 @@
+{
+  "name": "my-package",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/my-package/src",
+  "prefix": "lib",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/vite:build",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "configFile": "libs/my-package/vite.config.ts",
+        "outputPath": "dist/libs/my-package"
+      },
+      "defaultConfiguration": "production",
+      "configurations": {
+        "development": {
+          "mode": "development"
+        },
+        "production": {
+          "sourcemap": true,
+          "mode": "production"
+        }
+      }
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{projectRoot}/coverage"]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/my-package/src/index.ts
+++ b/libs/my-package/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/my-package/my-package.component';

--- a/libs/my-package/src/lib/my-package/my-package.component.html
+++ b/libs/my-package/src/lib/my-package/my-package.component.html
@@ -1,0 +1,1 @@
+<p>MyPackage works!</p>

--- a/libs/my-package/src/lib/my-package/my-package.component.spec.ts
+++ b/libs/my-package/src/lib/my-package/my-package.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MyPackageComponent } from './my-package.component';
+
+describe('MyPackageComponent', () => {
+  let component: MyPackageComponent;
+  let fixture: ComponentFixture<MyPackageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MyPackageComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MyPackageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/my-package/src/lib/my-package/my-package.component.ts
+++ b/libs/my-package/src/lib/my-package/my-package.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'lib-my-package',
+  imports: [CommonModule],
+  templateUrl: './my-package.component.html',
+  styleUrl: './my-package.component.css',
+})
+export class MyPackageComponent {}

--- a/libs/my-package/src/test-setup.ts
+++ b/libs/my-package/src/test-setup.ts
@@ -1,0 +1,15 @@
+import '@analogjs/vitest-angular/setup-zone';
+
+/**
+ * Initialize TestBed for all tests inside of content
+ */
+import { TestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+TestBed.initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+);

--- a/libs/my-package/tsconfig.json
+++ b/libs/my-package/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/my-package/tsconfig.lib.json
+++ b/libs/my-package/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "vite.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/my-package/tsconfig.lib.prod.json
+++ b/libs/my-package/tsconfig.lib.prod.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false,
+    "target": "ES2022",
+    "useDefineForClassFields": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/libs/my-package/tsconfig.spec.json
+++ b/libs/my-package/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node", "vitest/globals"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/libs/my-package/vite.config.ts
+++ b/libs/my-package/vite.config.ts
@@ -1,0 +1,47 @@
+/// <reference types='vitest' />
+import angular from '@analogjs/vite-plugin-angular';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { defineConfig } from 'vite';
+
+export default defineConfig(({ mode }) => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/libs/my-package',
+  plugins: [
+    angular(),
+    nxViteTsPaths(),
+    nxCopyAssetsPlugin(['*.md', 'package.json']),
+  ],
+  resolve: {
+    mainFields: ['module'],
+  },
+  build: {
+    target: ['esnext'],
+    sourcemap: true,
+    lib: {
+      entry: 'src/index.ts',
+      fileName: `fesm2022/my-package`,
+      formats: ['es' as const],
+    },
+    rollupOptions: {
+      external: [/^@angular\/.*/, 'rxjs', 'rxjs/operators'],
+      output: {
+        preserveModules: false,
+      },
+    },
+    cssCodeSplit: false,
+    cssMinify: true,
+    minify: false,
+  },
+  test: {
+    reporters: ['default'],
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['src/test-setup.ts'],
+    include: ['**/*.spec.ts'],
+    cacheDir: '../../node_modules/.vitest',
+  },
+  define: {
+    'import.meta.vitest': mode !== 'production',
+  },
+}));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -56,6 +56,7 @@
         "packages/vite-plugin-nitro/src/index.ts"
       ],
       "libs/card": ["libs/card/src/index.ts"],
+      "my-package": ["./dist/libs/my-package", "libs/my-package/src/index.ts"],
       "shared/feature": ["libs/shared/feature/src/index.ts"],
       "vitest-angular": [
         "./node_modules/@analogjs/vitest-angular",

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,4 @@
+export default [
+  'packages/**/vite.config.{mjs,js,ts,mts}',
+  '!**/create-analog/**',
+];


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Improves support for building Angular libraries using Vite:
- Infers correct `tsconfig.lib.json` / `tsconfig.lib.prod.json` for libraries
- Infers correct tsconfig based on app/test/library environment
- Adds a sample `my-package` library for validation
- Adds a guide for building a library using Vite

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOGh5NDVib3Q4MjJ0OTdkYTIydWwzMWVtaGxsY2M4Nm9kbjZzdXplNiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/IdIPp6OwYj3NJ9oBBZ/giphy.gif"/>