### PR TITLE
fix(create-analog): use latest version of marked w/shiki, fix tailwind support

### DIFF
--- a/packages/create-analog/index.js
+++ b/packages/create-analog/index.js
@@ -42,7 +42,7 @@ const HIGHLIGHTERS = {
     highlighter: 'withPrismHighlighter',
     entryPoint: 'prism-highlighter',
     dependencies: {
-      'marked-highlight': '^2.0.1',
+      'marked-highlight': '^2.2.1',
       prismjs: '^1.29.0',
     },
   },
@@ -50,7 +50,7 @@ const HIGHLIGHTERS = {
     highlighter: 'withShikiHighlighter',
     entryPoint: 'shiki-highlighter',
     dependencies: {
-      marked: '^7.0.0',
+      marked: '^15.0.7',
       'marked-shiki': '^1.1.0',
       shiki: '^1.6.1',
     },
@@ -214,6 +214,13 @@ async function init() {
     addTailwindDirectives(write, filesDir);
   }
 
+  replacePlaceholders(root, 'vite.config.ts', {
+    __TAILWIND_IMPORT__: !skipTailwind
+      ? `\nimport tailwindcss from '@tailwindcss/vite';`
+      : '',
+    __TAILWIND_PLUGIN__: !skipTailwind ? '\n    tailwindcss()' : '',
+  });
+
   const pkgInfo = pkgFromUserAgent(process.env.npm_config_user_agent);
   const pkgManager = pkgInfo ? pkgInfo.name : 'npm';
   const pkg = JSON.parse(
@@ -376,11 +383,11 @@ function addTailwindDependencies(pkg) {
 
 function addYarnDevDependencies(pkg, template) {
   // v18
-  if (template === 'latest' || template === 'blog') {
-    pkg.devDependencies['@nx/angular'] = '^19.1.0';
-    pkg.devDependencies['@nx/devkit'] = '^19.1.0';
-    pkg.devDependencies['@nx/vite'] = '^19.1.0';
-    pkg.devDependencies['nx'] = '^19.1.0';
+  if (template === 'latest' || template === 'blog' || template === 'minimal') {
+    pkg.devDependencies['@nx/angular'] = '^21.0.0';
+    pkg.devDependencies['@nx/devkit'] = '^21.0.0';
+    pkg.devDependencies['@nx/vite'] = '^21.0.0';
+    pkg.devDependencies['nx'] = '^21.0.0';
   } else if (template === 'angular-v17') {
     pkg.devDependencies['@angular-devkit/build-angular'] = '^17.2.0';
   }

--- a/packages/create-analog/template-blog/vite.config.ts
+++ b/packages/create-analog/template-blog/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import { defineConfig } from 'vite';
-import analog from '@analogjs/platform';
+import analog from '@analogjs/platform';__TAILWIND_IMPORT__
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -19,7 +19,7 @@ export default defineConfig(({ mode }) => ({
       prerender: {
         routes: ['/blog', '/blog/2022-12-27-my-first-post'],
       },__ANALOG_SFC_CONFIG__
-    }),
+    }),__TAILWIND_PLUGIN__
   ],
   test: {
     globals: true,

--- a/packages/create-analog/template-latest/vite.config.ts
+++ b/packages/create-analog/template-latest/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import { defineConfig } from 'vite';
-import analog from '@analogjs/platform';
+import analog from '@analogjs/platform';__TAILWIND_IMPORT__
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -11,7 +11,9 @@ export default defineConfig(({ mode }) => ({
   resolve: {
     mainFields: ['module'],
   },
-  plugins: [analog(__ANALOG_SFC_CONFIG__)],
+  plugins: [
+    analog(__ANALOG_SFC_CONFIG__),__TAILWIND_PLUGIN__
+  ],
   test: {
     globals: true,
     environment: 'jsdom',

--- a/packages/create-analog/template-minimal/vite.config.ts
+++ b/packages/create-analog/template-minimal/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import { defineConfig } from 'vite';
-import analog from '@analogjs/platform';
+import analog from '@analogjs/platform';__TAILWIND_IMPORT__
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -17,7 +17,7 @@ export default defineConfig(({ mode }) => ({
       static: true,
       prerender: {
         routes: [],
-      },__ANALOG_SFC_CONFIG__
-    }),
+      },__ANALOG_SFC_CONFIG__,
+    }),__TAILWIND_PLUGIN__
   ],
 }));


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1732 

## What is the new behavior?

- Updated `marked` dependency to latest version with `shiki` highlighter
- Correctly adds Tailwind to vite config when selected
- Updates to Nx 21

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
