### PR TITLE
docs: fix code example for libraries guide

### DIFF
--- a/apps/docs-app/docs/guides/libraries.md
+++ b/apps/docs-app/docs/guides/libraries.md
@@ -165,7 +165,7 @@ import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   // ...
-  plugins: [angular(), nxCopyAssetsPlugin(['*.md', 'package.json'])],
+  plugins: [analog(), nxCopyAssetsPlugin(['*.md', 'package.json'])],
 }));
 ```
 


### PR DESCRIPTION
In [docs/guides/libraries](https://analogjs.org/docs/guides/libraries), the code example has `import analog from '@analogjs/vite-plugin';` but uses `plugins: [angular(),...`. The function call should match the import name.

## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1803

## What is the new behavior?

**New behavior:** The code example now executes successfully and produces the expected output, whereas previously it would have failed with an error.

**Details:** This change fixes a critical issue that prevented the example from running at all. Users can now copy and paste the example directly from the documentation and see it work as intended, improving the developer experience and reducing confusion for newcomers to the project.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZW5zZXlqazVmNG00cDF1M2h6OWg5djZwaTkydjF4bzQzemhhbjAyOCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/h6g5FA1zhKswcRsEi7/giphy.gif"/>