### PR TITLE
feat(vite-plugin-nitro): add option for markdown source output alongside prerendered routes

### DIFF
--- a/apps/blog-app/vite.config.ts
+++ b/apps/blog-app/vite.config.ts
@@ -72,6 +72,7 @@ export default defineConfig(() => {
                     changefreq: 'never',
                   };
                 },
+                outputSourceFile: (file: PrerenderContentFile) => file.content,
               },
             ];
           },

--- a/apps/docs-app/docs/features/server/static-site-generation.md
+++ b/apps/docs-app/docs/features/server/static-site-generation.md
@@ -72,6 +72,74 @@ export default defineConfig(({ mode }) => ({
 }));
 ```
 
+### Outputting Source Markdown Files
+
+To make prerendered pages more accessible to LLMs or other tools that prefer raw markdown, you can output the source markdown file alongside each prerendered route. The source file will be accessible at the route path with a `.md` extension (e.g., `/blog/my-post` would also be available at `/blog/my-post.md`).
+
+For individual routes, specify the path to the source file:
+
+```ts
+import { defineConfig } from 'vite';
+import analog from '@analogjs/platform';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    analog({
+      prerender: {
+        routes: async () => [
+          '/',
+          {
+            route: '/overview',
+            outputSourceFile: 'src/content/overview.md',
+          },
+        ],
+      },
+    }),
+  ],
+}));
+```
+
+For content directories, use a function that receives the file information and returns the content to output:
+
+```ts
+import { defineConfig } from 'vite';
+import analog, { type PrerenderContentFile } from '@analogjs/platform';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    analog({
+      prerender: {
+        routes: async () => [
+          '/',
+          {
+            contentDir: 'src/content/blog',
+            transform: (file: PrerenderContentFile) => {
+              const slug = file.attributes.slug || file.name;
+              return `/blog/${slug}`;
+            },
+            outputSourceFile: (file: PrerenderContentFile) => file.content,
+          },
+        ],
+      },
+    }),
+  ],
+}));
+```
+
+You can also conditionally skip outputting the source file by returning `false`:
+
+```ts
+outputSourceFile: (file: PrerenderContentFile) => {
+  // Don't output source for draft posts
+  if (file.attributes.draft) {
+    return false;
+  }
+  return file.content;
+},
+```
+
 ## Only Prerendering Static Pages
 
 To only prerender the static pages without building the server, use the `static: true` flag.

--- a/packages/vite-plugin-nitro/src/lib/build-server.ts
+++ b/packages/vite-plugin-nitro/src/lib/build-server.ts
@@ -1,6 +1,7 @@
 import { NitroConfig, copyPublicAssets, prerender } from 'nitropack';
 import { createNitro, build, prepare } from 'nitropack';
-import { existsSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import { Options } from './options.js';
 import { addPostRenderingHooks } from './hooks/post-rendering-hook.js';
@@ -8,6 +9,7 @@ import { addPostRenderingHooks } from './hooks/post-rendering-hook.js';
 export async function buildServer(
   options?: Options,
   nitroConfig?: NitroConfig,
+  routeSourceFiles?: Record<string, string>,
 ) {
   const nitro = await createNitro({
     dev: false,
@@ -46,6 +48,21 @@ export async function buildServer(
   ) {
     console.log(`Prerendering static pages...`);
     await prerender(nitro);
+  }
+
+  if (routeSourceFiles && Object.keys(routeSourceFiles).length > 0) {
+    const publicDir = nitroConfig?.output?.publicDir!;
+
+    for (const [route, content] of Object.entries(routeSourceFiles)) {
+      const outputPath = join(publicDir, `${route}.md`);
+      const outputDir = dirname(outputPath);
+
+      if (!existsSync(outputDir)) {
+        mkdirSync(outputDir, { recursive: true });
+      }
+
+      writeFileSync(outputPath, content, 'utf8');
+    }
   }
 
   if (!options?.static) {

--- a/packages/vite-plugin-nitro/src/lib/options.ts
+++ b/packages/vite-plugin-nitro/src/lib/options.ts
@@ -72,7 +72,7 @@ export interface PrerenderContentDir {
   /**
    * Transform the matching content files path into a route.
    * The function is called for each matching content file within the specified contentDir.
-   * @param file information of the matching file (`path`, `name`, `extension`, `attributes`)
+   * @param file information of the matching file (`path`, `name`, `extension`, `attributes`, `content`)
    * @returns a string with the route should be returned (e. g. `/blog/<slug>`) or the value `false`, when the route should not be prerendered.
    */
   transform: (file: PrerenderContentFile) => string | false;
@@ -85,6 +85,14 @@ export interface PrerenderContentDir {
   sitemap?:
     | PrerenderSitemapConfig
     | ((file: PrerenderContentFile) => PrerenderSitemapConfig);
+
+  /**
+   * Output the source markdown content alongside the prerendered route.
+   * The source file will be accessible at the route path with a .md extension.
+   * @param file information of the matching file including its content
+   * @returns the markdown content string to output, or `false` to skip outputting for this file
+   */
+  outputSourceFile?: (file: PrerenderContentFile) => string | false;
 }
 
 /**
@@ -92,6 +100,7 @@ export interface PrerenderContentDir {
  * @param name the basename of the matching content file without the file extension
  * @param extension the file extension
  * @param attributes the frontmatter attributes extracted from the frontmatter section of the file
+ * @param content the raw file content including frontmatter
  * @returns a string with the route should be returned (e. g. `/blog/<slug>`) or the value `false`, when the route should not be prerendered.
  */
 export interface PrerenderContentFile {
@@ -99,6 +108,7 @@ export interface PrerenderContentFile {
   attributes: Record<string, any>;
   name: string;
   extension: string;
+  content: string;
 }
 
 export interface PrerenderSitemapConfig {
@@ -126,4 +136,10 @@ export interface PrerenderRouteConfig {
    * Prerender static data for the prerendered route
    */
   staticData?: boolean;
+  /**
+   * Path to the source markdown file to output alongside the prerendered route.
+   * The source file will be accessible at the route path with a .md extension.
+   * @example 'src/content/overview.md'
+   */
+  outputSourceFile?: string;
 }

--- a/packages/vite-plugin-nitro/src/lib/utils/get-content-files.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-content-files.ts
@@ -111,6 +111,7 @@ export function getMatchingContentFilesWithFrontMatter(
       extension,
       path: resolvedDir,
       attributes: raw.attributes as { attributes: Record<string, any> },
+      content: fileContents,
     };
   });
 

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -5,7 +5,7 @@ import { mergeConfig, normalizePath } from 'vite';
 import { dirname, join, relative, resolve } from 'node:path';
 import { platform } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 
 import { buildServer } from './build-server.js';
 import { buildSSRApp } from './build-ssr.js';
@@ -58,6 +58,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
     string,
     PrerenderSitemapConfig | (() => PrerenderSitemapConfig)
   > = {};
+  const routeSourceFiles: Record<string, string> = {};
   let rootDir = workspaceRoot;
 
   return [
@@ -253,6 +254,18 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                     routeSitemaps[current.route] = current.sitemap;
                   }
 
+                  if (current.outputSourceFile) {
+                    const sourcePath = resolve(
+                      workspaceRoot,
+                      rootDir,
+                      current.outputSourceFile,
+                    );
+                    routeSourceFiles[current.route] = readFileSync(
+                      sourcePath,
+                      'utf8',
+                    );
+                  }
+
                   prev.push(current.route);
 
                   // Add the server-side data fetching endpoint URL
@@ -279,6 +292,13 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                         current.sitemap && typeof current.sitemap === 'function'
                           ? current.sitemap?.(f)
                           : current.sitemap;
+                    }
+
+                    if (current.outputSourceFile) {
+                      const sourceContent = current.outputSourceFile(f);
+                      if (sourceContent) {
+                        routeSourceFiles[result] = sourceContent;
+                      }
                     }
 
                     prev.push(result);
@@ -389,7 +409,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                 '#analog/ssr': ssrEntry,
               };
 
-              await buildServer(options, nitroConfig);
+              await buildServer(options, nitroConfig, routeSourceFiles);
 
               if (
                 nitroConfig.prerender?.routes?.length &&
@@ -505,7 +525,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
             '#analog/ssr': ssrEntry,
           };
 
-          await buildServer(options, nitroConfig);
+          await buildServer(options, nitroConfig, routeSourceFiles);
 
           console.log(
             `\n\nThe '@analogjs/platform' server has been successfully built.`,


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2046

## What is the new behavior?

This allows markdown source files to be output alongside prerendered routes, making content more accessible to LLMs and other tools that prefer raw markdown. Source files are written with a .md extension at the route path.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYXBxeHNyM3h2MnZvMzhtNHNzbzB5MnptN3R2YmhxcGd4eGc1bWFsYyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/hrdX1BsUBq7DkGJCCd/giphy.gif"/>