### PR TITLE
feat(storybook-angular): add support for Vitest addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@semantic-release/git": "^10.0.1",
     "@storybook/addon-docs": "9.0.18",
     "@storybook/addon-links": "9.0.18",
+    "@storybook/addon-vitest": "9.0.18",
     "@storybook/angular": "9.0.18",
     "@storybook/builder-vite": "9.0.18",
     "@swc-node/register": "1.10.10",

--- a/packages/storybook-angular/package.json
+++ b/packages/storybook-angular/package.json
@@ -29,7 +29,12 @@
     },
     "./preset": "./preset.mjs",
     "./package.json": "./package.json",
-    "./*": "./src/*"
+    "./*": "./src/*",
+    "./testing": {
+      "types": "./src/lib/testing.d.ts",
+      "import": "./src/lib/testing.js",
+      "require": "./src/lib/testing.js"
+    }
   },
   "main": "src/index.js",
   "dependencies": {

--- a/packages/storybook-angular/src/lib/testing.ts
+++ b/packages/storybook-angular/src/lib/testing.ts
@@ -1,0 +1,34 @@
+import type { AngularRenderer } from '@storybook/angular';
+import { setProjectAnnotations as originalSetProjectAnnotations } from '@storybook/angular/dist/client/index.mjs';
+import {
+  NamedOrDefaultProjectAnnotations,
+  NormalizedProjectAnnotations,
+  RenderContext,
+} from 'storybook/internal/types';
+import * as configAnnotations from '@storybook/angular/dist/client/config.mjs';
+
+export const render = configAnnotations.render;
+
+export async function renderToCanvas(
+  context: RenderContext<AngularRenderer>,
+  element: HTMLElement,
+) {
+  element.id = context.id;
+  await configAnnotations.renderToCanvas(context, element);
+}
+
+const renderAnnotations = {
+  render,
+  renderToCanvas,
+};
+
+export function setProjectAnnotations(
+  projectAnnotations:
+    | NamedOrDefaultProjectAnnotations<any>
+    | NamedOrDefaultProjectAnnotations<any>[],
+): NormalizedProjectAnnotations<AngularRenderer> {
+  return originalSetProjectAnnotations([
+    renderAnnotations,
+    projectAnnotations,
+  ]) as NormalizedProjectAnnotations<AngularRenderer>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@storybook/addon-links':
         specifier: 9.0.18
         version: 9.0.18(react@18.3.1)(storybook@9.0.9(@testing-library/dom@10.4.0)(prettier@3.5.1))
+      '@storybook/addon-vitest':
+        specifier: 9.0.18
+        version: 9.0.18(@vitest/runner@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.9(@testing-library/dom@10.4.0)(prettier@3.5.1))(vitest@3.2.4)
       '@storybook/angular':
         specifier: 9.0.18
         version: 9.0.18(d425be5f86d5ee0e3a685cd1b4b11959)
@@ -5316,6 +5319,21 @@ packages:
       storybook: ^9.0.18
     peerDependenciesMeta:
       react:
+        optional: true
+
+  '@storybook/addon-vitest@9.0.18':
+    resolution: {integrity: sha512-uPLh9H7kRho+raxyIBCm8Ymd3j0VPuWIQ1HSAkdx8itmNafNqs4HE67Z8Cfl259YzdWU/j5BhZqoiT62BCbIDw==}
+    peerDependencies:
+      '@vitest/browser': ^3.0.0
+      '@vitest/runner': ^3.0.0
+      storybook: ^9.0.18
+      vitest: ^3.0.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+      '@vitest/runner':
+        optional: true
+      vitest:
         optional: true
 
   '@storybook/angular@9.0.18':
@@ -24077,6 +24095,20 @@ snapshots:
       storybook: 9.0.9(@testing-library/dom@10.4.0)(prettier@3.5.1)
     optionalDependencies:
       react: 18.3.1
+
+  '@storybook/addon-vitest@9.0.18(@vitest/runner@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.9(@testing-library/dom@10.4.0)(prettier@3.5.1))(vitest@3.2.4)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      prompts: 2.4.2
+      storybook: 9.0.9(@testing-library/dom@10.4.0)(prettier@3.5.1)
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      '@vitest/runner': 3.2.4
+      vitest: 3.2.4(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.3.0)(sass-embedded@1.86.0)(sass@1.88.0)(stylus@0.64.0)(terser@5.43.1)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@storybook/angular@9.0.18(d425be5f86d5ee0e3a685cd1b4b11959)':
     dependencies:


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

This adds a new `@analogjs/storybook-angular/testing` entrypoint to enable support for the `@storybook/addon-vitest` package that allows you to run your Storybook stories using Vitest in browser mode.

Storybook docs: https://storybook.js.org/docs/writing-tests/integrations/vitest-addon
Reference repo for setup: https://github.com/brandonroberts/angular-vite-storybook

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOTRpMGk2ZTM0NnNxZjFycnFvMjV2b3RiNnU5NmJwaTdmc2VuejJjciZlcD12MV9naWZzX3NlYXJjaCZjdD1n/IoQETeY2ue5bi/giphy.gif"/>