### PR TITLE
fix(vite-plugin-angular): allow opt-in for Angular CDK transforms

### DIFF
--- a/libs/card/vite.config.ts
+++ b/libs/card/vite.config.ts
@@ -8,6 +8,13 @@ export default defineConfig(({ mode }) => {
   return {
     root: __dirname,
     plugins: [angular()],
+    optimizeDeps: {
+      include: ['@angular/cdk/testing/testbed'],
+      exclude: ['@angular/cdk/testing'],
+    },
+    ssr: {
+      noExternal: [/cdk\/fesm/],
+    },
     test: {
       reporters: ['default'],
       globals: true,

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "ng-packagr": "21.0.0",
     "nitropack": "^2.11.0",
     "nx": "22.0.2",
+    "@oxc-project/runtime": "^0.99.0",
     "playwright": "^1.49.1",
     "postcss": "^8.4.21",
     "postcss-import": "~16.1.1",

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -1,5 +1,6 @@
 import { Plugin, UserConfig } from 'vite';
 import * as vite from 'vite';
+
 /**
  * Sets up test config for Vitest
  * and downlevels any dependencies that use
@@ -19,7 +20,6 @@ export function angularVitestPlugin(): Plugin {
         ssr: {
           noExternal: [
             '@analogjs/vitest-angular/setup-testbed',
-            /cdk\/fesm2022/,
             /fesm2022(.*?)testing/,
             /fesm2015/,
           ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@nx/web':
         specifier: 22.0.2
         version: 22.0.2(@babel/traverse@7.28.4)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@22.0.2(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
+      '@oxc-project/runtime':
+        specifier: ^0.99.0
+        version: 0.99.0
       '@playwright/test':
         specifier: ^1.54.2
         version: 1.54.2
@@ -5036,6 +5039,10 @@ packages:
 
   '@oxc-project/runtime@0.98.0':
     resolution: {integrity: sha512-F0ldlBv2orG2YqNL0w77deq9yCaO4zEHbanGnW/jaJxGBR8ImekvZb8x42zAHvdzr8J76psibijvHtXfSjbEIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/runtime@0.99.0':
+    resolution: {integrity: sha512-8iE5/4OK0SLHqWzRxSvI1gjFPmIH6718s8iwkuco95rBZsCZIHq+5wy4lYsASxnH+8FOhbGndiUrcwsVG5i2zw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@oxc-project/types@0.96.0':
@@ -24762,6 +24769,8 @@ snapshots:
   '@oslojs/encoding@1.1.0': {}
 
   '@oxc-project/runtime@0.98.0': {}
+
+  '@oxc-project/runtime@0.99.0': {}
 
   '@oxc-project/types@0.96.0': {}
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1891 

## What is the new behavior?

Transforms for Angular CDK when using Vitest are opt-in to guard against edge cases and failing instanceof checks.

To transform Angular CDK testing utils.

```ts
/// <reference types="vitest" />
import { defineConfig } from 'vite';
import angular from '@analogjs/vite-plugin-angular';
// https://vitejs.dev/config/
export default defineConfig(({ mode }) => {
  return {
    root: __dirname,
    plugins: [angular()],
    optimizeDeps: {
      include: ['@angular/cdk/testing/testbed'],
      exclude: ['@angular/cdk/testing'],
    },
    ssr: {
      noExternal: [/cdk\/fesm/],
    },
    test: {
      reporters: ['default'],
      globals: true,
      environment: 'jsdom',
      setupFiles: ['src/test-setup.ts'],
      include: ['**/*.spec.ts'],
      cacheDir: '../../node_modules/.vitest',
      pool: 'vmForks',
      fileParallelism: false,
    },
    define: {
      'import.meta.vitest': mode !== 'production',
    },
  };
});
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
