### PR TITLE
test(vite-plugin-angular): fix path resolution for Windows

### DIFF
--- a/packages/vite-plugin-angular/src/lib/component-resolvers.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.ts
@@ -101,10 +101,7 @@ export class TemplateUrlsResolver {
     }
 
     const templateUrlPaths = getTemplateUrls(code).map(
-      (url) =>
-        `${url}|${normalizePath(
-          resolve(dirname(id), url).replace(/\\/g, '/'),
-        )}`,
+      (url) => `${url}|${normalizePath(resolve(dirname(id), url))}`,
     );
 
     this.templateUrlsCache.set(id, { code, templateUrlPaths });


### PR DESCRIPTION
## PR Checklist

On Windows generated paths are `./app.component.css|C:/path/to/src/app.component.css` rather than `./app.component.css|/path/to/src/app.component.css`, causing tests to fail. Trying to understand where this issue is coming from, I found some older PRs (#275 and #799), that tried to utilize vite's `normalizePath()`, which [used to](https://github.com/vitejs/vite/commit/e2137b71a5a82580b2cf45e84ead136052014ac7#diff-071a32aedd2ea59472ebb69fb456e818b103d1a332da632e12c2d54395938ad1L63) also take care of Windows' drive letters, though that was ages ago.

Closes #1860

## What is the new behavior?

1) `./app.component.css|/path/to/src/app.component.css` now properly maps to `./app.component.css|/path/to/src/app.component.css`.
2) I changed the helper function into a proper matcher, making it easier in the future to see what the problem is:
```
// Previously
Expected: true
Received: false

// Now (roughly)
- Expected
+ Received
[
  -./app.component.css|/path/to/src/app.component.css
  +./app.component.css|C:/path/to/src/app.component.css
]
```
3) Removed redundant `.replace(/\\/g, '/')` which is already taken care of by `normalizePath()`.
4) Changed nomenclature in test to reflect typical test nomenclature, reducing ambiguity. E.g. `actualPaths -> expectedPaths` because actual actual paths :smirk: are generated by the resolver.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
