### PR TITLE
feat(content): introduce content resources and loaders

### DIFF
--- a/apps/blog-app/src/app/pages/archived/index.page.ts
+++ b/apps/blog-app/src/app/pages/archived/index.page.ts
@@ -1,27 +1,30 @@
-import { injectContentFiles } from '@analogjs/content';
+import { contentFilesResource } from '@analogjs/content/resources';
 import { Component } from '@angular/core';
 import { ArchivedPostAttributes } from './models';
 import { RouterLink } from '@angular/router';
-import { NgFor } from '@angular/common';
 
 @Component({
   standalone: true,
-  imports: [RouterLink, NgFor],
+  imports: [RouterLink],
   template: `
     <h1>Archived</h1>
     <p>Drafts are filtered out here.</p>
     <ul>
-      <li *ngFor="let post of posts">
-        <a [routerLink]="post.slug"> {{ post.attributes.title }}</a>
-      </li>
+      @for (post of posts.value(); track post.slug) {
+        <li>
+          <a [routerLink]="post.slug"> {{ post.attributes.title }}</a>
+        </li>
+      }
     </ul>
   `,
 })
 export default class ArchivedComponent {
-  readonly posts = injectContentFiles<ArchivedPostAttributes>((contentFile) => {
-    return (
-      !contentFile.attributes.draft &&
-      contentFile.filename.includes('/archived/')
-    );
-  });
+  readonly posts = contentFilesResource<ArchivedPostAttributes>(
+    (contentFile) => {
+      return (
+        !contentFile.attributes.draft &&
+        contentFile.filename.includes('/archived/')
+      );
+    },
+  );
 }

--- a/apps/blog-app/src/app/pages/blog/index.page.ts
+++ b/apps/blog-app/src/app/pages/blog/index.page.ts
@@ -1,23 +1,28 @@
-import { injectContentFiles } from '@analogjs/content';
 import { Component } from '@angular/core';
-import { PostAttributes } from './models';
 import { RouterLink } from '@angular/router';
-import { NgFor } from '@angular/common';
+import { contentFilesResource } from '@analogjs/content/resources';
+
+import { PostAttributes } from './models';
 
 @Component({
   standalone: true,
-  imports: [RouterLink, NgFor],
+  imports: [RouterLink],
   template: `
     <h1>Blog</h1>
+
     <ul>
-      <li *ngFor="let post of posts">
-        <a [routerLink]="post.slug"> {{ post.attributes.title }}</a>
-      </li>
+      @for (post of contentFilesResource.value(); track post.slug) {
+        <li>
+          <a [routerLink]="post.slug"> {{ post.attributes.title }}</a>
+        </li>
+      }
     </ul>
   `,
 })
 export default class BlogComponent {
-  readonly posts = injectContentFiles<PostAttributes>((contentFile) => {
-    return !contentFile.filename.includes('/archived/');
-  });
+  readonly contentFilesResource = contentFilesResource<PostAttributes>(
+    (contentFile) => {
+      return !contentFile.filename.includes('/archived/');
+    },
+  );
 }

--- a/packages/content/resources/README.md
+++ b/packages/content/resources/README.md
@@ -1,0 +1,3 @@
+# @analogjs/content/resources
+
+Secondary entry point of `@analogjs/content`. It can be used by importing from `@analogjs/content/resources`.

