### PR TITLE
feat(storybook-angular): allows setting tsconfig via framework options

### DIFF
--- a/packages/storybook-angular/src/lib/preset.ts
+++ b/packages/storybook-angular/src/lib/preset.ts
@@ -72,7 +72,10 @@ export const viteFinal = async (config, options) => {
           typeof framework.options?.liveReload !== 'undefined'
             ? framework.options?.liveReload
             : false,
-        tsconfig: options?.tsConfig ?? './.storybook/tsconfig.json',
+        tsconfig:
+          typeof framework.options?.tsconfig !== 'undefined'
+            ? framework.options?.tsconfig
+            : (options?.tsConfig ?? './.storybook/tsconfig.json'),
         inlineStylesExtension:
           typeof framework.options?.inlineStylesExtension !== 'undefined'
             ? framework.options?.inlineStylesExtension

--- a/packages/storybook-angular/src/types.ts
+++ b/packages/storybook-angular/src/types.ts
@@ -12,6 +12,7 @@ export type FrameworkOptions = {
   jit?: boolean;
   liveReload?: boolean;
   inlineStylesExtension?: string;
+  tsconfig?: string;
 };
 
 type StorybookConfigFramework = {


### PR DESCRIPTION
## PR Checklist

Currently most options that can be passed into `vite-angular-plugin` may be set via storybook framework options except for `tsconfig`. This felt like an odd omission and can result in the incorrect `tsconfig.json` being selected depending on the current working directory from which Storybook has been run. This can lead to issues when trying to run `vitest` to test Storybook stories from the root of a monorepo.

## What is the new behavior?

Allows users to also set the `tsconfig` path via framework options.

```diff
+ import { dirname, join } from 'node:path';
+ import { fileUrlToPath } from 'node:url';
  import { StorybookConfig } from '@analogjs/storybook-angular';

+ const dir = dirname(fileUrlToPath(import.meta.url));

  const config: StorybookConfig = {
    // other config, addons, etc.
    framework: {
      name: '@analogjs/storybook-angular',
      options: {
+       tsconfig: join(dir, '../tsconfig.json'),
      },
    },
  };

  export default config;
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdldmF0ZTVveGgyeWVoY3IzdTMwNG90eGpwdXFmZGNrbWRjZmsyZW0yMyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oz8xtBx06mcZWoNJm/giphy.gif"/>