### PR TITLE
fix(vite-plugin-angular): hash styleId to prevent filename exceeding max length

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { Plugin, ResolvedConfig, preprocessCSS } from 'vite';
 
 export function jitPlugin({
@@ -22,6 +23,11 @@ export function jitPlugin({
     async load(id: string) {
       if (id.includes('virtual:angular:jit:style:inline;')) {
         const styleId = id.split('style:inline;')[1];
+        // styleId may exceed 255 bytes of base64-encoded content, limit to 16
+        const styleIdHash = createHash('sha256')
+          .update(styleId)
+          .digest('hex')
+          .slice(0, 16);
 
         const decodedStyles = Buffer.from(
           decodeURIComponent(styleId),
@@ -33,7 +39,7 @@ export function jitPlugin({
         try {
           const compiled = await preprocessCSS(
             decodedStyles,
-            `${styleId}.${inlineStylesExtension}?direct`,
+            `${styleIdHash}.${inlineStylesExtension}?direct`,
             config,
           );
           styles = compiled?.code;


### PR DESCRIPTION
`styleId` from `@angular/build` was being used directly as a temp filename but it could potentially exceed 255 bytes of base64-encoded data causing third party tooling to throw `ENAMETOOLONG` on `fs.statSync` calls.

Closes #2077

## What is the new behavior?

`styleId` is hashed in `SHA256` to limit the temporary filename length to 16 bytes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No