### PR TITLE
refactor(docs): Simplify BlogComponent by removing NgFor & NgIf

### DIFF
--- a/apps/docs-app/docs/features/routing/content.md
+++ b/apps/docs-app/docs/features/routing/content.md
@@ -307,7 +307,7 @@ export interface PostAttributes {
 
 @Component({
   standalone: true,
-  imports: [MarkdownComponent],
+  imports: [MarkdownComponent, AsyncPipe],
   template: `
     @if (post$ | async; as post) {
       <h1>{{ post.attributes.title }}</h1>
@@ -432,7 +432,7 @@ export interface ProjectAttributes {
 
 @Component({
   standalone: true,
-  imports: [MarkdownComponent],
+  imports: [MarkdownComponent, AsyncPipe],
   template: `
     @if (project$ | async; as project) {
       <h1>{{ project.attributes.title }}</h1>


### PR DESCRIPTION
Removed `NgFor` import and updated template syntax to use `@for` directive for rendering posts.

## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Updated the template to use the new Angular control flow syntax `@for` `@if` and removed the unused `NgFor` `NgIf` and `<ng-container>` import. The component now follows the latest recommended Angular pattern for iteration.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

![gif](https://media1.tenor.com/m/U507ZChIWmQAAAAC/minimal-conciso.gif)
