### PR TITLE
fix(vite-plugin-angular): log warning when configured tsconfig path doesn't exist

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -7,7 +7,7 @@ import {
   relative,
   resolve,
 } from 'node:path';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 
 import * as compilerCli from '@angular/compiler-cli';
 import * as ts from 'typescript';
@@ -700,6 +700,12 @@ export function angular(options?: PluginOptions): Plugin[] {
     isLib: boolean,
   ) {
     if (options.tsconfig && isAbsolute(options.tsconfig)) {
+      if (!existsSync(options.tsconfig)) {
+        console.error(
+          `[@analogjs/vite-plugin-angular]: Unable to resolve tsconfig at ${options.tsconfig}. This causes compilation issues. Check the path or set the "tsconfig" property with an absolute path.`,
+        );
+      }
+
       return options.tsconfig;
     }
 
@@ -719,7 +725,15 @@ export function angular(options?: PluginOptions): Plugin[] {
       tsconfigFilePath = options.tsconfig;
     }
 
-    return resolve(root, tsconfigFilePath);
+    const resolvedPath = resolve(root, tsconfigFilePath);
+
+    if (!existsSync(resolvedPath)) {
+      console.error(
+        `[@analogjs/vite-plugin-angular]: Unable to resolve tsconfig at ${resolvedPath}. This causes compilation issues. Check the path or set the "tsconfig" property with an absolute path.`,
+      );
+    }
+
+    return resolvedPath;
   }
 
   async function performCompilation(config: ResolvedConfig, ids?: string[]) {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

A console error is logged when the `tsconfig` provided to the vite plugin does not exist. If the file is not found, TypeScript will fall back to its defaults, which causes compilation issues that are hard to debug.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNTE2bW40bXZqZ2Foenk4ZGdrY3d4OHAxZms0dTJzbm9uYjdnNTh1ZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Vcdbi5o470i9FACaZO/giphy.gif"/>