### PR TITLE
fix(docs): add `netlify init` configuration steps for Netlify

### DIFF
--- a/apps/docs-app/docs/features/deployment/providers.md
+++ b/apps/docs-app/docs/features/deployment/providers.md
@@ -140,12 +140,41 @@ You can also check out [Github Integration](https://docs.zerops.io/references/gi
 
 Analog supports deploying on [Netlify](https://netlify.com/) with minimal configuration.
 
-### Deploying the Project
+### Deploying the project
 
 <Tabs groupId="porject-type">
   <TabItem label="Create analog" value="create-analog">
-In the build settings of your Netlify project, set the [publish directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/analog/public` to deploy the static assets and the [functions directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/analog` to deploy the server.
-  </TabItem>
+Configuration is easiest when using [Netlify CLI](https://developers.netlify.com/cli/).
+    
+1. Start by running this command:
+
+```bash
+npx netlify init
+```
+
+If this is a new Netlify project, you'll be prompted to initialize it; build settings will be automatically configured in a `netlify.toml` file.
+
+2. If you're using server-side functionality, you need to manually set the functions directory to `dist/analog` in your `netlify.toml`:
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "dist/analog/public"
+  functions = "dist/analog" # ← update this
+```
+
+3. Finally, deploy your app:
+
+```bash
+npx netlify deploy
+```
+
+#### Manual configuration
+
+Alternatively, you can configure your project's build settings in the Netlify app.
+
+Set the [publish directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/analog/public` to deploy the static assets and the [functions directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/analog` to deploy the server.
+</TabItem>
 
   <TabItem label="Nx" value="nx">
 In the build settings of your Netlify project on the web UI, do the following.


### PR DESCRIPTION
## PR Checklist

The Netlify deployment docs currently only document a manual configuration approach using the Netlify app's UI.

## What is the new behavior?

Using the Netlify CLI instead automatically configures the build settings, so this PR documents this as the preferred configuration approach, documents the `netlify.toml` that this generates, and moves the manual UI-based configuration to a "Manual configuration" subsection.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is out of scope for this PR but... FYI we'd love to be able to not need that manual functions dir step. Our current framework auto-configuration system doesn't support populating this field. We've never needed this for any other framework, because our assumption is that frameworks will respect the [Netlify Frameworks API](https://docs.netlify.com/build/frameworks/frameworks-api/) when targeting Netlify. Since you're using Nitro (which does this in its Netlify presets), I'm curious why this is ending up in `dist/analog`? 🤔

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?