### PR TITLE
fix(vite-plugin-angular): adjust output path for library dts files

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -983,16 +983,16 @@ export function angular(options?: PluginOptions): Plugin[] {
             /\.d\.ts/.test(filename) &&
             !filename.includes('.ngtypecheck.')
           ) {
+            // output to library root instead /src
             const declarationPath = resolve(
               config.root,
               config.build.outDir,
               relative(config.root, filename),
-            );
+            ).replace('/src/', '/');
 
-            const declarationFileDir = declarationPath.replace(
-              basename(filename),
-              '',
-            );
+            const declarationFileDir = declarationPath
+              .replace(basename(filename), '')
+              .replace('/src/', '/');
 
             declarationFiles.push({
               declarationFileDir,


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When building declaration files for a library, the types are not nested within the `src` folder.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaTR6NnQzODRnemFzcHhxOGQ3bHE4MGtwZXlrcnVrYmxxZjJxcWVudyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/8nM6YNtvjuezzD7DNh/giphy-downsized-medium.gif"/>