### PR TITLE
fix(vite-plugin-angular): expand optimization for Angular packages

### DIFF
--- a/packages/vite-plugin-angular/src/lib/router-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/router-plugin.ts
@@ -3,11 +3,14 @@ import { JavaScriptTransformer } from './utils/devkit.js';
 export function routerPlugin() {
   const javascriptTransformer = new JavaScriptTransformer({ jit: true }, 1);
 
+  /**
+   * Transforms Angular packages the didn't get picked up by Vite's pre-optimization.
+   */
   return {
     name: 'analogjs-router-optimization',
     enforce: 'pre',
     async transform(_code: string, id: string) {
-      if (id.includes('analogjs-') && id.includes('.mjs')) {
+      if (id.includes('fesm') && id.includes('.mjs')) {
         const path = id.split('?')[0];
         const contents = await javascriptTransformer.transformFile(path);
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1922

## What is the new behavior?

Buildable Angular libraries are transformed that are not picked up by Vite's pre-optimization.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