--- a/packages/content/resources/ng-package.json
+++ b/packages/content/resources/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/content/resources/src/content-file-resource.ts
+++ b/packages/content/resources/src/content-file-resource.ts
@@ -1,0 +1,110 @@
+import { computed, inject, resource, Signal } from '@angular/core';
+import {
+  ContentFile,
+  parseRawContentFile,
+  injectContentFileLoader,
+} from '@analogjs/content';
+import { ActivatedRoute } from '@angular/router';
+
+import { toSignal } from '@angular/core/rxjs-interop';
+import { from } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+type ContentFileParams = Signal<
+  | string
+  | {
+      customFilename: string;
+    }
+>;
+
+async function getContentFile<
+  Attributes extends Record<string, any> = Record<string, any>,
+>(
+  contentFiles: Record<string, () => Promise<string>>,
+  slug: string,
+  fallback: string,
+): Promise<ContentFile<Attributes | Record<string, never>>> {
+  const filePath = `/src/content/${slug}`;
+  const contentFile =
+    contentFiles[`${filePath}.md`] ?? contentFiles[`${filePath}.agx`];
+
+  if (!contentFile) {
+    return {
+      filename: filePath,
+      attributes: {},
+      slug: '',
+      content: fallback,
+    } as ContentFile<Attributes | Record<string, never>>;
+  }
+
+  return contentFile().then(
+    (contentFile: string | { default: any; metadata: any }) => {
+      if (typeof contentFile === 'string') {
+        const { content, attributes } =
+          parseRawContentFile<Attributes>(contentFile);
+
+        return {
+          filename: filePath,
+          slug,
+          attributes,
+          content,
+        } as ContentFile<Attributes | Record<string, never>>;
+      }
+
+      return {
+        filename: filePath,
+        slug,
+        attributes: contentFile.metadata,
+        content: contentFile.default,
+      } as ContentFile<Attributes | Record<string, never>>;
+    },
+  );
+}
+
+/**
+ * Resource for requesting an individual content file
+ *
+ * @param params
+ * @param fallback
+ * @returns
+ */
+export function contentFileResource<
+  Attributes extends Record<string, any> = Record<string, any>,
+>(params?: ContentFileParams, fallback = 'No Content Found') {
+  const loaderPromise = injectContentFileLoader();
+  const contentFilesMap = toSignal(from(loaderPromise()));
+  const input =
+    params ||
+    toSignal(
+      inject(ActivatedRoute).paramMap.pipe(
+        map((params) => params.get('slug') as string),
+      ),
+      { requireSync: true },
+    );
+
+  return resource({
+    params: computed(() => ({ input: input(), files: contentFilesMap() })),
+    loader: async ({ params }) => {
+      const { input: param, files } = params;
+
+      if (typeof param === 'string') {
+        if (param) {
+          return getContentFile<Attributes>(files!, param, fallback);
+        }
+
+        return {
+          filename: '',
+          slug: '',
+          attributes: {},
+          content: fallback,
+        } as ContentFile<Attributes | Record<string, never>>;
+      } else {
+        return getContentFile<Attributes>(
+          files!,
+          param.customFilename,
+          fallback,
+        );
+      }
+    },
+  });
+}

--- a/packages/content/resources/src/content-files-resource.ts
+++ b/packages/content/resources/src/content-files-resource.ts
@@ -1,0 +1,26 @@
+import { resource } from '@angular/core';
+import {
+  injectContentListLoader,
+  InjectContentFilesFilterFunction,
+} from '@analogjs/content';
+
+import { toSignal } from '@angular/core/rxjs-interop';
+import { from } from 'rxjs';
+
+export function contentFilesResource<Attributes extends Record<string, any>>(
+  filterFn?: InjectContentFilesFilterFunction<Attributes> | undefined,
+) {
+  const contentListLoader = injectContentListLoader<Attributes>();
+  const contentList = toSignal(
+    from(
+      contentListLoader().then((items) =>
+        filterFn ? items.filter(filterFn) : items,
+      ),
+    ),
+  );
+
+  return resource({
+    params: contentList,
+    loader: async ({ params: list }) => list,
+  });
+}

--- a/packages/content/resources/src/index.ts
+++ b/packages/content/resources/src/index.ts
@@ -1,0 +1,2 @@
+export { contentFilesResource } from './content-files-resource';
+export { contentFileResource } from './content-file-resource';

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -2,7 +2,10 @@ export { AnchorNavigationDirective } from './lib/anchor-navigation.directive';
 export { injectContent } from './lib/content';
 export { ContentFile } from './lib/content-file';
 export { ContentRenderer, NoopContentRenderer } from './lib/content-renderer';
-export { injectContentFiles } from './lib/inject-content-files';
+export {
+  injectContentFiles,
+  InjectContentFilesFilterFunction,
+} from './lib/inject-content-files';
 export { MarkdownContentRendererService } from './lib/markdown-content-renderer.service';
 export {
   provideContent,
@@ -17,3 +20,12 @@ export {
   MarkedContentHighlighter,
   withHighlighter,
 } from './lib/marked-content-highlighter';
+export { injectContentFilesMap } from './lib/inject-content-files';
+export {
+  injectContentListLoader,
+  withContentListLoader,
+} from './lib/content-list-loader';
+export {
+  injectContentFileLoader,
+  withContentFileLoader,
+} from './lib/content-file-loader';

--- a/packages/content/src/lib/content-file-loader.ts
+++ b/packages/content/src/lib/content-file-loader.ts
@@ -1,0 +1,26 @@
+import { InjectionToken, Provider } from '@angular/core';
+import { inject } from '@angular/core';
+
+import { injectContentFilesMap } from './inject-content-files';
+
+type ContentFileLoaderFunction = () => Promise<
+  Record<string, () => Promise<string>>
+>;
+
+export const CONTENT_FILE_LOADER =
+  new InjectionToken<ContentFileLoaderFunction>(
+    '@analogjs/content/resource File Loader',
+  );
+
+export function injectContentFileLoader() {
+  return inject(CONTENT_FILE_LOADER) as ContentFileLoaderFunction;
+}
+
+export function withContentFileLoader(): Provider {
+  return {
+    provide: CONTENT_FILE_LOADER,
+    useFactory() {
+      return async () => injectContentFilesMap();
+    },
+  };
+}

--- a/packages/content/src/lib/content-files-token.ts
+++ b/packages/content/src/lib/content-files-token.ts
@@ -1,4 +1,4 @@
-import { InjectionToken, inject } from '@angular/core';
+import { InjectionToken, Signal, inject, signal } from '@angular/core';
 
 import { getAgxFiles, getContentFiles } from './get-content-files';
 import { CONTENT_FILES_LIST_TOKEN } from './content-files-list-token';
@@ -40,5 +40,14 @@ export const CONTENT_FILES_TOKEN = new InjectionToken<
     });
 
     return objectUsingSlugAttribute;
