### PR TITLE
fix(): use non-greedy regex for path normalization

### DIFF
--- a/packages/content/resources/src/content-file-resource.spec.ts
+++ b/packages/content/resources/src/content-file-resource.spec.ts
@@ -123,6 +123,31 @@ slug: 'docs'
       toc: [{ id: 'docs-heading', level: 1, text: 'Docs Heading' }],
     });
   });
+
+  it('resolves nested paths that include a content segment name', async () => {
+    const contentFiles = {
+      '/src/content/docs/reference/api/nested/content.md': () =>
+        Promise.resolve(`---
+slug: 'docs/reference/api/nested/content'
+---
+# Nested Content`),
+    };
+    setup({
+      routeParams: { slug: 'docs/reference/api/nested/content' },
+      contentFiles,
+    });
+
+    const result = TestBed.inject(TEST_RESOURCE_TOKEN);
+    await settleResource(result);
+
+    expect(result.value()).toEqual({
+      filename: '/src/content/docs/reference/api/nested/content',
+      slug: 'docs/reference/api/nested/content',
+      attributes: { slug: 'docs/reference/api/nested/content' },
+      content: '# Nested Content',
+      toc: [{ id: 'nested-content', level: 1, text: 'Nested Content' }],
+    });
+  });
 });
 
 function setup(args: {

--- a/packages/content/resources/src/content-file-resource.ts
+++ b/packages/content/resources/src/content-file-resource.ts
@@ -30,8 +30,9 @@ async function getContentFile<
   const normalizedFiles: Record<string, () => Promise<string>> = {};
   for (const [key, resolver] of Object.entries(contentFiles)) {
     const normalizedKey = key
-      // replace any prefix up to /content with /src/content
-      .replace(/^(?:.*)\/content/, '/src/content')
+      // replace any prefix up to the content directory with /src/content
+      // use a non-greedy match so nested paths containing "/content" are preserved
+      .replace(/^(?:.*?)\/content(?=\/)/, '/src/content')
       // normalize duplicate slashes
       .replace(/\/{2,}/g, '/');
     normalizedFiles[normalizedKey] = resolver;

--- a/packages/router/src/lib/routes.spec.ts
+++ b/packages/router/src/lib/routes.spec.ts
@@ -501,6 +501,25 @@ describe('routes', () => {
     });
   });
 
+  describe('a nested content route', () => {
+    const files: Files = {
+      '/src/content/a/b/content.md': () =>
+        Promise.resolve(`# Content Route
+
+Testing nested markdown routes.
+`),
+    };
+
+    const routes = createRoutes(files);
+    const route = routes[0];
+
+    it('should have a nested path matching content file segments', () => {
+      expect(route.path).toBe('a');
+      expect(route.children[0].path).toBe('b');
+      expect(route.children[0].children[0].path).toBe('content');
+    });
+  });
+
   describe('an optional catchall route (root)', () => {
     const files: Files = {
       '/app/routes/[[...slug]].ts': () =>

--- a/packages/router/src/lib/routes.ts
+++ b/packages/router/src/lib/routes.ts
@@ -123,7 +123,7 @@ function toRawPath(filename: string): string {
     filename
       .replace(
         // convert to relative path and remove file extension
-        /^(?:[a-zA-Z]:[\\/])?(.*?)[\\/](?:routes|pages)[\\/]|(?:[\\/](?:app[\\/](?:routes|pages)[\\/]))|(\.page\.(js|ts|analog|ag)$)|(\.(ts|md|analog|ag)$)/g,
+        /^(?:[a-zA-Z]:[\\/])?(.*?)[\\/](?:routes|pages)[\\/]|(?:[\\/](?:app[\\/](?:routes|pages)|src[\\/]content)[\\/])|(\.page\.(js|ts|analog|ag)$)|(\.(ts|md|analog|ag)$)/g,
         '',
       )
       // [[...slug]] => placeholder (named empty) which is stripped by toSegment


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?
This switches the `normalizedFiles` regex to not be greedy. If a content routes has the slug `content` anywhere in it, it would match too far along the path. A non-greedy regex will work just fine.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMXNrd3U0OHR6aDc5bGlmYjN3aGlpZDhtbG5jeTN3aDFjNHhoeWd6ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iAYupOdWXQy5a4nVGk/giphy.gif)