### PR TITLE
fix(vite-plugin-angular): normalize version string for pending tasks replacement

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-pending-tasks.plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-pending-tasks.plugin.ts
@@ -13,8 +13,12 @@ export function pendingTasksPlugin(): Plugin {
   return {
     name: 'analogjs-pending-tasks-plugin',
     transform(code, id) {
+      const padVersion = (version: number) => String(version).padStart(2, '0');
+
       if (
-        Number(`${angularMajor}${angularMinor}${angularPatch}`) < 1904 &&
+        Number(
+          `${angularMajor}${padVersion(angularMinor)}${padVersion(angularPatch)}`,
+        ) < 190004 &&
         id.includes('analogjs-content.mjs')
       ) {
         return {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1730

## What is the new behavior?

The minor and major versions are normalized to two digits before combining when doing a version check for older Angular versions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbDF6bTlmODFvcnBnaWYya3NkNHNzcWkzeWZ0bDB3djRvZGxtb2FiaSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/eHiCBtI9Q8KnHaFnvH/giphy.gif"/>