### PR TITLE
feat(vite-plugin-angular): add support for rolldown-vite plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "ts-morph": "^26.0.0",
     "ts-node": "10.9.2",
     "typescript": "5.9.3",
-    "vite": "7.1.9",
+    "vite": "npm:rolldown-vite@latest",
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-inspect": "11.3.2",
     "vite-tsconfig-paths": "4.2.0",

--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -1,5 +1,6 @@
 import { VERSION } from '@angular/compiler-cli';
-import { Plugin } from 'vite';
+import type { Plugin } from 'vite';
+import * as vite from 'vite';
 import { crawlFrameworkPkgs } from 'vitefu';
 
 import { Options } from './options.js';
@@ -11,10 +12,16 @@ export function depsPlugin(options?: Options): Plugin[] {
     {
       name: 'analogjs-deps-plugin',
       config() {
+        const esbuild = options?.vite?.experimental?.useAngularCompilationAPI
+          ? {}
+          : { exclude: ['**/*.ts', '**/*.js'] };
+
+        const oxc = options?.vite?.experimental?.useAngularCompilationAPI
+          ? {}
+          : { exclude: ['**/*.ts', '**/*.js'] };
+
         return {
-          ...(options?.vite?.experimental?.useAngularCompilationAPI
-            ? {}
-            : { esbuild: { exclude: ['**/*.ts', '**/*.js'] } }),
+          ...(vite.rolldownVersion ? { oxc } : { esbuild }),
           ssr: {
             noExternal: [
               '@analogjs/**',

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -1,5 +1,5 @@
 import type { Plugin, UserConfig } from 'vite';
-
+import * as vite from 'vite';
 import { JavaScriptTransformer } from './utils/devkit.js';
 
 export function buildOptimizerPlugin({
@@ -36,7 +36,7 @@ export function buildOptimizerPlugin({
               ngServerMode: `${!!userConfig.build?.ssr}`,
             }
           : {},
-        esbuild: {
+        [vite.rolldownVersion ? 'oxc' : 'esbuild']: {
           define: isProd
             ? {
                 ngDevMode: 'false',

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -1,5 +1,5 @@
-import { Plugin, transformWithEsbuild, UserConfig } from 'vite';
-
+import { Plugin, UserConfig } from 'vite';
+import * as vite from 'vite';
 /**
  * Sets up test config for Vitest
  * and downlevels any dependencies that use
@@ -34,18 +34,33 @@ export function angularVitestPlugin(): Plugin {
         (/fesm2022/.test(id) && _code.includes('async ')) ||
         _code.includes('@angular/cdk')
       ) {
-        const { code, map } = await transformWithEsbuild(_code, id, {
-          loader: 'js',
-          format: 'esm',
-          target: 'es2016',
-          sourcemap: true,
-          sourcefile: id,
-        });
+        if (vite.rolldownVersion) {
+          const { code, map } = await vite.transformWithOxc(_code, id, {
+            loader: 'js',
+            format: 'esm',
+            target: 'es2016',
+            sourcemap: true,
+            sourcefile: id,
+          });
 
-        return {
-          code,
-          map,
-        };
+          return {
+            code,
+            map,
+          };
+        } else {
+          const { code, map } = await vite.transformWithEsbuild(_code, id, {
+            loader: 'js',
+            format: 'esm',
+            target: 'es2016',
+            sourcemap: true,
+            sourcefile: id,
+          });
+
+          return {
+            code,
+            map,
+          };
+        }
       }
 
       return undefined;
@@ -60,9 +75,15 @@ export function angularVitestPlugin(): Plugin {
  */
 export function angularVitestEsbuildPlugin(): Plugin {
   return {
-    name: '@analogjs/vitest-angular-esbuild-plugin',
+    name: '@analogjs/vitest-angular-esbuild-oxc-plugin',
     enforce: 'pre',
     config(userConfig: UserConfig) {
+      if (vite.rolldownVersion) {
+        return {
+          oxc: userConfig.oxc ?? false,
+        };
+      }
+
       return {
         esbuild: userConfig.esbuild ?? false,
       };
@@ -90,11 +111,19 @@ export function angularVitestSourcemapPlugin(): Plugin {
         return;
       }
 
-      const result = await transformWithEsbuild(code, id, {
-        loader: 'js',
-      });
+      if (vite.rolldownVersion) {
+        const result = await vite.transformWithOxc(code, id, {
+          loader: 'js',
+        });
 
-      return result;
+        return result as unknown as vite.TransformResult;
+      } else {
+        const result = await vite.transformWithEsbuild(code, id, {
+          loader: 'js',
+        });
+
+        return result;
+      }
     },
   };
 }

--- a/packages/vite-plugin-nitro/src/lib/build-ssr.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-ssr.ts
@@ -1,4 +1,5 @@
 import { build, mergeConfig, UserConfig } from 'vite';
+import * as vite from 'vite';
 import { relative, resolve } from 'node:path';
 
 import { Options } from './options.js';
@@ -7,10 +8,10 @@ export async function buildSSRApp(config: UserConfig, options?: Options) {
   const workspaceRoot = options?.workspaceRoot ?? process.cwd();
   const sourceRoot = options?.sourceRoot ?? 'src';
   const rootDir = relative(workspaceRoot, config.root || '.') || '.';
-  const ssrBuildConfig = mergeConfig(config, {
+  const ssrBuildConfig = mergeConfig(config, <UserConfig>{
     build: {
       ssr: true,
-      rollupOptions: {
+      [vite.rolldownVersion ? 'rolldownOptions' : 'rollupOptions']: {
         input:
           options?.entryServer ||
           resolve(workspaceRoot, rootDir, `${sourceRoot}/main.server.ts`),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
         version: 21.0.0-rc.2(57a293e944c1293166b5e4afe95f3482)
       '@astrojs/mdx':
         specifier: ^3.1.9
-        version: 3.1.9(astro@4.16.18(@types/node@22.17.0)(less@4.4.0)(rollup@4.37.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(typescript@5.9.3))
+        version: 3.1.9(astro@4.16.18(@types/node@22.17.0)(less@4.4.0)(lightningcss@1.30.2)(rollup@4.37.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(typescript@5.9.3))
       '@astrojs/react':
         specifier: ^4.3.0
-        version: 4.3.0(@types/node@22.17.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(jiti@2.5.1)(less@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+        version: 4.3.0(@types/node@22.17.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
       '@babel/core':
         specifier: ^7.28.0
         version: 7.28.0
@@ -58,7 +58,7 @@ importers:
         version: 3.1.0(@types/react@18.3.23)(react@18.3.1)
       '@nx/angular':
         specifier: 22.0.2
-        version: 22.0.2(afe5fe578dd2f95c657efe13e4ffaff9)
+        version: 22.0.2(a8c42a643502d365231e28a3f13ad43d)
       '@nx/devkit':
         specifier: 22.0.2
         version: 22.0.2(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -134,7 +134,7 @@ importers:
         version: 0.2100.0-rc.4(chokidar@4.0.3)
       '@angular-devkit/build-angular':
         specifier: 21.0.0-rc.2
-        version: 21.0.0-rc.2(8c8f5b7ce7b4ce1cfb8db1b036314ffd)
+        version: 21.0.0-rc.2(013466ae56ad5d589f7a3bd057adb489)
       '@angular-devkit/core':
         specifier: 21.0.0-rc.2
         version: 21.0.0-rc.2(chokidar@4.0.3)
@@ -152,7 +152,7 @@ importers:
         version: 20.5.0(eslint@8.57.1)(typescript@5.9.3)
       '@angular/build':
         specifier: 21.0.0-rc.2
-        version: 21.0.0-rc.2(20b032b1fb20213da52caadeb0dc820c)
+        version: 21.0.0-rc.2(5b3a4845f04de3640cae4c1b6ffd3a6f)
       '@angular/cli':
         specifier: ~21.0.0-rc.2
         version: 21.0.0-rc.4(@types/node@22.17.0)(chokidar@4.0.3)
@@ -200,10 +200,10 @@ importers:
         version: 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.17.0)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.8))(eslint@8.57.1)(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.3))(typescript@5.9.3)
       '@nx/storybook':
         specifier: 22.0.2
-        version: 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@zkochan/js-yaml@0.0.7)(cypress@14.5.3)(eslint@8.57.1)(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(typescript@5.9.3)
+        version: 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@zkochan/js-yaml@0.0.7)(cypress@14.5.3)(eslint@8.57.1)(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(typescript@5.9.3)
       '@nx/vite':
         specifier: 22.0.2
-        version: 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.9.3)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(vitest@4.0.1)
+        version: 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(typescript@5.9.3)(vitest@4.0.1)
       '@nx/web':
         specifier: 22.0.2
         version: 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -224,19 +224,19 @@ importers:
         version: 10.0.1(semantic-release@22.0.12(typescript@5.9.3))
       '@storybook/addon-docs':
         specifier: 10.0.0-rc.0
-        version: 10.0.0-rc.0(@types/react@18.3.23)(esbuild@0.25.8)(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
+        version: 10.0.0-rc.0(@types/react@18.3.23)(esbuild@0.25.8)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       '@storybook/addon-links':
         specifier: 10.0.0-rc.0
-        version: 10.0.0-rc.0(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))
+        version: 10.0.0-rc.0(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))
       '@storybook/addon-vitest':
         specifier: 10.0.0-rc.0
-        version: 10.0.0-rc.0(@vitest/runner@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vitest@4.0.1)
+        version: 10.0.0-rc.0(@vitest/runner@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vitest@4.0.1)
       '@storybook/angular':
         specifier: 10.0.0-rc.0
-        version: 10.0.0-rc.0(f81e19b3d75c29ddbd1665d90330b878)
+        version: 10.0.0-rc.0(482607b79f4a0de832fb0332835973c8)
       '@storybook/builder-vite':
         specifier: 10.0.0-rc.0
-        version: 10.0.0-rc.0(esbuild@0.25.8)(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
+        version: 10.0.0-rc.0(esbuild@0.25.8)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       '@swc-node/register':
         specifier: 1.10.10
         version: 1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3)
@@ -293,7 +293,7 @@ importers:
         version: 6.24.0(encoding@0.1.13)
       astro:
         specifier: 4.16.18
-        version: 4.16.18(@types/node@22.17.0)(less@4.4.0)(rollup@4.37.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(typescript@5.9.3)
+        version: 4.16.18(@types/node@22.17.0)(less@4.4.0)(lightningcss@1.30.2)(rollup@4.37.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(typescript@5.9.3)
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.4.38)
@@ -440,7 +440,7 @@ importers:
         version: 1.15.5
       storybook:
         specifier: 10.0.0-rc.0
-        version: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+        version: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       tailwindcss:
         specifier: ^3.1.0
         version: 3.4.13(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.3))
@@ -463,23 +463,23 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 7.1.9
-        version: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+        specifier: npm:rolldown-vite@latest
+        version: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
       vite-plugin-eslint:
         specifier: ^1.8.1
-        version: 1.8.1(eslint@8.57.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+        version: 1.8.1(eslint@8.57.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       vite-plugin-inspect:
         specifier: 11.3.2
-        version: 11.3.2(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+        version: 11.3.2(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       vite-tsconfig-paths:
         specifier: 4.2.0
-        version: 4.2.0(typescript@5.9.3)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+        version: 4.2.0(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(typescript@5.9.3)
       vitefu:
         specifier: ^1.1.1
-        version: 1.1.1(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+        version: 1.1.1(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       vitest:
         specifier: ^4.0.0
-        version: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+        version: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
       webpack-bundle-analyzer:
         specifier: ^4.7.0
         version: 4.7.0
@@ -491,10 +491,10 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.5.2
-        version: 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/preset-classic':
         specifier: 3.5.2
-        version: 3.5.2(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(typescript@5.5.4)
+        version: 3.5.2(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(typescript@5.5.4)
       '@mdx-js/react':
         specifier: ^3.1.0
         version: 3.1.0(@types/react@18.3.23)(react@18.3.1)
@@ -5060,8 +5060,15 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@oxc-project/runtime@0.98.0':
+    resolution: {integrity: sha512-F0ldlBv2orG2YqNL0w77deq9yCaO4zEHbanGnW/jaJxGBR8ImekvZb8x42zAHvdzr8J76psibijvHtXfSjbEIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@oxc-project/types@0.96.0':
     resolution: {integrity: sha512-r/xkmoXA0xEpU6UGtn18CNVjXH6erU3KCpCDbpLmbVxBFor1U9MqN5Z2uMmCHJuXjJzlnDR+hWY+yPoLo8oHDw==}
+
+  '@oxc-project/types@0.98.0':
+    resolution: {integrity: sha512-Vzmd6FsqVuz5HQVcRC/hrx7Ujo3WEVeQP7C2UNP5uy1hUY4SQvMB+93jxkI1KRHz9a/6cni3glPOtvteN+zpsw==}
 
   '@oxc-resolver/binding-darwin-arm64@5.3.0':
     resolution: {integrity: sha512-hXem5ZAguS7IlSiHg/LK0tEfLj4eUo+9U6DaFwwBEGd0L0VIF9LmuiHydRyOrdnnmi9iAAFMAn/wl2cUoiuruA==}
@@ -5260,8 +5267,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.51':
+    resolution: {integrity: sha512-Ctn8FUXKWWQI9pWC61P1yumS9WjQtelNS9riHwV7oCkknPGaAry4o7eFx2KgoLMnI2BgFJYpW7Im8/zX3BuONg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-beta.47':
     resolution: {integrity: sha512-Lc3nrkxeaDVCVl8qR3qoxh6ltDZfkQ98j5vwIr5ALPkgjZtDK4BGCrrBoLpGVMg+csWcaqUbwbKwH5yvVa0oOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.51':
+    resolution: {integrity: sha512-EL1aRW2Oq15ShUEkBPsDtLMO8GTqfb/ktM/dFaVzXKQiEE96Ss6nexMgfgQrg8dGnNpndFyffVDb5IdSibsu1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -5272,8 +5291,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.0.0-beta.51':
+    resolution: {integrity: sha512-uGtYKlFen9pMIPvkHPWZVDtmYhMQi5g5Ddsndg1gf3atScKYKYgs5aDP4DhHeTwGXQglhfBG7lEaOIZ4UAIWww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.0.0-beta.47':
     resolution: {integrity: sha512-Ns+kgp2+1Iq/44bY/Z30DETUSiHY7ZuqaOgD5bHVW++8vme9rdiWsN4yG4rRPXkdgzjvQ9TDHmZZKfY4/G11AA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.51':
+    resolution: {integrity: sha512-JRoVTQtHYbZj1P07JLiuTuXjiBtIa7ag7/qgKA6CIIXnAcdl4LrOf7nfDuHPJcuRKaP5dzecMgY99itvWfmUFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -5284,8 +5315,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.51':
+    resolution: {integrity: sha512-BKATVnpPZ0TYBW9XfDwyd4kPGgvf964HiotIwUgpMrFOFYWqpZ+9ONNzMV4UFAYC7Hb5C2qgYQk/qj2OnAd4RQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.47':
     resolution: {integrity: sha512-CyIunZ6D9U9Xg94roQI1INt/bLkOpPsZjZZkiaAZ0r6uccQdICmC99M9RUPlMLw/qg4yEWLlQhG73W/mG437NA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.51':
+    resolution: {integrity: sha512-xLd7da5jkfbVsBCm1buIRdWtuXY8+hU3+6ESXY/Tk5X5DPHaifrUblhYDgmA34dQt6WyNC2kfXGgrduPEvDI6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -5296,8 +5339,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.51':
+    resolution: {integrity: sha512-EQFXTgHxxTzv3t5EmjUP/DfxzFYx9sMndfLsYaAY4DWF6KsK1fXGYsiupif6qPTViPC9eVmRm78q0pZU/kuIPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.47':
     resolution: {integrity: sha512-fodvSMf6Aqwa0wEUSTPewmmZOD44rc5Tpr5p9NkwQ6W1SSpUKzD3SwpJIgANDOhwiYhDuiIaYPGB7Ujkx1q0UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.51':
+    resolution: {integrity: sha512-p5P6Xpa68w3yFaAdSzIZJbj+AfuDnMDqNSeglBXM7UlJT14Q4zwK+rV+8Mhp9MiUb4XFISZtbI/seBprhkQbiQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -5308,8 +5363,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.51':
+    resolution: {integrity: sha512-sNVVyLa8HB8wkFipdfz1s6i0YWinwpbMWk5hO5S+XAYH2UH67YzUT13gs6wZTKg2x/3gtgXzYnHyF5wMIqoDAw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.47':
     resolution: {integrity: sha512-YakuVe+Gc87jjxazBL34hbr8RJpRuFBhun7NEqoChVDlH5FLhLXjAPHqZd990TVGVNkemourf817Z8u2fONS8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.51':
+    resolution: {integrity: sha512-e/JMTz9Q8+T3g/deEi8DK44sFWZWGKr9AOCW5e8C8SCVWzAXqYXAG7FXBWBNzWEZK0Rcwo9TQHTQ9Q0gXgdCaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -5319,8 +5386,19 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.51':
+    resolution: {integrity: sha512-We3LWqSu6J9s5Y0MK+N7fUiiu37aBGPG3Pc347EoaROuAwkCS2u9xJ5dpIyLW4B49CIbS3KaPmn4kTgPb3EyPw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.47':
     resolution: {integrity: sha512-o5BpmBnXU+Cj+9+ndMcdKjhZlPb79dVPBZnWwMnI4RlNSSq5yOvFZqvfPYbyacvnW03Na4n5XXQAPhu3RydZ0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.51':
+    resolution: {integrity: sha512-fj56buHRuMM+r/cb6ZYfNjNvO/0xeFybI6cTkTROJatdP4fvmQ1NS8D/Lm10FCSDEOkqIz8hK3TGpbAThbPHsA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -5331,8 +5409,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.51':
+    resolution: {integrity: sha512-fkqEqaeEx8AySXiDm54b/RdINb3C0VovzJA3osMhZsbn6FoD73H0AOIiaVAtGr6x63hefruVKTX8irAm4Jkt2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.47':
     resolution: {integrity: sha512-by/70F13IUE101Bat0oeH8miwWX5mhMFPk1yjCdxoTNHTyTdLgb0THNaebRM6AP7Kz+O3O2qx87sruYuF5UxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.51':
+    resolution: {integrity: sha512-CWuLG/HMtrVcjKGa0C4GnuxONrku89g0+CsH8nT0SNhOtREXuzwgjIXNJImpE/A/DMf9JF+1Xkrq/YRr+F/rCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -5342,6 +5432,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-beta.47':
     resolution: {integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.51':
+    resolution: {integrity: sha512-51/8cNXMrqWqX3o8DZidhwz1uYq0BhHDDSfVygAND1Skx5s1TDw3APSSxCMcFFedwgqGcx34gRouwY+m404BBQ==}
 
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
@@ -11477,6 +11570,76 @@ packages:
       webpack:
         optional: true
 
+  lightningcss-android-arm64@1.30.2:
+    resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.30.2:
+    resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.2:
+    resolution: {integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.2:
+    resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    resolution: {integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.2:
+    resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    resolution: {integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.2:
+    resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
@@ -14527,8 +14690,53 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
+  rolldown-vite@7.2.6:
+    resolution: {integrity: sha512-u+0VLWLPJgwINLTQI18fSQlqfwgu8biRP4SY6HH4HLcEWZUOnDu5ARpwPYPyDahXPuhdSRHmWfS5G2/7CmqpJw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      esbuild: ^0.25.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   rolldown@1.0.0-beta.47:
     resolution: {integrity: sha512-Mid74GckX1OeFAOYz9KuXeWYhq3xkXbMziYIC+ULVdUzPTG9y70OBSBQDQn9hQP8u/AfhuYw1R0BSg15nBI4Dg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.0-beta.51:
+    resolution: {integrity: sha512-ZRLgPlS91l4JztLYEZnmMcd3Umcla1hkXJgiEiR4HloRJBBoeaX8qogTu5Jfu36rRMVLndzqYv0h+M5gJAkUfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -16461,46 +16669,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.1.9:
-    resolution: {integrity: sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.2.2:
     resolution: {integrity: sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -17310,13 +17478,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@21.0.0-rc.2(8c8f5b7ce7b4ce1cfb8db1b036314ffd)':
+  '@angular-devkit/build-angular@21.0.0-rc.2(013466ae56ad5d589f7a3bd057adb489)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2100.0-rc.2(chokidar@4.0.3)
       '@angular-devkit/build-webpack': 0.2100.0-rc.2(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       '@angular-devkit/core': 21.0.0-rc.2(chokidar@4.0.3)
-      '@angular/build': 21.0.0-rc.2(8086dce20ec17ca924b861b5a20445e7)
+      '@angular/build': 21.0.0-rc.2(c8b08af852ce0a85f3d0b29d13b866b2)
       '@angular/compiler-cli': 21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(typescript@5.9.3)
       '@babel/core': 7.28.4
       '@babel/generator': 7.28.3
@@ -17515,7 +17683,7 @@ snapshots:
       '@angular/core': 21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0)
       tslib: 2.8.1
 
-  '@angular/build@21.0.0-rc.2(20b032b1fb20213da52caadeb0dc820c)':
+  '@angular/build@21.0.0-rc.2(5b3a4845f04de3640cae4c1b6ffd3a6f)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2100.0-rc.2(chokidar@4.0.3)
@@ -17525,7 +17693,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.19(@types/node@22.17.0)
-      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       beasties: 0.3.5
       browserslist: 4.27.0
       esbuild: 0.26.0
@@ -17546,7 +17714,7 @@ snapshots:
       tslib: 2.7.0
       typescript: 5.9.3
       undici: 7.16.0
-      vite: 7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: 7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
       watchpack: 2.4.4
     optionalDependencies:
       '@angular/core': 21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0)
@@ -17558,7 +17726,7 @@ snapshots:
       ng-packagr: 21.0.0-rc.1(@angular/compiler-cli@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(typescript@5.9.3))(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.3)))(tslib@2.7.0)(typescript@5.9.3)
       postcss: 8.4.38
       tailwindcss: 3.4.13(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.3))
-      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -17572,7 +17740,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.0.0-rc.2(8086dce20ec17ca924b861b5a20445e7)':
+  '@angular/build@21.0.0-rc.2(c8b08af852ce0a85f3d0b29d13b866b2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2100.0-rc.2(chokidar@4.0.3)
@@ -17582,7 +17750,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.19(@types/node@22.17.0)
-      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       beasties: 0.3.5
       browserslist: 4.27.0
       esbuild: 0.26.0
@@ -17603,7 +17771,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
       undici: 7.16.0
-      vite: 7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: 7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
       watchpack: 2.4.4
     optionalDependencies:
       '@angular/core': 21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0)
@@ -17615,7 +17783,7 @@ snapshots:
       ng-packagr: 21.0.0-rc.1(@angular/compiler-cli@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(typescript@5.9.3))(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.3)))(tslib@2.7.0)(typescript@5.9.3)
       postcss: 8.5.6
       tailwindcss: 3.4.13(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.3))
-      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -17798,12 +17966,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@3.1.9(astro@4.16.18(@types/node@22.17.0)(less@4.4.0)(rollup@4.37.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(typescript@5.9.3))':
+  '@astrojs/mdx@3.1.9(astro@4.16.18(@types/node@22.17.0)(less@4.4.0)(lightningcss@1.30.2)(rollup@4.37.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(typescript@5.9.3))':
     dependencies:
       '@astrojs/markdown-remark': 5.3.0
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       acorn: 8.14.1
-      astro: 4.16.18(@types/node@22.17.0)(less@4.4.0)(rollup@4.37.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(typescript@5.9.3)
+      astro: 4.16.18(@types/node@22.17.0)(less@4.4.0)(lightningcss@1.30.2)(rollup@4.37.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(typescript@5.9.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       gray-matter: 4.0.3
@@ -17822,15 +17990,15 @@ snapshots:
     dependencies:
       prismjs: 1.29.0
 
-  '@astrojs/react@4.3.0(@types/node@22.17.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(jiti@2.5.1)(less@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)':
+  '@astrojs/react@4.3.0(@types/node@22.17.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)':
     dependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
-      '@vitejs/plugin-react': 4.6.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      '@vitejs/plugin-react': 4.6.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       ultrahtml: 1.6.0
-      vite: 6.3.5(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -21690,7 +21858,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/core@3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/generator': 7.25.6
@@ -21722,7 +21890,7 @@ snapshots:
       copy-webpack-plugin: 11.0.0(webpack@5.94.0(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       core-js: 3.37.1
       css-loader: 6.10.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.94.0(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.25.8)(webpack@5.94.0(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.25.8)(lightningcss@1.30.2)(webpack@5.94.0(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       cssnano: 6.1.2(postcss@8.4.41)
       del: 6.1.1
       detect-port: 1.5.1
@@ -21849,13 +22017,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-content-blog@3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.5.2
       '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
       '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -21891,13 +22059,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.5.2
       '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/module-type-aliases': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
       '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -21931,9 +22099,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-content-pages@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
@@ -21962,9 +22130,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-debug@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
       fs-extra: 11.2.0
@@ -21991,9 +22159,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-google-analytics@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
       react: 18.3.1
@@ -22018,9 +22186,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-google-gtag@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
       '@types/gtag.js': 0.0.12
@@ -22046,9 +22214,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-google-tag-manager@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
       react: 18.3.1
@@ -22073,9 +22241,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-sitemap@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.5.2
       '@docusaurus/types': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
@@ -22105,20 +22273,20 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.5.2(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(typescript@5.5.4)':
+  '@docusaurus/preset-classic@3.5.2(@algolia/client-search@5.40.1)(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-blog': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-pages': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-debug': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-google-analytics': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-google-gtag': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-google-tag-manager': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-sitemap': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-classic': 3.5.2(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-search-algolia': 3.5.2(@algolia/client-search@5.40.1)(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-blog': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-pages': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-debug': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-analytics': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-gtag': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-tag-manager': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-sitemap': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-classic': 3.5.2(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-search-algolia': 3.5.2(@algolia/client-search@5.40.1)(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(typescript@5.5.4)
       '@docusaurus/types': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -22149,15 +22317,15 @@ snapshots:
       '@types/react': 18.3.23
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.5.2(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/theme-classic@3.5.2(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/module-type-aliases': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-pages': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-blog': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-pages': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/theme-translations': 3.5.2
       '@docusaurus/types': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
@@ -22197,11 +22365,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/theme-common@3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
       '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/module-type-aliases': 3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
       '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/history': 4.7.11
@@ -22223,13 +22391,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.5.2(@algolia/client-search@5.40.1)(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(typescript@5.5.4)':
+  '@docusaurus/theme-search-algolia@3.5.2(@algolia/client-search@5.40.1)(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/react@18.3.23)(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(typescript@5.5.4)':
     dependencies:
       '@docsearch/react': 3.6.0(@algolia/client-search@5.40.1)(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.5.2
-      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.1.0(@types/react@18.3.23)(react@18.3.1))(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(eslint@8.57.1)(lightningcss@1.30.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/theme-translations': 3.5.2
       '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
       '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(typescript@5.5.4)
@@ -23943,7 +24111,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nx/angular@22.0.2(afe5fe578dd2f95c657efe13e4ffaff9)':
+  '@nx/angular@22.0.2(a8c42a643502d365231e28a3f13ad43d)':
     dependencies:
       '@angular-devkit/core': 21.0.0-rc.2(chokidar@4.0.3)
       '@angular-devkit/schematics': 21.0.0-rc.2(chokidar@4.0.3)
@@ -23953,7 +24121,7 @@ snapshots:
       '@nx/module-federation': 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(esbuild@0.25.8)(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@nx/rspack': 22.0.2(@babel/traverse@7.28.4)(@module-federation/enhanced@0.18.2(@rspack/core@1.5.8(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)))(@module-federation/node@2.7.13(@rspack/core@1.5.8(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)))(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/express@4.17.21)(esbuild@0.25.8)(less@4.4.0)(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(react-dom@18.3.1(react@18.3.1))(react-refresh@0.17.0)(react@18.3.1)(typescript@5.9.3)
       '@nx/web': 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
-      '@nx/webpack': 22.0.2(@babel/traverse@7.28.4)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(html-webpack-plugin@5.6.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.9.3)
+      '@nx/webpack': 22.0.2(@babel/traverse@7.28.4)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(html-webpack-plugin@5.6.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)))(lightningcss@1.30.2)(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.9.3)
       '@nx/workspace': 22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.9.3)
       '@schematics/angular': 21.0.0-rc.2(chokidar@4.0.3)
@@ -23967,8 +24135,8 @@ snapshots:
       tslib: 2.8.1
       webpack-merge: 5.10.0
     optionalDependencies:
-      '@angular-devkit/build-angular': 21.0.0-rc.2(8c8f5b7ce7b4ce1cfb8db1b036314ffd)
-      '@angular/build': 21.0.0-rc.2(20b032b1fb20213da52caadeb0dc820c)
+      '@angular-devkit/build-angular': 21.0.0-rc.2(013466ae56ad5d589f7a3bd057adb489)
+      '@angular/build': 21.0.0-rc.2(5b3a4845f04de3640cae4c1b6ffd3a6f)
       ng-packagr: 21.0.0-rc.1(@angular/compiler-cli@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(typescript@5.9.3))(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.3)))(tslib@2.7.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -24322,7 +24490,7 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/storybook@22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@zkochan/js-yaml@0.0.7)(cypress@14.5.3)(eslint@8.57.1)(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(typescript@5.9.3)':
+  '@nx/storybook@22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@zkochan/js-yaml@0.0.7)(cypress@14.5.3)(eslint@8.57.1)(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(typescript@5.9.3)':
     dependencies:
       '@nx/cypress': 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@zkochan/js-yaml@0.0.7)(cypress@14.5.3)(eslint@8.57.1)(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.9.3)
       '@nx/devkit': 22.0.2(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -24330,7 +24498,7 @@ snapshots:
       '@nx/js': 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.9.3)
       semver: 7.7.2
-      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -24345,7 +24513,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.9.3)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(vitest@4.0.1)':
+  '@nx/vite@22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(typescript@5.9.3)(vitest@4.0.1)':
     dependencies:
       '@nx/devkit': 22.0.2(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
       '@nx/js': 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -24356,8 +24524,8 @@ snapshots:
       semver: 7.7.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
-      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -24385,7 +24553,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/webpack@22.0.2(@babel/traverse@7.28.4)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(html-webpack-plugin@5.6.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.9.3)':
+  '@nx/webpack@22.0.2(@babel/traverse@7.28.4)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(html-webpack-plugin@5.6.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)))(lightningcss@1.30.2)(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.28.3
       '@nx/devkit': 22.0.2(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -24397,7 +24565,7 @@ snapshots:
       browserslist: 4.27.0
       copy-webpack-plugin: 10.2.4(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       css-loader: 6.10.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
-      css-minimizer-webpack-plugin: 5.0.1(esbuild@0.25.8)(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
+      css-minimizer-webpack-plugin: 5.0.1(esbuild@0.25.8)(lightningcss@1.30.2)(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       less: 4.4.0
       less-loader: 11.1.0(less@4.4.0)(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
@@ -24542,7 +24710,11 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@oxc-project/runtime@0.98.0': {}
+
   '@oxc-project/types@0.96.0': {}
+
+  '@oxc-project/types@0.98.0': {}
 
   '@oxc-resolver/binding-darwin-arm64@5.3.0':
     optional: true
@@ -24689,31 +24861,61 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-beta.47':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.51':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-beta.47':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.51':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.47':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.0-beta.51':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.0.0-beta.47':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.51':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.47':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.51':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.47':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.51':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.47':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.51':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.47':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.51':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.47':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.51':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.47':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.51':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.47':
@@ -24721,18 +24923,34 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.51':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.47':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.51':
     optional: true
 
   '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.47':
     optional: true
 
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.51':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.47':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.51':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.19': {}
 
   '@rolldown/pluginutils@1.0.0-beta.47': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.51': {}
 
   '@rollup/plugin-alias@5.1.1(rollup@4.37.0)':
     optionalDependencies:
@@ -25327,15 +25545,15 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@storybook/addon-docs@10.0.0-rc.0(@types/react@18.3.23)(esbuild@0.25.8)(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))':
+  '@storybook/addon-docs@10.0.0-rc.0(@types/react@18.3.23)(esbuild@0.25.8)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@18.3.23)(react@18.3.1)
-      '@storybook/csf-plugin': 10.0.0-rc.0(esbuild@0.25.8)(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
+      '@storybook/csf-plugin': 10.0.0-rc.0(esbuild@0.25.8)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       '@storybook/icons': 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.0.0-rc.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))
+      '@storybook/react-dom-shim': 10.0.0-rc.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -25344,31 +25562,31 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-links@10.0.0-rc.0(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))':
+  '@storybook/addon-links@10.0.0-rc.0(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
     optionalDependencies:
       react: 18.3.1
 
-  '@storybook/addon-vitest@10.0.0-rc.0(@vitest/runner@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vitest@4.0.1)':
+  '@storybook/addon-vitest@10.0.0-rc.0(@vitest/runner@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vitest@4.0.1)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       prompts: 2.4.2
-      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       ts-dedent: 2.2.0
     optionalDependencies:
       '@vitest/runner': 3.2.4
-      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/angular@10.0.0-rc.0(f81e19b3d75c29ddbd1665d90330b878)':
+  '@storybook/angular@10.0.0-rc.0(482607b79f4a0de832fb0332835973c8)':
     dependencies:
       '@angular-devkit/architect': 0.2100.0-rc.4(chokidar@4.0.3)
-      '@angular-devkit/build-angular': 21.0.0-rc.2(8c8f5b7ce7b4ce1cfb8db1b036314ffd)
+      '@angular-devkit/build-angular': 21.0.0-rc.2(013466ae56ad5d589f7a3bd057adb489)
       '@angular-devkit/core': 21.0.0-rc.2(chokidar@4.0.3)
       '@angular/common': 21.0.0-rc.2(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2)
       '@angular/compiler': 21.0.0-rc.2
@@ -25377,10 +25595,10 @@ snapshots:
       '@angular/forms': 21.0.0-rc.2(@angular/common@21.0.0-rc.2(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@21.0.0-rc.2(@angular/animations@21.0.0-rc.2(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@21.0.0-rc.2(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0)))(@standard-schema/spec@1.0.0)(rxjs@7.8.2)
       '@angular/platform-browser': 21.0.0-rc.2(@angular/animations@21.0.0-rc.2(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@21.0.0-rc.2(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0))
       '@angular/platform-browser-dynamic': 21.0.0-rc.2(@angular/common@21.0.0-rc.2(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/compiler@21.0.0-rc.2)(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@21.0.0-rc.2(@angular/animations@21.0.0-rc.2(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@21.0.0-rc.2(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@21.0.0-rc.2(@angular/compiler@21.0.0-rc.2)(rxjs@7.8.2)(zone.js@0.15.0)))
-      '@storybook/builder-webpack5': 10.0.0-rc.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 10.0.0-rc.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(typescript@5.9.3)
       '@storybook/global': 5.0.0
       rxjs: 7.8.2
-      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       telejson: 8.0.0
       ts-dedent: 2.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
@@ -25397,20 +25615,20 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-vite@10.0.0-rc.0(esbuild@0.25.8)(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))':
+  '@storybook/builder-vite@10.0.0-rc.0(esbuild@0.25.8)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))':
     dependencies:
-      '@storybook/csf-plugin': 10.0.0-rc.0(esbuild@0.25.8)(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
-      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      '@storybook/csf-plugin': 10.0.0-rc.0(esbuild@0.25.8)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
+      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       ts-dedent: 2.2.0
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/builder-webpack5@10.0.0-rc.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@10.0.0-rc.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 10.0.0-rc.0(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))
+      '@storybook/core-webpack': 10.0.0-rc.0(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
       css-loader: 7.1.2(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.101.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
@@ -25418,7 +25636,7 @@ snapshots:
       fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.101.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       html-webpack-plugin: 5.6.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.101.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       magic-string: 0.30.19
-      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       style-loader: 4.0.0(webpack@5.101.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       terser-webpack-plugin: 5.3.14(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)(webpack@5.101.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))
       ts-dedent: 2.2.0
@@ -25435,19 +25653,19 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/core-webpack@10.0.0-rc.0(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))':
+  '@storybook/core-webpack@10.0.0-rc.0(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))':
     dependencies:
-      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.0.0-rc.0(esbuild@0.25.8)(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))':
+  '@storybook/csf-plugin@10.0.0-rc.0(esbuild@0.25.8)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(rollup@4.37.0)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8))':
     dependencies:
-      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       unplugin: 2.3.10
     optionalDependencies:
       esbuild: 0.25.8
       rollup: 4.37.0
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
       webpack: 5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)
 
   '@storybook/global@5.0.0': {}
@@ -25457,11 +25675,11 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-dom-shim@10.0.0-rc.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))':
+  '@storybook/react-dom-shim@10.0.0-rc.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      storybook: 10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.3)':
     dependencies:
@@ -25660,7 +25878,7 @@ snapshots:
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2
@@ -26264,15 +26482,15 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))':
+  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))':
     dependencies:
-      vite: 7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: 7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
 
-  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))':
+  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))':
     dependencies:
-      vite: 7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: 7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
 
-  '@vitejs/plugin-react@4.6.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))':
+  '@vitejs/plugin-react@4.6.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
@@ -26280,7 +26498,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.19
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -26298,7 +26516,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -26319,21 +26537,21 @@ snapshots:
       chai: 6.2.0
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))':
+  '@vitest/mocker@3.2.4(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
 
-  '@vitest/mocker@4.0.1(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))':
+  '@vitest/mocker@4.0.1(vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 4.0.1
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: 7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.1.4':
     dependencies:
@@ -26380,7 +26598,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vitest: 4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
 
   '@vitest/utils@3.1.4':
     dependencies:
@@ -26934,7 +27152,7 @@ snapshots:
 
   astring@1.8.6: {}
 
-  astro@4.16.18(@types/node@22.17.0)(less@4.4.0)(rollup@4.37.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(typescript@5.9.3):
+  astro@4.16.18(@types/node@22.17.0)(less@4.4.0)(lightningcss@1.30.2)(rollup@4.37.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(typescript@5.9.3):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.4.1
@@ -26990,8 +27208,8 @@ snapshots:
       tsconfck: 3.1.6(typescript@5.9.3)
       unist-util-visit: 5.0.0
       vfile: 6.0.3
-      vite: 5.4.11(@types/node@22.17.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)
-      vitefu: 1.1.1(vite@5.4.11(@types/node@22.17.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0))
+      vite: 5.4.11(@types/node@22.17.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)
+      vitefu: 1.1.1(vite@5.4.11(@types/node@22.17.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0))
       which-pm: 3.0.1
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
@@ -28466,7 +28684,7 @@ snapshots:
       '@rspack/core': 1.5.8(@swc/helpers@0.5.17)
       webpack: 5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.25.8)(webpack@5.94.0(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.25.8)(lightningcss@1.30.2)(webpack@5.94.0(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       cssnano: 6.0.1(postcss@8.4.49)
@@ -28478,8 +28696,9 @@ snapshots:
     optionalDependencies:
       clean-css: 5.3.3
       esbuild: 0.25.8
+      lightningcss: 1.30.2
 
-  css-minimizer-webpack-plugin@5.0.1(esbuild@0.25.8)(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)):
+  css-minimizer-webpack-plugin@5.0.1(esbuild@0.25.8)(lightningcss@1.30.2)(webpack@5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       cssnano: 6.0.1(postcss@8.4.49)
@@ -28490,6 +28709,7 @@ snapshots:
       webpack: 5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)
     optionalDependencies:
       esbuild: 0.25.8
+      lightningcss: 1.30.2
 
   css-prefers-color-scheme@10.0.0(postcss@8.4.38):
     dependencies:
@@ -32214,6 +32434,55 @@ snapshots:
       webpack-sources: 3.3.3
     optionalDependencies:
       webpack: 5.102.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.25.8)
+
+  lightningcss-android-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.2:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss@1.30.2:
+    dependencies:
+      detect-libc: 2.0.3
+    optionalDependencies:
+      lightningcss-android-arm64: 1.30.2
+      lightningcss-darwin-arm64: 1.30.2
+      lightningcss-darwin-x64: 1.30.2
+      lightningcss-freebsd-x64: 1.30.2
+      lightningcss-linux-arm-gnueabihf: 1.30.2
+      lightningcss-linux-arm64-gnu: 1.30.2
+      lightningcss-linux-arm64-musl: 1.30.2
+      lightningcss-linux-x64-gnu: 1.30.2
+      lightningcss-linux-x64-musl: 1.30.2
+      lightningcss-win32-arm64-msvc: 1.30.2
+      lightningcss-win32-x64-msvc: 1.30.2
 
   lilconfig@2.1.0: {}
 
@@ -36138,6 +36407,27 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
+  rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
+    dependencies:
+      '@oxc-project/runtime': 0.98.0
+      fdir: 6.5.0(picomatch@4.0.3)
+      lightningcss: 1.30.2
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rolldown: 1.0.0-beta.51
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.17.0
+      esbuild: 0.25.8
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      less: 4.4.0
+      sass: 1.90.0
+      sass-embedded: 1.86.0
+      stylus: 0.64.0
+      terser: 5.44.0
+      yaml: 2.7.0
+
   rolldown@1.0.0-beta.47:
     dependencies:
       '@oxc-project/types': 0.96.0
@@ -36157,6 +36447,26 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.47
       '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.47
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.47
+
+  rolldown@1.0.0-beta.51:
+    dependencies:
+      '@oxc-project/types': 0.98.0
+      '@rolldown/pluginutils': 1.0.0-beta.51
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-beta.51
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.51
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.51
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.51
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.51
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.51
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.51
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.51
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.51
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.51
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.51
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.51
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.51
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.51
 
   rollup-plugin-dts@6.2.1(rollup@4.44.1)(typescript@5.9.3):
     dependencies:
@@ -37099,14 +37409,14 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
+  storybook@10.0.0-rc.0(@testing-library/dom@10.4.0)(prettier@3.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/jest-dom': 6.6.3
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       '@vitest/spy': 3.2.4
       esbuild: 0.25.8
       recast: 0.23.11
@@ -38280,25 +38590,25 @@ snapshots:
       moment: 2.30.1
       propagating-hammerjs: 1.5.0
 
-  vite-dev-rpc@1.1.0(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
+  vite-dev-rpc@1.1.0(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
     dependencies:
       birpc: 2.4.0
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
-      vite-hot-client: 2.1.0(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      vite: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite-hot-client: 2.1.0(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
 
-  vite-hot-client@2.1.0(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
+  vite-hot-client@2.1.0(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
     dependencies:
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
 
-  vite-plugin-eslint@1.8.1(eslint@8.57.1)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
+  vite-plugin-eslint@1.8.1(eslint@8.57.1)(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@types/eslint': 8.37.0
       eslint: 8.57.1
       rollup: 2.79.1
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
 
-  vite-plugin-inspect@11.3.2(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
+  vite-plugin-inspect@11.3.2(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
     dependencies:
       ansis: 4.1.0
       debug: 4.4.1(supports-color@8.1.1)
@@ -38308,23 +38618,23 @@ snapshots:
       perfect-debounce: 1.0.0
       sirv: 3.0.1
       unplugin-utils: 0.2.4
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
-      vite-dev-rpc: 1.1.0(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      vite: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite-dev-rpc: 1.1.0(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite-tsconfig-paths@4.2.0(typescript@5.9.3)(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
+  vite-tsconfig-paths@4.2.0(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))(typescript@5.9.3):
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.9.3)
     optionalDependencies:
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.11(@types/node@22.17.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0):
+  vite@5.4.11(@types/node@22.17.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -38333,12 +38643,13 @@ snapshots:
       '@types/node': 22.17.0
       fsevents: 2.3.3
       less: 4.4.0
+      lightningcss: 1.30.2
       sass: 1.90.0
       sass-embedded: 1.86.0
       stylus: 0.64.0
       terser: 5.44.0
 
-  vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
+  vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.3)
@@ -38351,13 +38662,14 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.5.1
       less: 4.4.0
+      lightningcss: 1.30.2
       sass: 1.90.0
       sass-embedded: 1.86.0
       stylus: 0.64.0
       terser: 5.44.0
       yaml: 2.7.0
 
-  vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
+  vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.5.0(picomatch@4.0.3)
@@ -38370,13 +38682,14 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.5.1
       less: 4.4.0
+      lightningcss: 1.30.2
       sass: 1.90.0
       sass-embedded: 1.86.0
       stylus: 0.64.0
       terser: 5.44.0
       yaml: 2.7.0
 
-  vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
+  vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.5.0(picomatch@4.0.3)
@@ -38389,13 +38702,14 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.5.1
       less: 4.4.0
+      lightningcss: 1.30.2
       sass: 1.93.2
       sass-embedded: 1.86.0
       stylus: 0.64.0
       terser: 5.44.0
       yaml: 2.7.0
 
-  vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
+  vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.93.2)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.5.0(picomatch@4.0.3)
@@ -38408,24 +38722,25 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.5.1
       less: 4.4.2
+      lightningcss: 1.30.2
       sass: 1.93.2
       sass-embedded: 1.86.0
       stylus: 0.64.0
       terser: 5.44.0
       yaml: 2.7.0
 
-  vitefu@1.1.1(vite@5.4.11(@types/node@22.17.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)):
+  vitefu@1.1.1(rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.17.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)
+      vite: rolldown-vite@7.2.6(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
 
-  vitefu@1.1.1(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)):
+  vitefu@1.1.1(vite@5.4.11(@types/node@22.17.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)):
     optionalDependencies:
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: 5.4.11(@types/node@22.17.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)
 
-  vitest@4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
+  vitest@4.0.1(@types/node@22.17.0)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 4.0.1
-      '@vitest/mocker': 4.0.1(vite@7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
+      '@vitest/mocker': 4.0.1(vite@7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0))
       '@vitest/pretty-format': 4.0.1
       '@vitest/runner': 4.0.1
       '@vitest/snapshot': 4.0.1
@@ -38442,7 +38757,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.1.9(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
+      vite: 7.2.2(@types/node@22.17.0)(jiti@2.5.1)(less@4.4.0)(lightningcss@1.30.2)(sass-embedded@1.86.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.44.0)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.17.0


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When using `rolldown-vite`, the plugins use `rolldownOptions` and `oxc` options for dev/build/test/transpilation instead of `rollup` and `esbuild` equivalents.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMjVoZjdpNzgwMXhka2I1OG8wbjNiNG1qaG1zc21uMjkwcmdoOWEwNiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/lcySndwSDLxC4eOU86/giphy.gif"/>