### PR TITLE
fix(vite-plugin-angular): trigger compilation from external templates/styles

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -350,7 +350,10 @@ export function angular(options?: PluginOptions): Plugin[] {
             });
           });
 
-          await performCompilation(resolvedConfig, updates);
+          await performCompilation(resolvedConfig, [
+            ...mods.map((mod) => mod.id as string),
+            ...updates,
+          ]);
 
           if (updates.length > 0) {
             updates.forEach((updateId) => {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1733

## What is the new behavior?

When updating external templates/styles, compilation is triggered and files are updated correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYzJmamxmcm91b2cxMHBkbXRnN2EzNHZrNDkzMTJ3bWsyZzQwam9scCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/WmP68nQdnDBGeOsvkg/giphy.gif"/>