### PR TITLE
fix(vite-plugin-angular): add back defaults for `resolve.conditions`

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -13,6 +13,7 @@ import {
   ViteDevServer,
   preprocessCSS,
   ResolvedConfig,
+  defaultClientConditions,
 } from 'vite';
 import * as ngCompiler from '@angular/compiler';
 
@@ -210,7 +211,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             },
           },
           resolve: {
-            conditions: ['style'],
+            conditions: ['style', ...defaultClientConditions],
           },
         };
       },


### PR DESCRIPTION
## PR Checklist

Closes #1847

## What is the new behavior?

Defaults are added back. Note that I didn't add tests, because I have no idea how that could be tested or whether it even should be. Also I didn't investigate whether adding `'style'` is even necessary and just assumed it to be correct. If it isn't, the entire block could be removed instead, as there is a fallback to the defaults in that case.

## Does this PR introduce a breaking change?

- [x] Yes, in theory
- [x] No, in practice

The fact that this was not done when upgrading to Vite 6 was a breaking change. So if at all this could only be a breaking change for people who somehow started relying on the broken behavior since then. Because people might have used now obsolete workarounds, it's definitely worth adding a note though.