### PR TITLE
fix(vite-plugin-angular): emit transpiled TS code if unhandled by Angular compilation

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -548,7 +548,7 @@ export function angular(options?: PluginOptions): Plugin[] {
 
           if (jit) {
             return {
-              code: data,
+              code: data || code,
               map: null,
             };
           }
@@ -575,7 +575,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           }
 
           return {
-            code: data,
+            code: data || code,
             map: null,
           };
         }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1791 

## What is the new behavior?

When transforming `.ts` files, return the original transpiled code if the Angular compilation produced an empty output. This means the file isn't included in the compilation, but includes valid TypeScript code. This fixes the issue with test coverage being reported incorrectly when all the TS files should be accounted for in the test coverage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlN2hpYnpkcTI4Zm9kNmFqaDBvOWJhZzJoYjZzbGFpb2kwZDNsYmx6cyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/aHiv481xki1WdhQonS/giphy.gif"/>