### PR TITLE
Add imports and update providers in setupTestBed

### DIFF
--- a/packages/vitest-angular/setup-testbed.ts
+++ b/packages/vitest-angular/setup-testbed.ts
@@ -1,4 +1,11 @@
-import { EnvironmentProviders, inject, NgModule, Provider, provideZonelessChangeDetection, Type } from '@angular/core';
+import {
+  EnvironmentProviders,
+  inject,
+  NgModule,
+  Provider,
+  provideZonelessChangeDetection,
+  Type,
+} from '@angular/core';
 import {
   ɵgetCleanupHook as getCleanupHook,
   getTestBed,
@@ -13,7 +20,7 @@ const ANGULAR_TESTBED_SETUP = Symbol.for('testbed-setup');
 
 type TestBedSetupOptions = {
   zoneless?: boolean;
-  imports?: Type<any> | Type<any>[];
+  imports?: Type<any>[];
   providers?: (Provider | EnvironmentProviders)[];
   browserMode?: boolean;
 };


### PR DESCRIPTION
## PR Checklist

setupTestBed() now works with (service) providers and imports (NgModules).

Closes #

## What is the new behavior?

the "providers" in setupTestBed() was wrongly passed to initTestEnvironment() which only expects ngModules.

Now a CustomTestModule is created to support "real" providers, as well as imports in the setupTestBed().

## Does this PR introduce a breaking change?

- [x ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

"providers" must be renamed to "imports" in the setupTestBed() call.

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
