### PR TITLE
docs(astro-angular): add providers to example

### DIFF
--- a/packages/astro-angular/README.md
+++ b/packages/astro-angular/README.md
@@ -294,7 +294,7 @@ interface Todo {
 })
 export class TodosComponent implements OnInit {
   static clientProviders = [provideHttpClient()];
-  static renderProviders = [];
+  static renderProviders = [TodosComponent.clientProviders];
 
   http = inject(HttpClient);
   todos: Todo[] = [];


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

It is a very tiny addition

## What is the new behavior?

When I first saw `static renderProviders = [];` I didn't copy it because I didn't see the point of copying an empty array.
Later on I looked up another project and saw how it's used and I believe that including that in the docs would make it easier for others that are also exploring the integration 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
