### PR TITLE
fix(storybook-angular): flatten array of provided project annotations

### DIFF
--- a/packages/storybook-angular/src/lib/testing.ts
+++ b/packages/storybook-angular/src/lib/testing.ts
@@ -29,6 +29,8 @@ export function setProjectAnnotations(
 ): NormalizedProjectAnnotations<AngularRenderer> {
   return originalSetProjectAnnotations([
     renderAnnotations,
-    projectAnnotations,
+    ...(Array.isArray(projectAnnotations)
+      ? projectAnnotations
+      : [projectAnnotations]),
   ]) as NormalizedProjectAnnotations<AngularRenderer>;
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1864

## What is the new behavior?

The project annotations array passed to `setProjectAnnotations` is flattened before being passed to the internal `setProjectAnnotations` function so they are correctly applied globally to the stories.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdldWE4ZjJrdzJydWFxNWhic3I2ZDR0dTRlcXpkZzI4ajgzejhzZmZlZSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/87b6lrxvf4uJIL1zl3/giphy.gif"/>