### PR TITLE
fix(storybook-angular): creates config.plugin array when undefined

### DIFF
--- a/packages/storybook-angular/src/lib/preset.ts
+++ b/packages/storybook-angular/src/lib/preset.ts
@@ -38,7 +38,7 @@ export const core = async (config, options) => {
 };
 export const viteFinal = async (config, options) => {
   // Remove any loaded analogjs plugins from a vite.config.(m)ts file
-  config.plugins = config.plugins
+  config.plugins = (config.plugins ?? [])
     .flat()
     .filter((plugin) => !plugin.name.includes('analogjs'));
 


### PR DESCRIPTION
## PR Checklist

Ensures the `config.plugins` array exists if it's missing to prevent the following error:

```
TypeError: Cannot read properties of undefined (reading 'flat')
```

Closes #1992

## What is the new behavior?

No new behavior. Just fixes an edge case.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlampweGpnZTJua3czZDRwb2F0aWF0azJ2OXo2cWlncmxtcnJveTZiMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/26n08WnCiKbJ4l2Ffv/giphy.gif"/>