### PR TITLE
fix(vite-plugin-angular): fall back to oxc/esbuild when Angular compiler has no output for a file

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -649,8 +649,22 @@ export function angular(options?: PluginOptions): Plugin[] {
             this.error(`${typescriptResult.errors.join('\n')}`);
           }
 
-          // return fileEmitter
-          let data = typescriptResult?.content ?? '';
+          if (!typescriptResult) {
+            if (vite.rolldownVersion) {
+              return vite.transformWithOxc(code, id, {
+                lang: 'ts',
+                sourcemap: true,
+              });
+            } else {
+              return vite.transformWithEsbuild(code, id, {
+                loader: 'ts',
+                sourcemap: true,
+                sourcefile: id,
+              });
+            }
+          }
+
+          let data = typescriptResult.content ?? '';
 
           if (jit && data.includes('angular:jit:')) {
             data = data.replace(


### PR DESCRIPTION
## PR Checklist

The transform handler returned `{ code: '', map: null }` for `.ts` files not emitted by the Angular compiler. Vite interpreted this as "the plugin handled the file and the result is empty", so no other transformer processed the file.
This caused Vitest to report "No test suite found in file" for any `.spec.ts` file — including plain TypeScript tests with no Angular imports.

## What is the new behavior?

When `fileEmitter(id)` returns `undefined`, the transform handler now falls back to `transformWithOxc` (Vite 7+) or `transformWithEsbuild` to compile the TypeScript file, instead of returning empty code.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No