### PR TITLE
feat(nx-plugin): default to es2022 when setting up Vitest

### DIFF
--- a/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/testing/vitest.md
+++ b/apps/docs-app/i18n/de/docusaurus-plugin-content-docs/current/features/testing/vitest.md
@@ -142,14 +142,14 @@ Als Nächstes aktualisiere das Ziel `test` in der Datei `angular.json`, um den B
 
 > Du kannst auch ein neues Ziel hinzufügen und es `vitest` nennen, um es neben deinem `test`-Ziel auszuführen.
 
-Schließlich füge die Datei `src/test-setup.ts` zum Array `files` in der Datei `tsconfig.spec.json` im Stammverzeichnis des Projekts hinzu, setze das `target` auf `es2016` und aktualisiere die `types`.
+Schließlich füge die Datei `src/test-setup.ts` zum Array `files` in der Datei `tsconfig.spec.json` im Stammverzeichnis des Projekts hinzu, setze das `target` auf `es2022` und aktualisiere die `types`.
 
 ```json
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["vitest/globals", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/testing/vitest.md
+++ b/apps/docs-app/i18n/es/docusaurus-plugin-content-docs/current/features/testing/vitest.md
@@ -181,7 +181,7 @@ Por último, añade `src/test-setup.ts` al arreglo `files` en el archivo `tsconf
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["vitest/globals", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/testing/vitest.md
+++ b/apps/docs-app/i18n/zh-hans/docusaurus-plugin-content-docs/current/features/testing/vitest.md
@@ -178,14 +178,14 @@ getTestBed().initTestEnvironment(
 
 > 你也可以添加一个新的目标并命名为 `vitest` 以与 `test` 目标一起运行。
 
-最后，将 `src/test-setup.ts` 添加到项目根目录的 `tsconfig.spec.json` 的 `files` 数组中，将 `target` 设置为 `es2016`，并更新 `types`。
+最后，将 `src/test-setup.ts` 添加到项目根目录的 `tsconfig.spec.json` 的 `files` 数组中，将 `target` 设置为 `es2022`，并更新 `types`。
 
 ```json
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["vitest/globals", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/apps/ng-app/tsconfig.spec.json
+++ b/apps/ng-app/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "types": ["node", "vitest/globals"],
-    "target": "es2016"
+    "target": "es2022"
   },
   "files": ["src/test-setup.ts"],
   "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/packages/create-analog/template-blog/tsconfig.spec.json
+++ b/packages/create-analog/template-blog/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["node", "vitest/globals"]
   },
   "files": ["src/test-setup.ts"],

--- a/packages/create-analog/template-latest/tsconfig.spec.json
+++ b/packages/create-analog/template-latest/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["node", "vitest/globals"]
   },
   "files": ["src/test-setup.ts"],

--- a/packages/nx-plugin/src/generators/init/lib/update-test-tsconfig.ts
+++ b/packages/nx-plugin/src/generators/init/lib/update-test-tsconfig.ts
@@ -31,7 +31,7 @@ export function updateTestTsConfig(
       (json) => {
         json.compilerOptions ??= {};
         json.compilerOptions.module = undefined;
-        json.compilerOptions.target ??= 'es2016';
+        json.compilerOptions.target ??= 'es2022';
         json.compilerOptions.types = ['vitest/globals', 'node'];
         json.files = ['src/test-setup.ts'];
 

--- a/packages/nx-plugin/src/generators/setup-vitest/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/setup-vitest/generator.spec.ts
@@ -133,7 +133,7 @@ describe('setup-vitest generator', () => {
 
     // Check all modifications made by updateTsConfig
     expect(tsconfig.compilerOptions.module).toBeUndefined();
-    expect(tsconfig.compilerOptions.target).toBe('es2016');
+    expect(tsconfig.compilerOptions.target).toBe('es2022');
     expect(tsconfig.compilerOptions.types).toEqual(['node', 'vitest/globals']);
     expect(tsconfig.files).toEqual(['src/test-setup.ts']);
   });

--- a/packages/nx-plugin/src/generators/setup-vitest/lib/update-tsconfig.ts
+++ b/packages/nx-plugin/src/generators/setup-vitest/lib/update-tsconfig.ts
@@ -28,7 +28,7 @@ export function updateTsConfig(tree: Tree, schema: SetupVitestGeneratorSchema) {
       (json) => {
         json.compilerOptions ??= {};
         json.compilerOptions.module = undefined;
-        json.compilerOptions.target ??= 'es2016';
+        json.compilerOptions.target ??= 'es2022';
         json.files = ['src/test-setup.ts'];
         json.compilerOptions.types = (json.compilerOptions.types ?? ['node'])
           .filter((type) => type !== 'jest')

--- a/packages/vitest-angular/README.md
+++ b/packages/vitest-angular/README.md
@@ -85,6 +85,7 @@ export default defineConfig(({ mode }) => ({
 Next, define a `src/test-setup.ts` file to setup the `TestBed`:
 
 ```ts
+import '@angular/compiler';
 import '@analogjs/vitest-angular/setup-zone';
 
 import {
@@ -102,6 +103,7 @@ getTestBed().initTestEnvironment(
 If you are using `Zoneless` change detection, use the following setup:
 
 ```ts
+import '@angular/compiler';
 import '@analogjs/vitest-angular/setup-snapshots';
 
 import { provideZonelessChangeDetection, NgModule } from '@angular/core';
@@ -142,14 +144,14 @@ Next, update the `test` target in the `angular.json` to use the `@analogjs/vites
 }
 ```
 
-Lastly, add the `src/test-setup.ts` to `files` array in the `tsconfig.spec.json` in the root of your project, set the `target` to `es2016`, and update the `types`.
+Lastly, add the `src/test-setup.ts` to `files` array in the `tsconfig.spec.json` in the root of your project, set the `target` to `es2022`, and update the `types`.
 
 ```json
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "target": "es2016",
+    "target": "es2022",
     "types": ["vitest/globals", "node"]
   },
   "files": ["src/test-setup.ts"],
@@ -275,3 +277,7 @@ export default defineConfig(({ mode }) => ({
   plugins: [angular(), nxViteTsPaths()],
 }));
 ```
+
+## IDE Support
+
+Tests can also be run directly from your IDE using the Vitest [IDE integrations](https://vitest.dev/guide/ide) for VS Code or JetBrains IDEs.


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When adding Vitest, es2022 is set as the default. It was previously set to `es2016` to account for Zone applications, and tests using the Angular CDK, but out of the box can be on latest.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
