### PR TITLE
test: add test for lib without tests

### DIFF
--- a/libs/my-package/src/lib/my-package/my-package.spec.ts
+++ b/libs/my-package/src/lib/my-package/my-package.spec.ts
@@ -1,0 +1,14 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+import { MyPackage } from './my-package';
+import { page } from 'vitest/browser';
+
+describe(MyPackage.name, () => {
+  it('works', async () => {
+    TestBed.createComponent(MyPackage);
+
+    await expect
+      .element(page.elementLocator(document.body))
+      .toHaveTextContent('My Package');
+  });
+});

--- a/libs/my-package/vite.config.ts
+++ b/libs/my-package/vite.config.ts
@@ -42,12 +42,6 @@ export default defineConfig(({ mode }) => ({
     include: ['**/*.spec.ts'],
     cacheDir: '../../node_modules/.vitest',
     isolate: false,
-    /**
-     * Make sure that all tests are running in the same worker,
-     * so that we can test the reset of the TestBed between tests
-     * @see src/lib/my-package/reset-test-bed-between-tests/README.md
-     */
-    maxWorkers: 1,
     browser: {
       enabled: true,
       provider: playwright(),


### PR DESCRIPTION
Add test to `my-package` lib as it didn't have any tests anymore since they were moved by #2072.
Another option was to add `--pass-with-no-tests` option to all `test` targets in Nx defaults but that would probably be too permissive.