### PR TITLE
fix(vite-plugin-angular): use configured resolve conditions then defaults

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -226,7 +226,10 @@ export function angular(options?: PluginOptions): Plugin[] {
             },
           },
           resolve: {
-            conditions: ['style', ...defaultClientConditions],
+            conditions: [
+              'style',
+              ...(config.resolve?.conditions || defaultClientConditions),
+            ],
           },
         };
       },


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1880 

## What is the new behavior?

The `resolve.conditions` in the vite plugin appends the provided conditions, or falls back to the `defaultClientConditions`. This allows node packages including MSW to be resolved correctly when running tests.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcWQ4MXg4ZnhyNXZoODE5ZWpxc2ZhYm5qZ2J4Znc5ODRhdTA5NXl0byZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Ti1dpOjRAGEbcf7cOG/giphy.gif"/>