### PR TITLE
fix(vite-plugin-angular): skip compilation for inline assets, .nx for HMR

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -49,6 +49,7 @@ import { routerPlugin } from './router-plugin.js';
 import { pendingTasksPlugin } from './angular-pending-tasks.plugin.js';
 import { EmitFileResult } from './models.js';
 import { liveReloadPlugin } from './live-reload-plugin.js';
+import { nxFolderPlugin } from './nx-folder-plugin.js';
 
 export interface PluginOptions {
   tsconfig?: string;
@@ -292,7 +293,11 @@ export function angular(options?: PluginOptions): Plugin[] {
           const isDirect = ctx.modules.find(
             (mod) => ctx.file === mod.file && mod.id?.includes('?direct'),
           );
-          if (isDirect) {
+          const isInline = ctx.modules.find(
+            (mod) => ctx.file === mod.file && mod.id?.includes('?inline'),
+          );
+
+          if (isDirect || isInline) {
             if (pluginOptions.liveReload && isDirect?.id && isDirect.file) {
               const isComponentStyle =
                 isDirect.type === 'css' && isComponentStyleSheet(isDirect.id);
@@ -608,6 +613,7 @@ export function angular(options?: PluginOptions): Plugin[] {
     (isStorybook && angularStorybookPlugin()) as Plugin,
     routerPlugin(),
     pendingTasksPlugin(),
+    nxFolderPlugin(),
   ].filter(Boolean) as Plugin[];
 
   function findAnalogFiles(config: ResolvedConfig) {

--- a/packages/vite-plugin-angular/src/lib/nx-folder-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/nx-folder-plugin.ts
@@ -1,0 +1,19 @@
+import { normalizePath, Plugin } from 'vite';
+
+/**
+ * Ignores anything in the .nx folder from triggering HMR
+ *
+ * @returns
+ */
+export function nxFolderPlugin(): Plugin {
+  return {
+    name: 'analogjs-nx-folder-plugin',
+    handleHotUpdate(ctx) {
+      if (ctx.file.includes(normalizePath('/.nx/'))) {
+        return [];
+      }
+
+      return ctx.modules;
+    },
+  };
+}


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Inline assets (HTML, CSS) skip TypeScript compilation, providing performance improvements
- The `.nx` folder is ignored by HMR updates

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
