### PR TITLE
fix(platform): remove @analogjs/content import from bundle when not used

### DIFF
--- a/packages/platform/src/lib/content-plugin.ts
+++ b/packages/platform/src/lib/content-plugin.ts
@@ -62,6 +62,26 @@ export function contentPlugin(
           };
         },
       },
+      {
+        name: 'analogjs-exclude-content-import',
+        transform(code) {
+          /**
+           * Remove the package so it doesn't get
+           * referenced when building for serverless
+           * functions.
+           */
+          if (code.includes(`import('@analogjs/content')`)) {
+            return {
+              code: code.replace(
+                `import('@analogjs/content')`,
+                'Promise.resolve({})',
+              ),
+            };
+          }
+
+          return;
+        },
+      },
     ];
   }
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When deploying a new application to a Vercel Edge function, the bundled function size exceeded the limit because it wasn't excluding the `@analogjs/platform` package, even though it was marked as external in the server build.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMjgycmtvc3htMzc3dHM1ZTF1MHJjcjVuZjBrdnM5d2NsaXRmYTFvYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/h5sCkem0vQgu42j7ap/giphy.gif"/>