### PR TITLE
fix(content): allow retrieving content file resource by slug

### DIFF
--- a/packages/content/resources/src/content-file-resource.ts
+++ b/packages/content/resources/src/content-file-resource.ts
@@ -25,8 +25,7 @@ async function getContentFile<
   fallback: string,
 ): Promise<ContentFile<Attributes | Record<string, never>>> {
   const filePath = `/src/content/${slug}`;
-  const contentFile =
-    contentFiles[`${filePath}.md`] ?? contentFiles[`${filePath}.agx`];
+  const contentFile = contentFiles[`${filePath}.md`] ?? contentFiles[`${slug}`];
 
   if (!contentFile) {
     return {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When using content resources, the content files map accepts the slug as a lookup, allowing for more flexibility when using custom content file loaders.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
