### PR TITLE
fix(nx-plugin): bump Nx app generator to Vitest 4.x

### DIFF
--- a/packages/nx-plugin/src/utils/versions/ng_19_X/versions.ts
+++ b/packages/nx-plugin/src/utils/versions/ng_19_X/versions.ts
@@ -18,4 +18,4 @@ export const V19_X_VITE_TSCONFIG_PATHS = '^4.2.0';
 export const V19_X_VITEST = '^2.0.0';
 export const V19_X_VITE = '^5.0.0';
 export const NX_X_LATEST_VITE = '^7.0.0';
-export const NX_X_LATEST_VITEST = '^3.0.0';
+export const NX_X_LATEST_VITEST = '^4.0.0';


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Vitest 4 is installed in a new Nx workspace application

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
