### PR TITLE
fix(storybook-angular): add missing applyDecorators to render annotaions

### DIFF
--- a/packages/storybook-angular/src/lib/testing.ts
+++ b/packages/storybook-angular/src/lib/testing.ts
@@ -21,6 +21,7 @@ export async function renderToCanvas(
 const renderAnnotations = {
   render,
   renderToCanvas,
+  applyDecorators: configAnnotations.applyDecorators,
 };
 
 export function setProjectAnnotations(


### PR DESCRIPTION
## PR Checklist

Closes #2074 

## What is the new behavior?

  `@storybook/angular`'s [`componentWrapperDecorator()` depends on `storyFn().template` internally](https://github.com/storybookjs/storybook/blob/10d1e88911be83d5467d32ccd446d5499d00b8e5/code/frameworks/angular/src/client/decorators.ts#L60).

  This `storyFn().template` is resolved by `prepareMain()`, which is called inside Storybook's  [`decorateStory()`](https://github.com/storybookjs/storybook/blob/10d1e88911be83d5467d32ccd446d5499d00b8e5/code/frameworks/angular/src/client/decorateStory.ts#L7). This function is [exported as `applyDecorators` within Storybook](https://github.com/storybookjs/storybook/blob/10d1e88911be83d5467d32ccd446d5499d00b8e5/code/frameworks/angular/src/client/config.ts#L4).

  However, before this fix, `decorateStory()` was not being called at runtime. Instead, Storybook's generic renderer
  [`defaultDecorateStory`](https://github.com/storybookjs/storybook/blob/10d1e88911be83d5467d32ccd446d5499d00b8e5/code/core/src/preview-api/modules/store/decorators.ts#L49) was being used. Since  `defaultDecorateStory` does not call `prepareMain()`, `storyFn().template` remained unresolved.

  This happens because [`prepareStory()`](https://github.com/storybookjs/storybook/blob/10d1e88911be83d5467d32ccd446d5499d00b8e5/code/core/src/preview-api/modules/store/csf/prepareStory.ts#L37C17-L37C29), which
   is called during portable story rendering in the Vitest environment, contains the following:

```ts
  // Currently it is only possible to set these globally
  const { applyDecorators = defaultDecorateStory, runStep } = projectAnnotations;
```

  When applyDecorators is not defined in `projectAnnotations`, it falls back to `defaultDecorateStory`.

  With this fix, `applyDecorators `is now included in `renderAnnotations` and passed through to `prepareStory()`. This causes Angular's `decorateStory()` to be used, which calls `prepareMain()` and properly resolves `storyFn().template`.

  As a result, `storyFn().template` inside `componentWrapperDecorator() `is no longer undefined.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is my first PR to an OSS project. English is not my first language, so I wrote this description in Japanese first and then had it translated. I apologize if anything is unclear or hard to read.