### PR TITLE
fix(storybook-angular): fix support for CSS and preprocessor options

### DIFF
--- a/apps/analog-app/.storybook/preview.ts
+++ b/apps/analog-app/.storybook/preview.ts
@@ -1,5 +1,3 @@
-import 'zone.js';
-
 import { applicationConfig, type Preview } from '@analogjs/storybook-angular';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 

--- a/apps/analog-app/project.json
+++ b/apps/analog-app/project.json
@@ -76,7 +76,11 @@
         "configDir": "apps/analog-app/.storybook",
         "compodoc": false,
         "compodocArgs": ["-e", "json", "-d", "."],
-        "port": 6006
+        "port": 6006,
+        "styles": ["apps/analog-app/src/styles.css"],
+        "stylePreprocessorOptions": {
+          "loadPaths": []
+        }
       }
     },
     "build-storybook": {
@@ -85,7 +89,11 @@
         "configDir": "apps/analog-app/.storybook",
         "compodoc": false,
         "compodocArgs": ["-e", "json", "-d", "."],
-        "outputDir": "dist/apps/storybook-static"
+        "outputDir": "dist/apps/storybook-static",
+        "styles": ["apps/analog-app/src/styles.css"],
+        "stylePreprocessorOptions": {
+          "loadPaths": []
+        }
       }
     }
   }

--- a/packages/storybook-angular/src/lib/build-storybook/schema.json
+++ b/packages/storybook-angular/src/lib/build-storybook/schema.json
@@ -69,6 +69,28 @@
       "type": "boolean",
       "description": "Experimental: Use zoneless change detection.",
       "default": false
+    },
+    "styles": {
+      "type": "array",
+      "description": "Global styles to be included in the build.",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
+    "stylePreprocessorOptions": {
+      "description": "Options to pass to style preprocessors.",
+      "type": "object",
+      "properties": {
+        "loadPaths": {
+          "description": "Paths to include.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/packages/storybook-angular/src/lib/start-storybook/schema.json
+++ b/packages/storybook-angular/src/lib/start-storybook/schema.json
@@ -105,6 +105,28 @@
       "type": "boolean",
       "description": "Experimental: Use zoneless change detection.",
       "default": false
+    },
+    "styles": {
+      "type": "array",
+      "description": "Global styles to be included in the build.",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
+    "stylePreprocessorOptions": {
+      "description": "Options to pass to style preprocessors.",
+      "type": "object",
+      "properties": {
+        "loadPaths": {
+          "description": "Paths to include.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

- Support for the `styles` and `stylePreprocessorOptions` options in the Storybook Angular builders has been fixed.
- Auto-import of zone.js for non-zoneless environments

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
