### PR TITLE
fix(vitest-angular): update `@angular-devkit/architect` dep range to include v20

### DIFF
--- a/packages/vitest-angular/package.json
+++ b/packages/vitest-angular/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@analogjs/vite-plugin-angular": "*",
-    "@angular-devkit/architect": ">=0.1500.0 < 0.2000.0",
+    "@angular-devkit/architect": ">=0.1500.0 < 0.2100.0",
     "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0"
   },
   "ng-update": {


### PR DESCRIPTION
## PR Checklist

The `@analogjs/vitest-angular` has a peer dependency range for `@angular-devkit/architect` that doesn't include its v20 version.

Closes #

## What is the new behavior?

The `@analogjs/vitest-angular` supports `@angular-devkit/architect@20`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
