### PR TITLE
fix(nx-plugin): adjust migrations to Analog for Angular v21

### DIFF
--- a/packages/nx-plugin/src/generators/app/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/app/generator.spec.ts
@@ -46,14 +46,12 @@ describe('nx-plugin generator', () => {
     expect(dependencies['mermaid']).toBe('^10.2.4');
     expect(dependencies['prismjs']).toBe('^1.29.0');
 
-    expect(dependencies['@nx/angular']).toBeDefined();
     // we just check for truthy because @nx/eslint generator
     // will install the correct version based on Nx version
     // expect(devDependencies['@nx/eslint']).toBeTruthy();
     expect(devDependencies['@analogjs/platform']).toBeDefined();
     expect(devDependencies['@analogjs/vite-plugin-angular']).toBeDefined();
     expect(devDependencies['@analogjs/vitest-angular']).toBeDefined();
-    expect(devDependencies['@nx/vite']).toBeDefined();
     expect(devDependencies['jsdom']).toBeDefined();
     expect(devDependencies['vite']).toBeDefined();
     expect(devDependencies['vite-tsconfig-paths']).toBe('^4.2.0');

--- a/packages/nx-plugin/src/generators/init/files/src/main.server.ts__template__
+++ b/packages/nx-plugin/src/generators/init/files/src/main.server.ts__template__
@@ -1,4 +1,4 @@
-import 'zone.js/node';
+<% if (majorAngularVersion < 21) { %>import 'zone.js/node';<% } %>
 import '@angular/platform-server/init';
 import { render } from '@analogjs/router/server';
 <% if (majorAngularVersion > 19) { %>

--- a/packages/nx-plugin/src/generators/init/generator.ts
+++ b/packages/nx-plugin/src/generators/init/generator.ts
@@ -74,7 +74,11 @@ export async function setupAnalogGenerator(
   updateAppTsConfig(tree, options);
   updatePackageJson(tree, options);
   updateIndex(tree, options);
-  updateMain(tree, options);
+
+  if (majorAngularVersion < 21) {
+    updateMain(tree, options);
+  }
+
   updateGitIgnore(tree);
 
   addFiles(tree, options, majorAngularVersion);

--- a/packages/nx-plugin/src/utils/versions/dependencies.ts
+++ b/packages/nx-plugin/src/utils/versions/dependencies.ts
@@ -23,7 +23,6 @@ import {
 import {
   V19_X_ANALOG_JS_CONTENT,
   V19_X_ANALOG_JS_ROUTER,
-  V19_X_NX_ANGULAR,
   V19_X_MARKED,
   V19_X_MARKED_GFM_HEADING_ID,
   V19_X_MARKED_HIGHLIGHT,
@@ -34,7 +33,6 @@ import {
 const dependencyKeys = [
   '@analogjs/content',
   '@analogjs/router',
-  '@nx/angular',
   'marked',
   'marked-gfm-heading-id',
   'marked-highlight',
@@ -90,7 +88,6 @@ const getDependencies = (escapedAngularVersion: string) => {
   return {
     '@analogjs/content': V19_X_ANALOG_JS_CONTENT,
     '@analogjs/router': V19_X_ANALOG_JS_ROUTER,
-    '@nx/angular': V19_X_NX_ANGULAR,
     marked: V19_X_MARKED,
     'marked-gfm-heading-id': V19_X_MARKED_GFM_HEADING_ID,
     'marked-highlight': V19_X_MARKED_HIGHLIGHT,

--- a/packages/nx-plugin/src/utils/versions/dev-dependencies.ts
+++ b/packages/nx-plugin/src/utils/versions/dev-dependencies.ts
@@ -37,7 +37,6 @@ const devDependencyKeys = [
   'jsdom',
   'vite-tsconfig-paths',
   'vitest',
-  '@nx/vite',
   'vite',
   '@vitest/coverage-v8',
   '@vitest/ui',
@@ -105,7 +104,6 @@ const getDevDependencies = (
     '@analogjs/platform': V19_X_ANALOG_JS_PLATFORM,
     '@analogjs/vite-plugin-angular': V19_X_ANALOG_JS_VITE_PLUGIN_ANGULAR,
     '@analogjs/vitest-angular': V19_X_ANALOG_JS_VITEST_ANGULAR,
-    '@nx/vite': V19_X_NX_VITE,
     jsdom: V19_X_JSDOM,
     'vite-tsconfig-paths': V19_X_VITE_TSCONFIG_PATHS,
     vite:

--- a/packages/nx-plugin/src/utils/versions/ng_19_X/versions.ts
+++ b/packages/nx-plugin/src/utils/versions/ng_19_X/versions.ts
@@ -18,4 +18,4 @@ export const V19_X_VITE_TSCONFIG_PATHS = '^4.2.0';
 export const V19_X_VITEST = '^2.0.0';
 export const V19_X_VITE = '^5.0.0';
 export const NX_X_LATEST_VITE = '^7.0.0';
-export const NX_X_LATEST_VITEST = '^3.0.0';
+export const NX_X_LATEST_VITEST = '^4.0.0';


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Adjust the migration for Angular projects to Analog.

- Zone.js is removed from being added
- Vitest 4.x is added
- Nx libs are removed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
