### PR TITLE
fix(create-analog): add overrides for Vitest 4 and .env gitignore

### DIFF
--- a/packages/create-analog/template-blog/_gitignore
+++ b/packages/create-analog/template-blog/_gitignore
@@ -42,3 +42,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Environment files
+.env*

--- a/packages/create-analog/template-blog/package.json
+++ b/packages/create-analog/template-blog/package.json
@@ -42,5 +42,8 @@
     "vite": "^7.0.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^4.0.0"
+  },
+  "overrides": {
+    "vitest": "$vitest"
   }
 }

--- a/packages/create-analog/template-latest/_gitignore
+++ b/packages/create-analog/template-latest/_gitignore
@@ -42,3 +42,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Environment files
+.env*

--- a/packages/create-analog/template-latest/package.json
+++ b/packages/create-analog/template-latest/package.json
@@ -42,5 +42,8 @@
     "vite": "^7.0.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^4.0.0"
+  },
+  "overrides": {
+    "vitest": "$vitest"
   }
 }

--- a/packages/create-analog/template-minimal/_gitignore
+++ b/packages/create-analog/template-minimal/_gitignore
@@ -42,3 +42,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Environment files
+.env*

--- a/packages/create-analog/template-minimal/package.json
+++ b/packages/create-analog/template-minimal/package.json
@@ -42,5 +42,8 @@
     "vite": "^7.0.0",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^4.0.0"
+  },
+  "overrides": {
+    "vitest": "$vitest"
   }
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

As the `@angular/build` package still depends on Vitest 3, overrides are added when creating new projects. Also added `.env` files to the `.gitignore` template files.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
