### PR TITLE
fix(vite-plugin-angular): add missing tinyglobby dependency

### DIFF
--- a/packages/vite-plugin-angular/package.json
+++ b/packages/vite-plugin-angular/package.json
@@ -36,6 +36,7 @@
     }
   },
   "dependencies": {
+    "tinyglobby": "^0.2.14",
     "ts-morph": "^21.0.0"
   },
   "builders": "./src/lib/tools/builders.json",


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Closes #2063

## What is the new behavior?

This defines `tinyglobby` as an explicit dependency for `@analogjs/vite-plugin-angular`. I pulled the version from the root `package.json`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I noticed `pnpm-lock.yaml` wasn't updated when I ran `pnpm i` after this change. That was unexpected for me. Let me know if there is something special I need to do, or if this is a symptom of using Nx.