### PR TITLE
docs(router): correct extra route example (remove leading slash in path)

### DIFF
--- a/apps/docs-app/docs/features/routing/overview.md
+++ b/apps/docs-app/docs/features/routing/overview.md
@@ -349,7 +349,7 @@ import { provideFileRouter, withExtraRoutes } from '@analogjs/router';
 
 const customRoutes: Routes = [
   {
-    path: '/custom',
+    path: 'custom',
     loadComponent: () =>
       import('./custom-component').then((m) => m.CustomComponent),
   },


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The routing docs include an Angular Router example where the `Route.path` starts with a leading `/`, which is invalid in Angular route configuration. This can mislead readers into defining routes with a leading slash.

Closes N/A

## What is the new behavior?

The example under "Providing Extra Routes" now uses `path: 'custom'` (without a leading slash):

- File: `apps/docs-app/docs/features/routing/overview.md`
- Change: `path: '/custom'` → `path: 'custom'`

This aligns the docs with Angular Router conventions where `path` segments do not start with `/`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
- Type: docs
- Scope: router
- Local checks:
  - `pnpm nx build docs-app` succeeds.
  - `pnpm nx affected --target=test` shows no affected packages for this docs-only change.
- I searched the repository for similar patterns (e.g., `path: '/`) and only found contexts where a leading slash is appropriate (`redirectTo: '/...'`, URLs, server routes). No further `Route.path` examples require changes.

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
A small docs correctness win 🎉
