### PR TITLE
fix(vite-plugin-nitro): configure default Netlify functions output directory

### DIFF
--- a/apps/docs-app/docs/features/deployment/providers.md
+++ b/apps/docs-app/docs/features/deployment/providers.md
@@ -138,7 +138,7 @@ You can also check out [Github Integration](https://docs.zerops.io/references/gi
 
 ## Netlify
 
-Analog supports deploying on [Netlify](https://netlify.com/) with minimal configuration.
+Analog supports deploying on [Netlify](https://netlify.com/) with no additional configuration.
 
 ### Deploying the project
 
@@ -154,16 +154,7 @@ npx netlify init
 
 If this is a new Netlify project, you'll be prompted to initialize it; build settings will be automatically configured in a `netlify.toml` file.
 
-2. If you're using server-side functionality, you need to manually set the functions directory to `dist/analog` in your `netlify.toml`:
-
-```toml
-[build]
-  command = "npm run build"
-  publish = "dist/analog/public"
-  functions = "dist/analog" # ← update this
-```
-
-3. Finally, deploy your app:
+2. Deploy your app:
 
 ```bash
 npx netlify deploy
@@ -173,7 +164,7 @@ npx netlify deploy
 
 Alternatively, you can configure your project's build settings in the Netlify app.
 
-Set the [publish directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/analog/public` to deploy the static assets and the [functions directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/analog` to deploy the server.
+Set the [publish directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `dist/analog/public` to deploy the static assets and the [functions directory](https://docs.netlify.com/configure-builds/overview/#definitions) to `netlify/functions` to deploy the server.
 </TabItem>
 
   <TabItem label="Nx" value="nx">

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -179,6 +179,14 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
           nitroConfig = withCloudflareOutput(nitroConfig);
         }
 
+        if (
+          isNetlifyPreset(buildPreset) &&
+          rootDir === '.' &&
+          !existsSync(resolve(workspaceRoot, 'netlify.toml'))
+        ) {
+          nitroConfig = withNetlifyOutputAPI(nitroConfig, workspaceRoot);
+        }
+
         if (isFirebaseAppHosting()) {
           nitroConfig = withAppHostingOutput(nitroConfig);
         }
@@ -594,3 +602,18 @@ const withAppHostingOutput = (nitroConfig: NitroConfig) => {
     },
   };
 };
+
+const isNetlifyPreset = (buildPreset: string | undefined) =>
+  process.env['NETLIFY'] ||
+  (buildPreset && buildPreset.toLowerCase().includes('netlify'));
+
+const withNetlifyOutputAPI = (
+  nitroConfig: NitroConfig | undefined,
+  workspaceRoot: string,
+) => ({
+  ...nitroConfig,
+  output: {
+    ...nitroConfig?.output,
+    dir: normalizePath(resolve(workspaceRoot, 'netlify/functions')),
+  },
+});


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When using the Netlify preset in a new Analog application, the server build is placed in the `netlify/functions` directory. This allows for no additional configuration needed for deployment after running `npx netlify init`.

The docs are updated to reflect the zero configuration deployment setup.

cc: @serhalp

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
