### PR TITLE
fix(vitest-angular): ensure setupTestBed defaults merge

### DIFF
--- a/packages/vitest-angular/setup-testbed.ts
+++ b/packages/vitest-angular/setup-testbed.ts
@@ -17,9 +17,11 @@ type TestBedSetupOptions = {
   browserMode?: boolean;
 };
 
-export function setupTestBed(
-  options: TestBedSetupOptions = { zoneless: true, providers: [] },
-) {
+export function setupTestBed({
+  zoneless = true,
+  providers = [],
+  browserMode = false,
+}: TestBedSetupOptions = {}) {
   beforeEach(getCleanupHook(false));
   afterEach(getCleanupHook(true));
 
@@ -27,20 +29,18 @@ export function setupTestBed(
     (globalThis as any)[ANGULAR_TESTBED_SETUP] = true;
 
     @NgModule({
-      providers: options?.zoneless ? [provideZonelessChangeDetection()] : [],
+      providers: zoneless ? [provideZonelessChangeDetection()] : [],
     })
     class ZonelessTestModule {}
 
     getTestBed().initTestEnvironment(
       [
         BrowserTestingModule,
-        ...(options?.zoneless ? [ZonelessTestModule] : []),
-        ...((options?.providers || []) as Type<any>[]),
+        ...(zoneless ? [ZonelessTestModule] : []),
+        ...((providers || []) as Type<any>[]),
       ],
       platformBrowserTesting(),
-      options?.browserMode
-        ? { teardown: { destroyAfterEach: false } }
-        : undefined,
+      browserMode ? { teardown: { destroyAfterEach: false } } : undefined,
     );
   }
 }


### PR DESCRIPTION
## PR Checklist

Fixes parameter defaults not being applied when passing partial options to `setupTestBed()`.

Previously, when calling `setupTestBed({ browserMode: true })`, the default values for `zoneless` and `providers` would be lost because the entire default object was replaced.

## What is the new behavior?

Changed setupTestBed to use destructured parameters with individual default values instead of a single default object parameter.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlODZ2OWI4ODhiY3V1YmNqcGpnYnNyZ3YwcXlpazhhdnRjNnV6ZDE3aSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/s7qmvjy9qQej0KMf2K/giphy.gif"/>