### PR TITLE
feat(astro-angular): use zoneless change detection by default

### DIFF
--- a/packages/astro-angular/package.json
+++ b/packages/astro-angular/package.json
@@ -35,18 +35,16 @@
     "@analogjs/vite-plugin-angular": "^2.0.0-beta.8"
   },
   "peerDependencies": {
-    "@angular-devkit/build-angular": ">=16.0.0",
-    "@angular/animations": ">=16.0.0",
-    "@angular/common": ">=16.0.0",
-    "@angular/compiler-cli": ">=16.0.0",
-    "@angular/compiler": ">=16.0.0",
-    "@angular/core": ">=16.0.0",
-    "@angular/language-service": ">=16.0.0",
-    "@angular/platform-browser": ">=16.0.0",
-    "@angular/platform-browser-dynamic": ">=16.0.0",
-    "@angular/platform-server": ">=16.0.0",
-    "rxjs": "^7.5.6",
-    "zone.js": ">=0.13.3",
+    "@angular/build": ">=20.0.0",
+    "@angular/animations": ">=20.0.0",
+    "@angular/common": ">=20.0.0",
+    "@angular/compiler-cli": ">=20.0.0",
+    "@angular/compiler": ">=20.0.0",
+    "@angular/core": ">=20.0.0",
+    "@angular/language-service": ">=20.0.0",
+    "@angular/platform-browser": ">=20.0.0",
+    "@angular/platform-server": ">=20.0.0",
+    "rxjs": "^7.8.0",
     "tslib": "^2.4.0"
   },
   "ng-update": {

--- a/packages/astro-angular/src/index.ts
+++ b/packages/astro-angular/src/index.ts
@@ -64,16 +64,7 @@ export default function (options?: AngularOptions): AstroIntegration {
   return {
     name: '@analogjs/astro-angular',
     hooks: {
-      'astro:config:setup': ({
-        addRenderer,
-        config,
-        isRestart,
-        updateConfig,
-      }) => {
-        if (!isRestart && config.markdown?.syntaxHighlight === 'shiki') {
-          config.markdown.syntaxHighlight = 'prism';
-        }
-
+      'astro:config:setup': ({ addRenderer, updateConfig }) => {
         addRenderer(getRenderer());
         updateConfig({
           vite: getViteConfiguration(
@@ -81,16 +72,7 @@ export default function (options?: AngularOptions): AstroIntegration {
           ) as DeepPartial<ViteUserConfig>,
         });
       },
-      'astro:config:done': ({ config }) => {
-        if (
-          'markdown' in config &&
-          config.markdown.syntaxHighlight === 'shiki'
-        ) {
-          console.warn(
-            `[warning] The Angular integration doesn't support Shiki syntax highlighting in MDX files. Overriding with Prism.\n
-To disable this warning, set the syntaxHighlight option in your astro.config.mjs mdx() integration to 'prism' or false.`,
-          );
-        }
+      'astro:config:done': () => {
         if (process.env['NODE_ENV'] === 'production') {
           enableProdMode();
         }

--- a/packages/astro-angular/src/server.ts
+++ b/packages/astro-angular/src/server.ts
@@ -1,4 +1,3 @@
-import 'zone.js/node';
 import type {
   ComponentMirror,
   EnvironmentProviders,
@@ -9,6 +8,7 @@ import {
   ApplicationRef,
   InjectionToken,
   reflectComponentType,
+  provideZonelessChangeDetection,
 } from '@angular/core';
 import {
   BEFORE_APP_SERIALIZED,
@@ -99,6 +99,7 @@ async function renderToStaticMarkup(
           STATIC_PROPS_HOOK_PROVIDER,
           provideServerRendering(),
           { provide: ɵSERVER_CONTEXT, useValue: 'analog' },
+          provideZonelessChangeDetection(),
           ...(Component.renderProviders || []),
         ],
       },


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGES:

The Angular and Astro integration default change detection strategy has changed.

BEFORE:

The integration relied on zone.js for change detection.

AFTER:

The integration uses zoneless change detection.

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
