### PR TITLE
chore: remove occurrences of splitVendorChunkPlugin from vite

### DIFF
--- a/apps/analog-app/vite.config.ts
+++ b/apps/analog-app/vite.config.ts
@@ -58,7 +58,6 @@ export default defineConfig(({ mode, isSsrBuild }) => {
       }),
       nxViteTsPaths(),
       visualizer() as Plugin,
-      // splitVendorChunkPlugin(),
       !isSsrBuild &&
         inspect({
           build: true,

--- a/apps/docs-app/docs/features/server/static-site-generation.md
+++ b/apps/docs-app/docs/features/server/static-site-generation.md
@@ -239,7 +239,7 @@ Below is a small example where we can append a script to include Google Analytic
 /// <reference types="vitest" />
 
 import analog from '@analogjs/platform';
-import { defineConfig, splitVendorChunkPlugin } from 'vite';
+import { defineConfig } from 'vite';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { PrerenderRoute } from 'nitropack';
 

--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/server/static-site-generation.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/server/static-site-generation.md
@@ -183,7 +183,7 @@ Nachfolgend ein kleines Beispiel, in dem ein Skript angehängt wird, um Google A
 /// <reference types="vitest" />
 
 import analog from '@analogjs/platform';
-import { defineConfig, splitVendorChunkPlugin } from 'vite';
+import { defineConfig } from 'vite';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { PrerenderRoute } from 'nitropack';
 

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/server/static-site-generation.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/server/static-site-generation.md
@@ -173,7 +173,7 @@ A continuación, se muestra un pequeño ejemplo donde podemos añadir un script 
 /// <reference types="vitest" />
 
 import analog from '@analogjs/platform';
-import { defineConfig, splitVendorChunkPlugin } from 'vite';
+import { defineConfig } from 'vite';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { PrerenderRoute } from 'nitropack';
 

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/server/static-site-generation.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/server/static-site-generation.md
@@ -181,7 +181,7 @@ export default defineConfig(() => {
 /// <reference types="vitest" />
 
 import analog from '@analogjs/platform';
-import { defineConfig, splitVendorChunkPlugin } from 'vite';
+import { defineConfig } from 'vite';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { PrerenderRoute } from 'nitropack';
 

--- a/apps/trpc-app/vite.config.ts
+++ b/apps/trpc-app/vite.config.ts
@@ -2,7 +2,7 @@
 
 import analog from '@analogjs/platform';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { defineConfig, Plugin, splitVendorChunkPlugin } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 
 // https://vitejs.dev/config/
@@ -33,7 +33,6 @@ export default defineConfig(({ mode }) => {
       }),
       nxViteTsPaths(),
       visualizer() as Plugin,
-      splitVendorChunkPlugin(),
     ],
     test: {
       reporters: ['default'],

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v15/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v15/vite.config.ts__template__
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import analog from '@analogjs/platform';
-import { defineConfig, Plugin, splitVendorChunkPlugin } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 import tsConfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
@@ -52,7 +52,6 @@ export default defineConfig(({ mode }) => {
       tsConfigPaths({
         root: '<%= offsetFromRoot %>',
       }),
-      splitVendorChunkPlugin(),
     ],
     test: {
       globals: true,

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v16/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v16/vite.config.ts__template__
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import analog from '@analogjs/platform';
-import { defineConfig, Plugin, splitVendorChunkPlugin } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 import tsConfigPaths from 'vite-tsconfig-paths';
 <% if (addTailwind) { %>
 // @ts-expect-error @tailwindcss/vite currently uses mts. TypeScript is complaining this, but it works as expected.
@@ -40,7 +40,6 @@ export default defineConfig(({ mode }) => {
       tsConfigPaths({
         root: '<%= offsetFromRoot %>',
       }),
-      splitVendorChunkPlugin(),
     ],
     test: {
       globals: true,

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v17/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v17/vite.config.ts__template__
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import analog from '@analogjs/platform';
-import { defineConfig, Plugin, splitVendorChunkPlugin } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 <% if (addTailwind) { %>
 // @ts-expect-error @tailwindcss/vite currently uses mts. TypeScript is complaining this, but it works as expected.
@@ -47,7 +47,6 @@ export default defineConfig(({ mode }) => {
       analog(),
       <% } %>
       nxViteTsPaths(),
-      splitVendorChunkPlugin(),
     ],
     test: {
       globals: true,

--- a/packages/nx-plugin/src/generators/app/files/template-angular-v18/vite.config.ts__template__
+++ b/packages/nx-plugin/src/generators/app/files/template-angular-v18/vite.config.ts__template__
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import analog from '@analogjs/platform';
-import { defineConfig, Plugin, splitVendorChunkPlugin } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 <% if (addTailwind) { %>
 // @ts-expect-error @tailwindcss/vite currently uses mts. TypeScript is complaining this, but it works as expected.
@@ -46,7 +46,6 @@ export default defineConfig(({ mode }) => {
       analog(),
       <% } %>
       nxViteTsPaths(),
-      splitVendorChunkPlugin(),
     ],
     test: {
       globals: true,


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The `splitVendorChunkPlugin` has been removed in Vite 7. This is just cleanup from our docs and samples.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
