### PR TITLE
fix(storybook-angular): prevent duplicate loading of analogjs plugins

### DIFF
--- a/packages/storybook-angular/preset/preset.mjs
+++ b/packages/storybook-angular/preset/preset.mjs
@@ -15,6 +15,11 @@ export const core = async (config, options) => {
   };
 };
 export const viteFinal = async (config, options) => {
+  // Remove any loaded analogjs plugins from a vite.config.(m)ts file
+  config.plugins = config.plugins
+    .flat()
+    .filter((plugin) => !plugin.name.includes('analogjs'));
+
   // Merge custom configuration into the default config
   const { mergeConfig } = await import('vite');
   const { default: angular } = await import('@analogjs/vite-plugin-angular');
@@ -28,8 +33,6 @@ export const viteFinal = async (config, options) => {
         '@analogjs/storybook-angular',
         '@angular/compiler',
         '@angular/platform-browser/animations',
-        '@storybook/addon-docs/angular',
-        'react/jsx-dev-runtime',
         'tslib',
         'zone.js',
       ],
@@ -45,6 +48,10 @@ export const viteFinal = async (config, options) => {
             ? framework.options?.liveReload
             : false,
         tsconfig: options?.tsConfig ?? './.storybook/tsconfig.json',
+        inlineStylesExtension:
+          typeof framework.options?.inlineStylesExtension !== 'undefined'
+            ? framework.options?.inlineStylesExtension
+            : 'css',
       }),
     ],
     define: {

--- a/packages/storybook-angular/src/types.ts
+++ b/packages/storybook-angular/src/types.ts
@@ -11,6 +11,7 @@ export type FrameworkOptions = {
   builder?: BuilderOptions;
   jit?: boolean;
   liveReload?: boolean;
+  inlineStylesExtension?: string;
 };
 
 type StorybookConfigFramework = {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When using the `@analogjs/storybook-angular` package in combination with a `vite.config.mts` file that is used for testing, the Analog plugin gets loaded twice with different settings, causing slowdowns in compilation. This filters out any analogjs plugins that were previously loaded before adding the plugin internally.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
