### PR TITLE
feat: update Angular builders to compile to ESM

### DIFF
--- a/packages/storybook-angular/src/lib/builders.json
+++ b/packages/storybook-angular/src/lib/builders.json
@@ -1,12 +1,12 @@
 {
   "builders": {
     "build-storybook": {
-      "implementation": "./build-storybook/build-storybook",
+      "implementation": "./build-storybook/build-storybook.js",
       "schema": "./build-storybook/schema.json",
       "description": "Build storybook"
     },
     "start-storybook": {
-      "implementation": "./start-storybook/start-storybook",
+      "implementation": "./start-storybook/start-storybook.js",
       "schema": "./start-storybook/schema.json",
       "description": "Start storybook"
     }

--- a/packages/storybook-angular/tsconfig.json
+++ b/packages/storybook-angular/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "es2022"
   },
   "files": [],
   "include": [],

--- a/packages/storybook-angular/tsconfig.lib.json
+++ b/packages/storybook-angular/tsconfig.lib.json
@@ -9,9 +9,9 @@
   },
   "include": ["src/**/*.ts"],
   "exclude": [
-    "src/generators/app/files/**/*",
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
+    "src/test-setup.ts",
     "**/template/**"
   ]
 }

--- a/packages/vite-plugin-angular-tools/builders.json
+++ b/packages/vite-plugin-angular-tools/builders.json
@@ -1,12 +1,12 @@
 {
   "builders": {
     "vite-dev-server": {
-      "implementation": "./src/builders/vite-dev-server/dev-server.impl",
+      "implementation": "./src/builders/vite-dev-server/dev-server.impl.js",
       "schema": "./src/builders/vite-dev-server/schema.json",
       "description": "Vite dev server."
     },
     "vite": {
-      "implementation": "./src/builders/vite/vite-build.impl",
+      "implementation": "./src/builders/vite/vite-build.impl.js",
       "schema": "./src/builders/vite/schema.json",
       "description": "Build with Vite."
     },

--- a/packages/vite-plugin-angular-tools/tsconfig.json
+++ b/packages/vite-plugin-angular-tools/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "es2022"
   },
   "files": [],
   "include": [],

--- a/packages/vitest-angular/builders.json
+++ b/packages/vitest-angular/builders.json
@@ -1,12 +1,12 @@
 {
   "builders": {
     "test": {
-      "implementation": "./src/lib/builders/test/vitest.impl",
+      "implementation": "./src/lib/builders/test/vitest.impl.js",
       "schema": "./src/lib/builders/test/schema.json",
       "description": "Run tests with Vitest"
     },
     "build-test": {
-      "implementation": "./src/lib/builders/build/vitest.impl",
+      "implementation": "./src/lib/builders/build/vitest.impl.js",
       "schema": "./src/lib/builders/build/schema.json",
       "description": "Bundle and run tests with Vitest using the Application Builder"
     }

--- a/packages/vitest-angular/tsconfig.json
+++ b/packages/vitest-angular/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "es2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Angular CLI builders have support to be shipped as ESM, while schematics are still only supported with CommonJS. This updates the compilation configuration to `es2022` where applicable.

Nx executors are still built as CommonJS

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

