### PR TITLE
fix(storybook-angular): don't mangle class names during the build

### DIFF
--- a/packages/storybook-angular/preset/preset.mjs
+++ b/packages/storybook-angular/preset/preset.mjs
@@ -57,6 +57,7 @@ export const viteFinal = async (config, options) => {
             : 'css',
       }),
       angularOptionsPlugin(options, { normalizePath }),
+      storybookEsbuildPlugin(),
     ],
     define: {
       STORYBOOK_ANGULAR_OPTIONS: JSON.stringify({
@@ -124,6 +125,22 @@ function angularOptionsPlugin(options, { normalizePath }) {
       }
 
       return;
+    },
+  };
+}
+
+function storybookEsbuildPlugin() {
+  return {
+    name: 'analogjs-storybook-esbuild-config',
+    apply: 'build',
+    config() {
+      return {
+        esbuild: {
+          // Don't mangle class names during the build
+          // This fixes display of compodoc argtypes
+          keepNames: true,
+        },
+      };
     },
   };
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1886 

## What is the new behavior?

When building the Storybook, esbuild no longer mangles the class names, which are needed by Compodoc to display API reference tables correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlb3RyazBibHNpaGtyZGx3ZHdkYWtjOXY2NjZianU2bXZ6Z2ZsZXY3MCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/EEvaPhKOp7uphg148v/giphy.gif"/>