### PR TITLE
feat(vitest-angular): added support for browser mode preview

### DIFF
--- a/apps/docs-app/docs/features/testing/vitest.md
+++ b/apps/docs-app/docs/features/testing/vitest.md
@@ -127,6 +127,24 @@ setupTestBed({
 });
 ```
 
+### Configuration Options
+
+The `setupTestBed()` function accepts an optional configuration object with the following properties:
+
+- `zoneless` (boolean): Whether to use zoneless change detection (default: `true`)
+- `providers` (`Type<any>[]`): Additional providers to include in the test environment (default: `[]`)
+- `browserMode` (boolean): Enables visual test preview in Vitest browser mode by keeping the component rendered, allowing you to inspect its final state (default: `false`)
+
+**Example with options:**
+
+```ts
+setupTestBed({
+  zoneless: true,
+  providers: [],
+  browserMode: false,
+});
+```
+
 Next, update the `test` target in the `angular.json` to use the `@analogjs/vitest-angular:test` builder:
 
 ```json
@@ -233,6 +251,20 @@ export default defineConfig(({ mode }) => ({
   },
 }));
 ```
+
+When running tests in the browser, you may want to update your `src/test-setup.ts` to enable `browserMode`:
+
+```ts
+import '@angular/compiler';
+import '@analogjs/vitest-angular/setup-snapshots';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+setupTestBed({
+  browserMode: true, // Enables visual test preview
+});
+```
+
+This keeps the component rendered after tests complete, allowing you to visually inspect the final state in the browser preview.
 
 ## Running Tests
 

--- a/packages/vitest-angular/README.md
+++ b/packages/vitest-angular/README.md
@@ -109,6 +109,24 @@ setupTestBed({
 });
 ```
 
+### Configuration Options
+
+The `setupTestBed()` function accepts an optional configuration object with the following properties:
+
+- `zoneless` (boolean): Whether to use zoneless change detection (default: `true`)
+- `providers` (`Type<any>[]`): Additional providers to include in the test environment (default: `[]`)
+- `browserMode` (boolean): Enables visual test preview in Vitest browser mode by keeping the component rendered, allowing you to inspect its final state (default: `false`)
+
+**Example with options:**
+
+```ts
+setupTestBed({
+  zoneless: true,
+  providers: [],
+  browserMode: false,
+});
+```
+
 Next, update the `test` target in the `angular.json` to use the `@analogjs/vitest-angular:test` builder:
 
 ```json

--- a/packages/vitest-angular/setup-testbed.ts
+++ b/packages/vitest-angular/setup-testbed.ts
@@ -1,7 +1,7 @@
 import { NgModule, provideZonelessChangeDetection, Type } from '@angular/core';
 import {
-  getTestBed,
   ɵgetCleanupHook as getCleanupHook,
+  getTestBed,
 } from '@angular/core/testing';
 import {
   BrowserTestingModule,
@@ -14,6 +14,7 @@ const ANGULAR_TESTBED_SETUP = Symbol.for('testbed-setup');
 type TestBedSetupOptions = {
   zoneless?: boolean;
   providers?: Type<any>[];
+  browserMode?: boolean;
 };
 
 export function setupTestBed(
@@ -37,6 +38,9 @@ export function setupTestBed(
         ...((options?.providers || []) as Type<any>[]),
       ],
       platformBrowserTesting(),
+      options?.browserMode
+        ? { teardown: { destroyAfterEach: false } }
+        : undefined,
     );
   }
 }


### PR DESCRIPTION
## PR Checklist

Adds new `browserMode` option in `setupTestBed()`.


## What is the new behavior?

This option enables visual test preview in Vitest browser mode by preventing Angular from destroying components after each test, allowing developers to inspect the final state of their components in the browser preview window.

Also updated documentation in both the package README and docs-app to explain the new option


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYnl1Z29vaHczdGY2ZTQ3NXZ0OHQ1dGdlMnpmb3Q1amxsYzluMnJ2dSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/LFvWp14BLUiM8/giphy.gif"/>