### PR TITLE
docs(storybook-angular): update nx.json zoneless guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ Must be one of the following:
 
 ### Scope
 
-The scope should be the name of the npm package affected (as perceived by the person reading the changelog generated from commit messages.
+The scope should be the name of the npm package affected (as perceived by the person reading the changelog generated from commit messages).
 
 The following is the list of currently supported scopes:
 
@@ -165,6 +165,7 @@ The following is the list of currently supported scopes:
 - **nx-plugin**
 - **platform**
 - **router**
+- **storybook-angular**
 - **trpc**
 - **vite-plugin-angular**
 - **vite-plugin-nitro**

--- a/apps/docs-app/docs/integrations/storybook/index.md
+++ b/apps/docs-app/docs/integrations/storybook/index.md
@@ -143,6 +143,9 @@ To register global styles, add them to the `@analogjs/storybook-angular` builder
 
 To use zoneless change detection for the Storybook, add the `experimentalZoneless` flag to the `@analogjs/storybook-angular` builder options in the `angular.json` or `project.json`.
 
+<Tabs groupId="zoneless-change-detection">
+  <TabItem value="angular.json">
+
 ```json
     "storybook": {
       "builder": "@analogjs/storybook-angular:start-storybook",
@@ -159,6 +162,33 @@ To use zoneless change detection for the Storybook, add the `experimentalZoneles
       }
     }
 ```
+
+  </TabItem>
+  <TabItem value="project.json">
+
+```json
+    "storybook": {
+      "executor": "@analogjs/storybook-angular:start-storybook",
+      "options": {
+        // ... other options
+        "configDir": "path/to/.storybook",
+        "experimentalZoneless": true,
+        "compodoc": false
+      }
+    },
+    "build-storybook": {
+      "executor": "@analogjs/storybook-angular:build-storybook",
+      "options": {
+        // ... other options
+        "configDir": "path/to/.storybook",
+        "experimentalZoneless": true,
+        "compodoc": false
+      }
+    }
+```
+
+  </TabItem>
+</Tabs>
 
 > Zoneless change detection is the default for new projects starting Angular v21.
 

--- a/packages/storybook-angular/README.md
+++ b/packages/storybook-angular/README.md
@@ -91,7 +91,7 @@ To register global styles, add them to the `@analogjs/storybook-angular` builder
 
 ## Enabling Zoneless Change Detection
 
-To use zoneless change detection for the Storybook, add the `experimentalZoneless` flag to the `@analogjs/storybook-angular` builder options in the `angular.json` or `project.json`.
+To use zoneless change detection for the Storybook, add the `experimentalZoneless` flag to the `@analogjs/storybook-angular` builder options in the `angular.json`.
 
 ```json
     "storybook": {
@@ -106,6 +106,29 @@ To use zoneless change detection for the Storybook, add the `experimentalZoneles
       "options": {
         // ... other options
         "experimentalZoneless": true
+      }
+    }
+```
+
+For `project.json`
+
+```json
+    "storybook": {
+      "executor": "@analogjs/storybook-angular:start-storybook",
+      "options": {
+        // ... other options
+        "configDir": "path/to/.storybook",
+        "experimentalZoneless": true,
+        "compodoc": false
+      }
+    },
+    "build-storybook": {
+      "executor": "@analogjs/storybook-angular:build-storybook",
+      "options": {
+        // ... other options
+        "configDir": "path/to/.storybook",
+        "experimentalZoneless": true,
+        "compodoc": false
       }
     }
 ```


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Following documentation does not allow storybook to run in zoneless app.

Closes #2057

## What is the new behavior?

Added documentation separation between `angular.json` (left unchanged) and `project.json`

<img width="1013" height="645" alt="image" src="https://github.com/user-attachments/assets/b1885d52-302b-444f-9678-5b68c3169cc9" />

<img width="981" height="724" alt="image" src="https://github.com/user-attachments/assets/5f9123f1-8503-468a-8eb4-18c686e7d88d" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Added missing scope from the validator enum to the CONTRIBUTING.md guidelines/

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
