### PR TITLE
perf(platform): use singleton instances for marked and highlighters for content

### DIFF
--- a/packages/platform/src/lib/content-plugin.ts
+++ b/packages/platform/src/lib/content-plugin.ts
@@ -150,10 +150,8 @@ export function contentPlugin(
         const { body, frontmatter } = frontmatterFn(fileContents);
 
         // parse markdown and highlight
-        const { MarkedSetupService } = await import(
-          './content/marked/marked-setup.service.js'
-        );
-        const markedSetupService = new MarkedSetupService(
+        const { getMarkedSetup } = await import('./content/marked/index.js');
+        const markedSetupService = getMarkedSetup(
           { mangle: true, ...(markedOptions || {}) },
           markedHighlighter,
         );

--- a/packages/platform/src/lib/content/marked/index.ts
+++ b/packages/platform/src/lib/content/marked/index.ts
@@ -1,6 +1,18 @@
 import { MarkedExtension } from 'marked';
+import { MarkedSetupService } from './marked-setup.service.js';
+import { MarkedContentHighlighter } from './marked-content-highlighter.js';
 
 export type WithMarkedOptions = {
   mangle?: boolean;
   extensions?: MarkedExtension[];
 };
+
+let markedSetupInstance: MarkedSetupService;
+
+export function getMarkedSetup(
+  options?: WithMarkedOptions,
+  highlighter?: MarkedContentHighlighter,
+) {
+  markedSetupInstance ??= new MarkedSetupService(options, highlighter);
+  return markedSetupInstance;
+}

--- a/packages/platform/src/lib/content/prism/index.ts
+++ b/packages/platform/src/lib/content/prism/index.ts
@@ -2,6 +2,9 @@ import { PrismHighlighter } from './prism-highlighter.js';
 
 export { PrismHighlighter };
 
+let highlighterInstance: PrismHighlighter;
+
 export function getPrismHighlighter() {
-  return new PrismHighlighter();
+  highlighterInstance ??= new PrismHighlighter();
+  return highlighterInstance;
 }

--- a/packages/platform/src/lib/content/shiki/index.ts
+++ b/packages/platform/src/lib/content/shiki/index.ts
@@ -7,11 +7,17 @@ import {
 
 export { ShikiHighlighter };
 
+let highlighterInstance: ShikiHighlighter;
+
 export function getShikiHighlighter({
   highlighter = {},
   highlight = {},
   container = '%s',
 }: WithShikiHighlighterOptions = {}): ShikiHighlighter {
+  if (highlighterInstance) {
+    return highlighterInstance;
+  }
+
   if (!highlighter.themes) {
     if (highlight.theme) {
       highlighter.themes = [highlight.theme];
@@ -31,10 +37,12 @@ export function getShikiHighlighter({
     delete highlighter.additionalLangs;
   }
 
-  return new ShikiHighlighter(
+  highlighterInstance = new ShikiHighlighter(
     highlighter as ShikiHighlighterOptions,
     highlight,
     container,
     !!highlighter.langs.includes('mermaid'),
   );
+
+  return highlighterInstance;
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Upon testing building the [Hashbrown](https://hashbrown.dev) docs, I ran into out-of-memory errors, longer than expected build times, and warnings from Shiki about multiple instances. The PR switches to a single instance for Marked, Prism, and Shiki to minimize memory usage and increase performance.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdleW84YWQ0ZDl5ODZnMHNtbXI2czlwNzRhNzJyb3F4ZTV5aHJpZzd5eCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/MaroHZljcgUjWTrvHF/giphy.gif"/>