### PR TITLE
fix(vite-plugin-angular): process styles in jit mode instead of returning raw output

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -504,7 +504,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           const path = id.split(';')[1];
           return `${normalizePath(
             resolve(dirname(importer as string), path),
-          )}?raw`;
+          )}??${id.includes(':style') ? 'inline' : 'raw'}`;
         }
 
         // Map angular external styleUrls to the source file


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2018 

## What is the new behavior?

When building in JIT mode, JIT styles are processed inline instead of returned as-is. This fixes an issue when building Storybook components with external component styles.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNHgwYnNkbDF1aHg4cm93ZzdoY2MxcjN6NmlpazRsdTVqNmcwZXRnMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/WtMgPMG6Z2NP6uD9wd/giphy.gif"/>