### PR TITLE
fix(vitest-angular): add missing zone.js optional peer dependency

### DIFF
--- a/packages/vitest-angular/package.json
+++ b/packages/vitest-angular/package.json
@@ -36,7 +36,13 @@
     "@analogjs/vite-plugin-angular": "*",
     "@angular-devkit/architect": ">=0.1500.0 < 0.2200.0",
     "@angular-devkit/schematics": ">=17.0.0",
-    "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+    "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0",
+    "zone.js": ">=0.14.0"
+  },
+  "peerDependenciesMeta": {
+    "zone.js": {
+      "optional": true
+    }
   },
   "ng-update": {
     "packageGroup": [


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Related to #2063 and #2069. pnpm's `hoist=false` prevents packages from having implicit dependencies.

## What is the new behavior?

This defines `zone.js` as an optional peer dependency so `@analogjs/vitest-angular` can actually find it. I pulled the version from the root `package.json`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The peer dependency is optional, so it should not be a breaking change given a non-ancient package manager version is used.

## Other information

I noticed `pnpm-lock.yaml` wasn't updated when I ran `pnpm i` after this change. That was unexpected for me. Let me know if there is something special I need to do, or if this is a symptom of using Nx.