### PR TITLE
fix(vite-plugin-nitro): trigger environment builds before server build

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -369,6 +369,8 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                 builds.push(builder.build(builder.environments['ssr']));
               }
 
+              await Promise.all(builds);
+
               let ssrEntryPath = resolve(
                 options?.ssrBuildDir ||
                   resolve(workspaceRoot, 'dist', rootDir, `ssr`),
@@ -376,7 +378,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
               );
 
               // add check for main.server.mjs fallback on Windows
-              if (filePrefix && !existsSync(ssrEntryPath)) {
+              if (isWindows && !existsSync(ssrEntryPath)) {
                 ssrEntryPath = ssrEntryPath.replace('.js', '.mjs');
               }
 
@@ -387,7 +389,6 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                 '#analog/ssr': ssrEntry,
               };
 
-              await Promise.all(builds);
               await buildServer(options, nitroConfig);
 
               if (
@@ -493,7 +494,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
           );
 
           // add check for main.server.mjs fallback on Windows
-          if (filePrefix && !existsSync(ssrEntryPath)) {
+          if (isWindows && !existsSync(ssrEntryPath)) {
             ssrEntryPath = ssrEntryPath.replace('.js', '.mjs');
           }
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Fixes a bug with environment builds on Windows. The path to resolve the `main.server.(m)js` was done before the build finished.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbjZkeDlnZzYwM2kwMnE1aGMweHQ4ZDRmeWVtNXUxcjkyaHViN3ZxcyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/NWpTZunsRRaJor5KD1/giphy.gif"/>