### PR TITLE
fix(storybook-angular): adjust package ranges for 1.x

### DIFF
--- a/packages/storybook-angular/package.json
+++ b/packages/storybook-angular/package.json
@@ -38,12 +38,12 @@
   },
   "main": "src/index.js",
   "dependencies": {
-    "@storybook/builder-vite": ">=8.6.0 || ^9.0.0"
+    "@storybook/builder-vite": "^8.6.0 || ^9.0.0"
   },
   "peerDependencies": {
-    "@storybook/angular": ">=8.6.0 || ^9.0.0",
+    "@storybook/angular": "^8.6.0 || ^9.0.0",
     "@analogjs/vite-plugin-angular": "*",
-    "storybook": ">=8.6.0 || ^9.0.0",
+    "storybook": "^8.6.0 || ^9.0.0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "engines": {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1912

## What is the new behavior?

Storybook versions `^8.6.0` or `^9.0.0` are supported in 1.x

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
