### PR TITLE
fix(storybook): use vite config root when angularBuilderContext unavailable

### DIFF
--- a/packages/storybook-angular/src/lib/preset.spec.ts
+++ b/packages/storybook-angular/src/lib/preset.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { viteFinal } from './preset';
+
+describe('viteFinal', () => {
+  const createMockOptions = (overrides = {}) => ({
+    configDir: '.storybook',
+    presets: {
+      apply: vi.fn().mockResolvedValue({ options: {} }),
+    },
+    angularBuilderOptions: {},
+    ...overrides,
+  });
+
+  describe('when angularBuilderContext is undefined', () => {
+    it('should not crash during plugin initialization', async () => {
+      const config = { plugins: [] };
+      const options = createMockOptions({
+        // angularBuilderContext is intentionally undefined
+      });
+
+      await expect(viteFinal(config, options)).resolves.not.toThrow();
+    });
+
+    it('should return a valid vite config', async () => {
+      const config = { plugins: [] };
+      const options = createMockOptions();
+
+      const result = await viteFinal(config, options);
+
+      expect(result).toBeDefined();
+      expect(result.plugins).toBeDefined();
+      expect(Array.isArray(result.plugins)).toBe(true);
+    });
+
+    it('should include the angular options plugin', async () => {
+      const config = { plugins: [] };
+      const options = createMockOptions();
+
+      const result = await viteFinal(config, options);
+
+      const angularOptionsPlugin = result.plugins
+        .flat()
+        .find((p) => p?.name === 'analogjs-storybook-options-plugin');
+      expect(angularOptionsPlugin).toBeDefined();
+    });
+
+    it('should handle stylePreprocessorOptions.loadPaths without angularBuilderContext', async () => {
+      const config = { plugins: [] };
+      const options = createMockOptions({
+        angularBuilderOptions: {
+          stylePreprocessorOptions: {
+            loadPaths: ['src/styles'],
+          },
+        },
+        // angularBuilderContext is intentionally undefined
+      });
+
+      // Should not crash when processing loadPaths
+      await expect(viteFinal(config, options)).resolves.not.toThrow();
+    });
+  });
+
+  describe('when angularBuilderContext is available', () => {
+    it('should use angularBuilderContext.workspaceRoot for loadPaths', async () => {
+      const config = { plugins: [] };
+      const options = createMockOptions({
+        angularBuilderOptions: {
+          stylePreprocessorOptions: {
+            loadPaths: ['src/styles'],
+          },
+        },
+        angularBuilderContext: {
+          workspaceRoot: '/workspace/root',
+        },
+      });
+
+      const result = await viteFinal(config, options);
+
+      const angularOptionsPlugin = result.plugins
+        .flat()
+        .find((p) => p?.name === 'analogjs-storybook-options-plugin');
+
+      // Call the config hook to get the scss config
+      const pluginConfig = angularOptionsPlugin?.config?.({
+        root: '/vite/root',
+      });
+
+      expect(
+        pluginConfig?.css?.preprocessorOptions?.scss?.loadPaths?.[0],
+      ).toContain('/workspace/root');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

When running Storybook tests via `@storybook/addon-vitest`, the `angularBuilderContext` is undefined since Vitest doesn't use Angular's build system. This caused a crash in the `angularOptionsPlugin`:

```
TypeError: Cannot read properties of undefined (reading 'getProjectMetadata')
```

## Solution

Following @brandonroberts' suggestion in #2032:

1. Store the Vite `userConfig` from the `config()` hook in a `resolvedConfig` variable
2. Use `config.root` as the project root when `angularBuilderContext` is unavailable
3. Maintain backwards compatibility when `angularBuilderContext` IS available

**Fallback chain:** `angularBuilderContext.workspaceRoot` → `userConfig.root` → `process.cwd()`

## Testing

Tested in a real Nx monorepo with:
- `@analogjs/storybook-angular: 2.2.1`
- `@storybook/addon-vitest: 10.1.11`
- `vitest: 4.0.16`
- `@angular/core: 21.0.6`

All Storybook tests pass via Vitest after this fix.

Fixes #2032