### PR TITLE
fix(nx-plugin): nx generator - ensure that *--tags* are option is used.

### DIFF
--- a/packages/nx-plugin/src/generators/app/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/app/generator.spec.ts
@@ -157,6 +157,14 @@ describe('nx-plugin generator', () => {
     expect(injectsTrpcClient).toBeTruthy();
   };
 
+  const verifyTagsArePopulated = (
+    config: ProjectConfiguration,
+    tags: string[],
+  ) => {
+    expect(config.tags).toBeDefined();
+    expect(config.tags).toEqual(tags);
+  };
+
   describe('Nx, Angular', () => {
     it('creates a default analogjs app in the source directory', async () => {
       const analogAppName = 'analog';
@@ -214,6 +222,22 @@ describe('nx-plugin generator', () => {
 
       verifyHomePageExists(tree, analogAppName);
       verifyTrpcIsSetUp(tree, dependencies);
+    });
+
+    it('creates an analogjs app in the source directory with tags populated', async () => {
+      const analogAppName = 'tags-app';
+      const { config, tree } = await setup({
+        analogAppName,
+        tags: 'tag1,tag2, type:app ',
+      });
+      const { dependencies, devDependencies } = readJson(tree, 'package.json');
+
+      verifyCoreDependenciesNx_Angular(dependencies, devDependencies);
+
+      verifyConfig(config, analogAppName);
+
+      verifyHomePageExists(tree, analogAppName);
+      verifyTagsArePopulated(config, ['tag1', 'tag2', 'type:app']);
     });
   });
 });

--- a/packages/nx-plugin/src/generators/app/generator.ts
+++ b/packages/nx-plugin/src/generators/app/generator.ts
@@ -112,7 +112,7 @@ export async function appGenerator(
       tree,
       normalizedOptions.projectRoot,
       normalizedOptions.projectName,
-      [],
+      normalizedOptions.parsedTags,
       normalizedOptions.name,
       normalizedOptions.appsDir,
       normalizedOptions.nxPackageNamespace,

--- a/packages/nx-plugin/src/generators/app/lib/add-analog-project-config.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-analog-project-config.ts
@@ -81,6 +81,7 @@ export function addAnalogProjectConfig(
     projectConfiguration[targets] = projectConfiguration.targets;
     projectConfiguration[targets]['extract-i18n'] = undefined;
     projectConfiguration[targets]['serve-static'] = undefined;
+    projectConfiguration.tags = parsedTags;
     delete projectConfiguration['$schema'];
     delete projectConfiguration['name'];
     delete projectConfiguration['generators'];

--- a/packages/nx-plugin/src/generators/app/lib/add-angular-app.ts
+++ b/packages/nx-plugin/src/generators/app/lib/add-angular-app.ts
@@ -16,6 +16,7 @@ export async function addAngularApp(tree: Tree, options: NormalizedOptions) {
       bundler: 'esbuild',
       serverRouting: false,
       skipFormat: true,
+      tags: options.tags,
     };
 
   await (

--- a/packages/nx-plugin/src/generators/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/generators/preset/__snapshots__/generator.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`preset generator > should match project.json 1`] = `
   "projectType": "application",
   "prefix": "app",
   "sourceRoot": "my-app/src",
-  "tags": [],
+  "tags": ["tag1", "tag2", "type:app"],
   "targets": {
     "build": {
       "executor": "@analogjs/platform:vite",

--- a/packages/nx-plugin/src/generators/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.spec.ts
@@ -23,7 +23,10 @@ describe('preset generator', () => {
   };
 
   it('should match project.json', async () => {
-    const { tree } = await setup({ analogAppName: 'my-app' });
+    const { tree } = await setup({
+      analogAppName: 'my-app',
+      tags: 'tag1,tag2, type:app',
+    });
 
     expect(tree.read('/my-app/project.json').toString()).toMatchSnapshot();
   });


### PR DESCRIPTION
When the *--tags* option is supplied to the `nx generate @analogjs/platform:app` command ensure that they get set in the project.json

## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMHA3aTQ0ZHgxeGJtdjJ1bGMzcWZiYjUzb2Jqc3Z6ZjgzMWNoY3Y1bCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/453QsWPQj5bsQaqp8M/giphy.gif"/>