### PR TITLE
feat(vite-plugin-angular): add support for file replacements per environment

### DIFF
--- a/apps/analog-app/src/app/cart.service.ts
+++ b/apps/analog-app/src/app/cart.service.ts
@@ -1,5 +1,4 @@
-import { inject, Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 import type { Product } from './products';
 
 @Injectable({
@@ -7,8 +6,6 @@ import type { Product } from './products';
 })
 export class CartService {
   items: Product[] = [];
-
-  private readonly http = inject(HttpClient);
 
   addToCart(product: Product) {
     this.items.push(product);
@@ -21,11 +18,5 @@ export class CartService {
   clearCart() {
     this.items = [];
     return this.items;
-  }
-
-  getShippingPrices() {
-    return this.http.get<{ type: string; price: number }[]>(
-      '/assets/shipping.json',
-    );
   }
 }

--- a/apps/analog-app/src/app/pages/shipping/index.page.ts
+++ b/apps/analog-app/src/app/pages/shipping/index.page.ts
@@ -1,7 +1,7 @@
 import { AsyncPipe, CurrencyPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 
-import { CartService } from '../../cart.service';
+import { ShippingService } from './shipping-service';
 
 @Component({
   selector: 'app-shipping',
@@ -10,7 +10,7 @@ import { CartService } from '../../cart.service';
   styleUrls: ['./shipping.scss'],
 })
 export default class ShippingComponent {
-  private readonly cartService = inject(CartService);
+  private readonly shippingService = inject(ShippingService);
 
-  shippingCosts = this.cartService.getShippingPrices();
+  shippingCosts = this.shippingService.getShippingPrices();
 }

--- a/apps/analog-app/src/app/pages/shipping/shipping-service-server.ts
+++ b/apps/analog-app/src/app/pages/shipping/shipping-service-server.ts
@@ -1,0 +1,16 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ShippingService {
+  private readonly http = inject(HttpClient);
+
+  getShippingPrices() {
+    console.log('on server');
+    return this.http.get<{ type: string; price: number }[]>(
+      '/assets/shipping.json',
+    );
+  }
+}

--- a/apps/analog-app/src/app/pages/shipping/shipping-service.ts
+++ b/apps/analog-app/src/app/pages/shipping/shipping-service.ts
@@ -1,0 +1,16 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ShippingService {
+  private readonly http = inject(HttpClient);
+
+  getShippingPrices() {
+    console.log('on client');
+    return this.http.get<{ type: string; price: number }[]>(
+      '/assets/shipping.json',
+    );
+  }
+}

--- a/apps/analog-app/src/environments/environment.prod.ts
+++ b/apps/analog-app/src/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: true,
+};

--- a/apps/analog-app/src/environments/environment.ts
+++ b/apps/analog-app/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: false,
+};

--- a/apps/analog-app/src/main.ts
+++ b/apps/analog-app/src/main.ts
@@ -1,7 +1,11 @@
 import 'zone.js';
 import { bootstrapApplication } from '@angular/platform-browser';
-
+import { environment } from './environments/environment';
 import { AppComponent } from './app/app.component';
 import { appConfig } from './app/app.config';
+
+if (!environment.production) {
+  console.log('dev mode');
+}
 
 bootstrapApplication(AppComponent, appConfig);

--- a/apps/analog-app/vite.config.ts
+++ b/apps/analog-app/vite.config.ts
@@ -15,7 +15,28 @@ if (process.env['NETLIFY'] === 'true') {
 }
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode, isSsrBuild }) => {
+export default defineConfig(({ mode }) => {
+  const fileReplacements =
+    mode === 'production'
+      ? [
+          {
+            replace: 'apps/analog-app/src/environments/environment.ts',
+            with: 'apps/analog-app/src/environments/environment.prod.ts',
+          },
+          {
+            replace:
+              'apps/analog-app/src/app/pages/shipping/shipping-service.ts',
+            ssr: 'apps/analog-app/src/app/pages/shipping/shipping-service-server.ts',
+          },
+        ]
+      : [
+          {
+            replace:
+              'apps/analog-app/src/app/pages/shipping/shipping-service.ts',
+            ssr: 'apps/analog-app/src/app/pages/shipping/shipping-service-server.ts',
+          },
+        ];
+
   return {
     root: __dirname,
     publicDir: 'src/public',
@@ -32,6 +53,7 @@ export default defineConfig(({ mode, isSsrBuild }) => {
         apiPrefix: 'api',
         additionalPagesDirs: ['/libs/shared/feature'],
         additionalAPIDirs: ['/libs/shared/feature/src/api'],
+        fileReplacements,
         prerender: {
           routes: [
             '/',

--- a/apps/docs-app/docs/guides/migrating.md
+++ b/apps/docs-app/docs/guides/migrating.md
@@ -117,16 +117,13 @@ Read [here](https://vitejs.dev/guide/env-and-mode.html) for about more informati
 
 ### Using File Replacements
 
-You can also use the `replaceFiles()` plugin from Nx to replace files during your build.
-
-Import the plugin and set it up:
+You can also use the `fileReplacements` option to replace files.
 
 ```ts
 /// <reference types="vitest" />
 
 import { defineConfig } from 'vite';
 import analog from '@analogjs/platform';
-import { replaceFiles } from '@nx/vite/plugins/rollup-replace-files.plugin';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -137,14 +134,17 @@ export default defineConfig(({ mode }) => ({
     mainFields: ['module'],
   },
   plugins: [
-    analog(),
-    mode === 'production' &&
-      replaceFiles([
-        {
-          replace: './src/environments/environment.ts',
-          with: './src/environments/environment.prod.ts',
-        },
-      ]),
+    analog({
+      fileReplacements:
+        mode === 'production'
+          ? [
+              {
+                replace: 'src/environments/environment.ts',
+                with: 'src/environments/environment.prod.ts',
+              },
+            ]
+          : [],
+    }),
   ],
   test: {
     globals: true,
@@ -157,20 +157,6 @@ export default defineConfig(({ mode }) => ({
     'import.meta.vitest': mode !== 'production',
   },
 }));
-```
-
-Add the environment files to `files` array in the `tsconfig.app.json` may also be necessary.
-
-```json
-{
-  "extends": "./tsconfig.json",
-  // other config
-  "files": [
-    "src/main.ts",
-    "src/main.server.ts",
-    "src/environments/environment.prod.ts"
-  ]
-}
 ```
 
 ## Copying Assets

--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -89,6 +89,10 @@ export interface Options {
    * Disable type checking diagnostics by the Angular compiler
    */
   disableTypeChecking?: boolean;
+  /**
+   * File replacements
+   */
+  fileReplacements?: PluginOptions['fileReplacements'];
 }
 
 export { PrerenderContentDir, PrerenderContentFile };

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -61,6 +61,7 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
       additionalContentDirs: platformOptions.additionalContentDirs,
       liveReload: platformOptions.liveReload,
       inlineStylesExtension: platformOptions.inlineStylesExtension,
+      fileReplacements: platformOptions.fileReplacements,
       ...(opts?.vite ?? {}),
     }),
     serverModePlugin(),

--- a/packages/vite-plugin-angular/src/lib/plugins/file-replacements.plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/plugins/file-replacements.plugin.ts
@@ -1,0 +1,84 @@
+// source: https://github.com/Myrmod/vitejs-theming/blob/master/build-plugins/rollup/replace-files.js
+import { isAbsolute, resolve } from 'node:path';
+import { Plugin } from 'vite';
+
+export function replaceFiles(
+  replacements: FileReplacement[],
+  workspaceRoot: string,
+): Plugin | false {
+  if (!replacements?.length) {
+    return false;
+  }
+
+  return {
+    name: 'rollup-plugin-replace-files',
+    enforce: 'pre',
+    async resolveId(source, importer, options) {
+      const resolved = await this.resolve(source, importer, {
+        ...options,
+        skipSelf: true,
+      });
+      /**
+       * The reason we're using endsWith here is because the resolved id
+       * will be the absolute path to the file. We want to check if the
+       * file ends with the file we're trying to replace, which will be essentially
+       * the path from the root of our workspace.
+       */
+      const mappedReplacements = replacements.map((fr: FileReplacement) => {
+        const frSSR = fr as FileReplacementSSR;
+        const frWith = fr as FileReplacementWith;
+
+        return {
+          ...fr,
+          ssr: frSSR.ssr
+            ? isAbsolute(frSSR.ssr)
+              ? frSSR.ssr
+              : resolve(workspaceRoot, frSSR.ssr)
+            : '',
+          with: frWith.with
+            ? isAbsolute(frWith.with)
+              ? frWith.with
+              : resolve(workspaceRoot, frWith.with)
+            : '',
+        };
+      });
+      const foundReplace = mappedReplacements.find((replacement) =>
+        resolved?.id?.endsWith(replacement.replace),
+      );
+      if (foundReplace) {
+        try {
+          if (this.environment.name === 'ssr' && foundReplace.ssr) {
+            // return new file id for ssr
+            return {
+              id: foundReplace.ssr,
+            };
+          } else if (foundReplace.ssr) {
+            return null;
+          }
+
+          // return new file id
+          return {
+            id: foundReplace.with,
+          };
+        } catch (err) {
+          console.error(err);
+          return null;
+        }
+      }
+      return null;
+    },
+  };
+}
+
+export type FileReplacement = FileReplacementWith | FileReplacementSSR;
+
+export interface FileReplacementBase {
+  replace: string;
+}
+export interface FileReplacementWith extends FileReplacementBase {
+  with: string;
+}
+
+export interface FileReplacementSSR extends FileReplacementBase {
+  ssr: string;
+}


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Adds support for file replacements to the `analog` and `vite-plugin-angular` plugins. File replacements can also be configured per environment, so client/SSR-specific replacements can be configured.

```ts
import analog from '@analogjs/platform';
import { defineConfig } from 'vite';

// https://vitejs.dev/config/
export default defineConfig(({ mode }) => {
  return {
    plugins: [
      analog({
        fileReplacements:
          mode === 'production'
            ? [
                {
                  replace: 'src/environments/environment.ts',
                  with: 'src/environments/environment.prod.ts',
                },
                {
                  replace: 'src/app/pages/shipping/shipping-service.ts', // client-only service
                  ssr: 'src/app/pages/shipping/shipping-service-server.ts', // server-only service
                },
              ]
            : [
                {
                  replace: 'src/app/pages/shipping/shipping-service.ts', // client-only service
                  ssr: 'src/app/pages/shipping/shipping-service-server.ts', // server-only service
                },
              ],
      }),
    ]
  };
});
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdldXVjb3ppenNza2p0eWlybDhmdTFlM3dsMTRmcjhncXg3YXBwcjMybSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/YebCIK19XH8DvK0nep/giphy.gif"/>