### PR TITLE
fix(vite-plugin-angular): detect ESM import for storybook transform

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-storybook-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-storybook-plugin.ts
@@ -1,17 +1,31 @@
-export function angularStorybookPlugin() {
+import fs from 'node:fs';
+import { resolve } from 'node:path';
+
+export function angularStorybookPlugin(workspaceRoot: string) {
+  const esmPath = resolve(
+    workspaceRoot,
+    'node_modules/@storybook/angular/dist/client/index.mjs',
+  );
+  const hasESM = fs.existsSync(esmPath);
+
   return {
     name: 'analogjs-storybook-import-plugin',
-    transform(code: string) {
+    transform(code: string, id: string) {
+      if (id.includes('node_modules')) {
+        return;
+      }
+
       if (code.includes('"@storybook/angular"')) {
         return code.replace(
           /\"@storybook\/angular\"/g,
-          '"@storybook/angular/dist/client/index.js"',
+          `"@storybook/angular/dist/client/index.${hasESM ? 'm' : ''}js"`,
         );
       }
+
       if (code.includes("'@storybook/angular'")) {
         return code.replace(
           /\'@storybook\/angular\'/g,
-          "'@storybook/angular/dist/client/index.js'",
+          `'@storybook/angular/dist/client/index.${hasESM ? 'm' : ''}js'`,
         );
       }
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -613,7 +613,8 @@ export function angular(options?: PluginOptions): Plugin[] {
       supportedBrowsers: pluginOptions.supportedBrowsers,
       jit,
     }),
-    (isStorybook && angularStorybookPlugin()) as Plugin,
+    (isStorybook &&
+      angularStorybookPlugin(pluginOptions.workspaceRoot)) as Plugin,
     routerPlugin(),
     pendingTasksPlugin(),
     nxFolderPlugin(),


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1831 

## What is the new behavior?

The ESM import will be preferred with Storybook for newer versions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
