### PR TITLE
fix(nx-plugin): support migration for Angular v20 app component

### DIFF
--- a/packages/nx-plugin/src/generators/init/files/src/main.server.ts__template__
+++ b/packages/nx-plugin/src/generators/init/files/src/main.server.ts__template__
@@ -1,8 +1,14 @@
 import 'zone.js/node';
 import '@angular/platform-server/init';
 import { render } from '@analogjs/router/server';
+<% if (majorAngularVersion > 19) { %>
+import { App } from './app/app';
+import { config } from './app/app.config.server';
 
+export default render(App, config);
+<% } else { %>
 import { AppComponent } from './app/app.component';
 import { config } from './app/app.config.server';
 
 export default render(AppComponent, config);
+<% } %>


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When using the `@analogjs/platform:migrate` schematic with an Angular v20 app, the new app.ts convention is supported.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