+  },
+});
+
+export const CONTENT_FILES_MAP_TOKEN = new InjectionToken<
+  Signal<Record<string, () => Promise<string>>>
+>('@analogjs/content Content Files', {
+  providedIn: 'root',
+  factory() {
+    return signal(inject(CONTENT_FILES_TOKEN));
   },
 });

--- a/packages/content/src/lib/content-list-loader.ts
+++ b/packages/content/src/lib/content-list-loader.ts
@@ -1,0 +1,27 @@
+import { InjectionToken, Provider } from '@angular/core';
+import { inject } from '@angular/core';
+
+import { ContentFile } from './content-file';
+import { injectContentFiles } from './inject-content-files';
+
+type ContentListLoaderFunction<Attributes extends Record<string, any>> =
+  () => Promise<ContentFile<Attributes>[]>;
+
+export const CONTENT_LIST_LOADER = new InjectionToken<
+  ContentListLoaderFunction<any>
+>('@analogjs/content/resource List Loader');
+
+export function injectContentListLoader<
+  Attributes extends Record<string, any>,
+>() {
+  return inject(CONTENT_LIST_LOADER) as ContentListLoaderFunction<Attributes>;
+}
+
+export function withContentListLoader(): Provider {
+  return {
+    provide: CONTENT_LIST_LOADER,
+    useFactory() {
+      return async () => injectContentFiles();
+    },
+  };
+}

--- a/packages/content/src/lib/inject-content-files.ts
+++ b/packages/content/src/lib/inject-content-files.ts
@@ -1,6 +1,8 @@
-import { ContentFile } from './content-file';
 import { inject } from '@angular/core';
+
+import { ContentFile } from './content-file';
 import { CONTENT_FILES_LIST_TOKEN } from './content-files-list-token';
+import { CONTENT_FILES_TOKEN } from './content-files-token';
 import { RenderTaskService } from './render-task.service';
 
 export function injectContentFiles<Attributes extends Record<string, any>>(
@@ -27,3 +29,7 @@ export type InjectContentFilesFilterFunction<T extends Record<string, any>> = (
   index: number,
   array: ContentFile<T>[],
 ) => boolean;
+
+export function injectContentFilesMap() {
+  return inject(CONTENT_FILES_TOKEN);
+}

--- a/packages/content/src/lib/provide-content.ts
+++ b/packages/content/src/lib/provide-content.ts
@@ -1,6 +1,8 @@
 import { Provider, InjectionToken } from '@angular/core';
 import { ContentRenderer, NoopContentRenderer } from './content-renderer';
 import { RenderTaskService } from './render-task.service';
+import { withContentFileLoader } from './content-file-loader';
+import { withContentListLoader } from './content-list-loader';
 
 export interface MarkdownRendererOptions {
   loadMermaid?: () => Promise<typeof import('mermaid')>;
@@ -11,6 +13,8 @@ const CONTENT_RENDERER_PROVIDERS: Provider[] = [
     provide: ContentRenderer,
     useClass: NoopContentRenderer,
   },
+  withContentFileLoader(),
+  withContentListLoader(),
 ];
 
 export function withMarkdownRenderer(

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,10 @@
       "@analogjs/content/prism-highlighter": [
         "packages/content/prism-highlighter/src/index.ts"
       ],
+      "@analogjs/content/resources": [
+        "./node_modules/@analogjs/content/resources",
+        "packages/content/resources/src/index.ts"
+      ],
       "@analogjs/content/shiki-highlighter": [
         "packages/content/shiki-highlighter/src/index.ts"
       ],


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1562 

## What is the new behavior?

Content loaders and resources are a signal-based way to load and consume content in Analog. They are also customizable to allow different async loaders to be used instead of the built-in default.

The two main APIs are the `contentFilesResource` that provides a list of content files with metadata, and the `contentFileResource` for retrieving an individual piece of content.

These are exposed as Angular resources under the `@analogjs/content/resources` entrypoint and do not change how the existing content APIs function.

The `blog-app` is also updated to use the content resource APIs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlamZxdjN5amt5MmFpd3ZsOWhtaWU1NDZuam1pdDZqbDEwdWVycG8yMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/wJTvUemBJ1DfVYLYUp/giphy.gif"/>