### PR TITLE
docs: update TypeScript target version to es2022

### DIFF
--- a/apps/docs-app/docs/features/testing/vitest.md
+++ b/apps/docs-app/docs/features/testing/vitest.md
@@ -171,14 +171,14 @@ Next, update the `test` target in the `angular.json` to use the `@analogjs/vites
 
 > You can also add a new target and name it `vitest` to run alongside your `test` target.
 
-Lastly, add the `src/test-setup.ts` to `files` array in the `tsconfig.spec.json` in the root of your project, set the `target` to `es2016`, and update the `types`.
+Lastly, add the `src/test-setup.ts` to `files` array in the `tsconfig.spec.json` in the root of your project, set the `target` to `es2022`, and update the `types`.
 
 ```json
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["vitest/globals", "node"]
   },
   "files": ["src/test-setup.ts"],


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1852

## What is the new behavior?
I'm not sure why the requirement was to set it specifically to 2016 in the first place, so maybe this is not a good change, but 2016 did cause issues with vitest fixtures, which is a fundamental part of vitest, so I thought it'll be good to update this doc. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
