### PR TITLE
fix(nx-plugin): skip installing Vitest packages when skipped during migration

### DIFF
--- a/packages/nx-plugin/src/generators/init/generator.ts
+++ b/packages/nx-plugin/src/generators/init/generator.ts
@@ -63,7 +63,7 @@ export async function setupAnalogGenerator(
   const angularVersion = getInstalledPackageVersion(tree, '@angular/core');
   const nxVersion = getInstalledPackageVersion(tree, 'nx');
   const majorAngularVersion = major(coerce(angularVersion));
-  addAnalogDependencies(tree, angularVersion, nxVersion);
+  addAnalogDependencies(tree, angularVersion, options.vitest, nxVersion);
   updateBuildTarget(tree, options);
   updateServeTarget(tree, options);
 

--- a/packages/nx-plugin/src/generators/init/lib/add-analog-dependencies.ts
+++ b/packages/nx-plugin/src/generators/init/lib/add-analog-dependencies.ts
@@ -6,10 +6,17 @@ import { getAnalogDependencies } from '../../../utils/versions/dependencies';
 export function addAnalogDependencies(
   tree: Tree,
   angularVersion: string,
+  vitest: boolean,
   nxVersion?: string,
 ) {
   const devDependencies = getAnalogDevDependencies(angularVersion, nxVersion);
   const dependencies = getAnalogDependencies(angularVersion);
+
+  if (!vitest) {
+    delete devDependencies['vitest'];
+    delete devDependencies['@vitest/coverage-v8'];
+    delete devDependencies['@vitest/ui'];
+  }
 
   addDependenciesToPackageJson(
     tree,

--- a/packages/nx-plugin/src/generators/setup-vitest/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/setup-vitest/generator.spec.ts
@@ -154,7 +154,7 @@ describe('setup-vitest generator', () => {
 
     const packageJson = JSON.parse(tree.read('package.json', 'utf-8'));
     expect(packageJson.devDependencies.vite).toBe(NX_X_LATEST_VITE); // '^6.0.0'
-    expect(packageJson.devDependencies.vitest).toBe(NX_X_LATEST_VITEST); // '^3.0.0'
+    expect(packageJson.devDependencies.vitest).toBe(V19_X_VITEST); // '^3.0.0'
   });
 
   it('should create test-setup.ts with correct content', async () => {

--- a/packages/nx-plugin/src/utils/versions/dev-dependencies.ts
+++ b/packages/nx-plugin/src/utils/versions/dev-dependencies.ts
@@ -111,15 +111,18 @@ const getDevDependencies = (
         ? V19_X_VITE
         : NX_X_LATEST_VITE,
     vitest:
-      escapedNxVersion && lt(escapedNxVersion, '22.3.0')
+      lt(escapedAngularVersion, '21.0.0') ||
+      (escapedNxVersion && lt(escapedNxVersion, '22.3.0'))
         ? V19_X_VITEST
         : NX_X_LATEST_VITEST,
     '@vitest/coverage-v8':
-      escapedNxVersion && lt(escapedNxVersion, '22.3.0')
+      lt(escapedAngularVersion, '21.0.0') ||
+      (escapedNxVersion && lt(escapedNxVersion, '22.3.0'))
         ? V19_X_VITEST
         : NX_X_LATEST_VITEST,
     '@vitest/ui':
-      escapedNxVersion && lt(escapedNxVersion, '22.3.0')
+      lt(escapedAngularVersion, '21.0.0') ||
+      (escapedNxVersion && lt(escapedNxVersion, '22.3.0'))
         ? V19_X_VITEST
         : NX_X_LATEST_VITEST,
   };


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2016 

## What is the new behavior?

Vitest packages are not installed when skipping the vitest option when running `@analogjs/platform:migrate --project [project-name]`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbGFkbzA1ODV3eWt6YXRsNzRjcWtocTNvbHprYTZnNmo3Njh5ZzJhYSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/10tt2DwqDd4AWk/giphy.gif"/>