### PR TITLE
fix(platform): externalize @analogjs/content package until configured

### DIFF
--- a/apps/docs-app/docs/features/routing/content.md
+++ b/apps/docs-app/docs/features/routing/content.md
@@ -18,6 +18,27 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
+Next, enable the content package in the `vite.config.ts`
+
+```ts
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite';
+import analog from '@analogjs/platform';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    analog({
+      // enable content/highlighter
+      content: {
+        highlighter: 'prism',
+      },
+    }),
+  ],
+}));
+```
+
 ## Defining Content Routes
 
 Content routes include support for frontmatter, metatags, and syntax highlighting with PrismJS.
@@ -80,6 +101,7 @@ export default defineConfig({
   plugins: [
     analog({
       content: {
+        highlighter: 'prism',
         prismOptions: {
           additionalLangs: ['prism-diff'],
         },

--- a/packages/platform/src/lib/content-plugin.spec.ts
+++ b/packages/platform/src/lib/content-plugin.spec.ts
@@ -6,7 +6,7 @@ vi.mock('fs');
 import { contentPlugin } from './content-plugin';
 
 describe('content plugin', () => {
-  const [plugin] = contentPlugin();
+  const [plugin] = contentPlugin({ highlighter: 'prism' });
   const transform = (code: string, id: string): any => {
     // Use `any` because not of the signatures are callable and it also expects
     // to pass a valid `this` type.

--- a/packages/platform/src/lib/content-plugin.ts
+++ b/packages/platform/src/lib/content-plugin.ts
@@ -27,10 +27,7 @@ export function contentPlugin(
     markedOptions,
     shikiOptions,
     prismOptions,
-  }: ContentPluginOptions = {
-    highlighter: 'prism',
-    markedOptions: { mangle: true },
-  },
+  }: ContentPluginOptions = {},
   options?: Options,
 ): Plugin[] {
   const cache = new Map<string, Content>();
@@ -39,6 +36,23 @@ export function contentPlugin(
   const workspaceRoot = normalizePath(options?.workspaceRoot ?? process.cwd());
   let config: UserConfig;
   let root: string;
+
+  if (!highlighter) {
+    return [
+      {
+        name: 'analogjs-external-content',
+        config() {
+          return {
+            build: {
+              rollupOptions: {
+                external: ['@analogjs/content'],
+              },
+            },
+          };
+        },
+      },
+    ];
+  }
 
   return [
     {
@@ -129,7 +143,7 @@ export function contentPlugin(
           './content/marked/marked-setup.service.js'
         );
         const markedSetupService = new MarkedSetupService(
-          markedOptions,
+          { mangle: true, ...(markedOptions || {}) },
           markedHighlighter,
         );
         const mdContent = (await markedSetupService

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -473,7 +473,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         /**
          * Skip transforming content files
          */
-        if (id.includes('analog-content-')) {
+        if (id.includes('?') && id.includes('analog-content-')) {
           return;
         }
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1918 

## What is the new behavior?

The `@analogjs/content` package will be excluded from being bundled with the router unless the content highlighter is configured through the `analog` plugin in the `vite.config.ts` file. This produces smaller bundle sizes for apps that don't use the markdown content rendering functionality.

BEFORE:

```ts
/// <reference types="vitest" />

import { defineConfig } from 'vite';
import analog from '@analogjs/platform';

// https://vitejs.dev/config/
export default defineConfig(({ mode }) => ({
  build: {
    target: ['es2020'],
  },
  resolve: {
    mainFields: ['module'],
  },
  plugins: [
    analog(), // package is excluded from the build
  ],
  test: {
    globals: true,
    environment: 'jsdom',
    setupFiles: ['src/test-setup.ts'],
    include: ['**/*.spec.ts'],
    reporters: ['default'],
  },
  define: {
    'import.meta.vitest': mode !== 'production',
  },
}));
```

AFTER:

```ts
/// <reference types="vitest" />

import { defineConfig } from 'vite';
import analog from '@analogjs/platform';

// https://vitejs.dev/config/
export default defineConfig(({ mode }) => ({
  build: {
    target: ['es2020'],
  },
  resolve: {
    mainFields: ['module'],
  },
  plugins: [
    analog({
      content: {
        highlighter: 'shiki' // includes the package in the bundle
      }
    }),
  ],
  test: {
    globals: true,
    environment: 'jsdom',
    setupFiles: ['src/test-setup.ts'],
    include: ['**/*.spec.ts'],
    reporters: ['default'],
  },
  define: {
    'import.meta.vitest': mode !== 'production',
  },
}));
```

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdldGlueDlqYnNpMWsyZGVjMXBoeGl4MTRmeHZ5dXFuaGhtZjRmNTJkbCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/F555eFaXX8XfLXSaS9/giphy-downsized-medium.gif"/>