### PR TITLE
fix(vite-plugin-angular): improve compatibility with older TypeScript versions

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -151,6 +151,7 @@ export function angular(options?: PluginOptions): Plugin[] {
     isLib: boolean;
   } | null = null;
 
+  const ts = require('typescript');
   let builder: ts.BuilderProgram | ts.EmitAndSemanticDiagnosticsBuilderProgram;
   let nextProgram: NgtscProgram | undefined;
   // Caches (always rebuild Angular program per user request)
@@ -990,7 +991,7 @@ export function angular(options?: PluginOptions): Plugin[] {
     } else {
       host = ts.createIncrementalCompilerHost(tsCompilerOptions, {
         ...ts.sys,
-        readFile(path, encoding) {
+        readFile(path: string, encoding: string) {
           if (fileTransformMap.has(path)) {
             return fileTransformMap.get(path);
           }


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2020 

## What is the new behavior?

Restores the code to load TypeScript using the `require` function. This restores compatibility with Angular v17 projects.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlem43dmViNGI5Nmd3bHpkaXNpbHR4dWU2cHpubWg4ejN4eWF2ZmEyNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/EIuzTIg0dsyESw4IVC/giphy.gif"/>