### PR TITLE
fix(platform): allow using custom vite plugins for Angular compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@nx/vite": "22.4.1",
     "@nx/vitest": "22.4.1",
     "@nx/web": "22.4.1",
+    "@oxc-angular/vite": "^0.0.10",
     "@oxc-project/runtime": "^0.99.0",
     "@playwright/test": "^1.54.2",
     "@schematics/angular": "21.1.1",

--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -12,13 +12,17 @@ export function depsPlugin(options?: Options): Plugin[] {
     {
       name: 'analogjs-deps-plugin',
       config() {
-        const esbuild = options?.vite?.experimental?.useAngularCompilationAPI
-          ? {}
-          : { exclude: ['**/*.ts', '**/*.js'] };
+        const esbuild =
+          options?.vite === false ||
+          options?.vite?.experimental?.useAngularCompilationAPI
+            ? {}
+            : { exclude: ['**/*.ts', '**/*.js'] };
 
-        const oxc = options?.vite?.experimental?.useAngularCompilationAPI
-          ? {}
-          : { exclude: ['**/*.ts', '**/*.js'] };
+        const oxc =
+          options?.vite === false ||
+          options?.vite?.experimental?.useAngularCompilationAPI
+            ? {}
+            : { exclude: ['**/*.ts', '**/*.js'] };
 
         return {
           ...(vite.rolldownVersion ? { oxc } : { esbuild }),

--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -47,7 +47,11 @@ export interface Options {
   static?: boolean;
   prerender?: PrerenderOptions;
   entryServer?: string;
-  vite?: PluginOptions;
+  /**
+   * Pass configuration options to the internal `@analogjs/vite-plugin-angular`
+   * plugin. Set to false to disable the internal vite plugin.
+   */
+  vite?: PluginOptions | false;
   nitro?: NitroConfig;
   apiPrefix?: string;
   jit?: boolean;

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -49,22 +49,24 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
     ...(!isTest ? depsPlugin(platformOptions) : []),
     ...routerPlugin(platformOptions),
     ...contentPlugin(platformOptions?.content, platformOptions),
-    ...angular({
-      jit: platformOptions.jit,
-      workspaceRoot: platformOptions.workspaceRoot,
-      disableTypeChecking: platformOptions.disableTypeChecking ?? false,
-      include: [
-        ...(platformOptions.include ?? []),
-        ...(platformOptions.additionalPagesDirs ?? []).map(
-          (pageDir) => `${pageDir}/**/*.page.ts`,
-        ),
-      ],
-      additionalContentDirs: platformOptions.additionalContentDirs,
-      liveReload: platformOptions.liveReload,
-      inlineStylesExtension: platformOptions.inlineStylesExtension,
-      fileReplacements: platformOptions.fileReplacements,
-      ...(opts?.vite ?? {}),
-    }),
+    ...(opts?.vite === false
+      ? []
+      : angular({
+          jit: platformOptions.jit,
+          workspaceRoot: platformOptions.workspaceRoot,
+          disableTypeChecking: platformOptions.disableTypeChecking ?? false,
+          include: [
+            ...(platformOptions.include ?? []),
+            ...(platformOptions.additionalPagesDirs ?? []).map(
+              (pageDir) => `${pageDir}/**/*.page.ts`,
+            ),
+          ],
+          additionalContentDirs: platformOptions.additionalContentDirs,
+          liveReload: platformOptions.liveReload,
+          inlineStylesExtension: platformOptions.inlineStylesExtension,
+          fileReplacements: platformOptions.fileReplacements,
+          ...(opts?.vite ?? {}),
+        })),
     serverModePlugin(),
     ssrXhrBuildPlugin(),
     clearClientPageEndpointsPlugin(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@nx/web':
         specifier: 22.4.1
         version: 22.4.1(@babel/traverse@7.28.6)(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@22.4.1(@swc-node/register@1.10.10(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
+      '@oxc-angular/vite':
+        specifier: ^0.0.10
+        version: 0.0.10(vite@8.0.0-beta.9(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.2)(sass-embedded@1.86.0)(sass@1.97.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.7.0))
       '@oxc-project/runtime':
         specifier: ^0.99.0
         version: 0.99.0
@@ -3859,6 +3862,51 @@ packages:
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@oxc-angular/binding-darwin-arm64@0.0.10':
+    resolution: {integrity: sha512-iKLlJa25QTOyDGBViKEP1+/FjpdjsahZN7xtCGIOYFnqKY5pam01NmTAoqgoVm0una2y8PASfu95qEz37MSCsA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-angular/binding-darwin-x64@0.0.10':
+    resolution: {integrity: sha512-IJyYxMpf0KiObrksDfzyB64iTIipcLu55giDXOJIgz5IrNSgW74po0yGpCsDq7USLcTGecMUkmLo9H3W8ygcEQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-angular/binding-linux-arm64-gnu@0.0.10':
+    resolution: {integrity: sha512-HRVC1xUftXlYCHSATFhpAx4gT9yhQF33OYWluajQuPN+QldKs2l4qzgfEDP/iRiFuYlUbP7Pj7LvjuIVXyiZSg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-angular/binding-linux-arm64-musl@0.0.10':
+    resolution: {integrity: sha512-XksIeCYCjhnAEusEB0ZIWB0ExUx5LkZYoe25Rjz5ID5D/NFRcffraXJYbR/iFqHyS3OVN3Z4V3fxG+NYpchcVg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-angular/binding-linux-x64-gnu@0.0.10':
+    resolution: {integrity: sha512-U3ms06BBIyIuLoonbnQ9y8X0nT7XH3kBZ1XJvWTR5qbq725Wwis8+StZzxEMzfZFFQoN4AJC6BI2pDC8t1vlEg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-angular/binding-linux-x64-musl@0.0.10':
+    resolution: {integrity: sha512-xFqhUNz2f2L3TJOzaAFwSBdlXUVwK7XS5aLcwdpavzFH2pmVGrGRtapd3AQkmHMY+2pq+jJuH4v2FZR2ygvWDA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-angular/binding-win32-arm64-msvc@0.0.10':
+    resolution: {integrity: sha512-OLHGhF4IvF3R4NM4Aj8Vs/UvIHiN7U5O0ye6oF5/7wdPYePhoS1IzqEN/CLRDzTyewGzcU16UdPCEXHkJC3G6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-angular/binding-win32-x64-msvc@0.0.10':
+    resolution: {integrity: sha512-ThoSB1XffBqkW66z4n1WEQ5OLys4iCQ0PdjUW2qD10I1/jFAGknuArJzYG+6p2ahiUtV9AsX/Ar9T352cCfydQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-angular/vite@0.0.10':
+    resolution: {integrity: sha512-QloBKuANraIlFiq9XAPhkb7WeVpcxXgJUFh0R9mLYoZ9ArPSVjBrfSRgl4RfqxdY7Rrnt5hFU6SnW+uFvTBODg==}
+    peerDependencies:
+      vite: '>=8.0.0-beta.10'
 
   '@oxc-project/runtime@0.110.0':
     resolution: {integrity: sha512-4t5lYmPneAGKGN7zDhK2iQrn+Ax3DXLCNqVr3z6K2VqemKWfQTlLyzjgjilxZmwFAKe65qI4WG7Bsj05UgUHaA==}
@@ -8548,21 +8596,23 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -13455,7 +13505,7 @@ packages:
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   telejson@8.0.0:
     resolution: {integrity: sha512-8mCI1dHX80nchOkIEgvyWlGLgeh/SxO7JZPOud0DxvfFdI6MgwxRL8ff7rVdj6436uHhpWaxLQjU74Jb2I0u9g==}
@@ -20140,6 +20190,44 @@ snapshots:
   '@oozcitak/util@10.0.0': {}
 
   '@oslojs/encoding@1.1.0': {}
+
+  '@oxc-angular/binding-darwin-arm64@0.0.10':
+    optional: true
+
+  '@oxc-angular/binding-darwin-x64@0.0.10':
+    optional: true
+
+  '@oxc-angular/binding-linux-arm64-gnu@0.0.10':
+    optional: true
+
+  '@oxc-angular/binding-linux-arm64-musl@0.0.10':
+    optional: true
+
+  '@oxc-angular/binding-linux-x64-gnu@0.0.10':
+    optional: true
+
+  '@oxc-angular/binding-linux-x64-musl@0.0.10':
+    optional: true
+
+  '@oxc-angular/binding-win32-arm64-msvc@0.0.10':
+    optional: true
+
+  '@oxc-angular/binding-win32-x64-msvc@0.0.10':
+    optional: true
+
+  '@oxc-angular/vite@0.0.10(vite@8.0.0-beta.9(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.2)(sass-embedded@1.86.0)(sass@1.97.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.7.0))':
+    dependencies:
+      obug: 2.1.1
+      vite: 8.0.0-beta.9(@types/node@22.17.0)(esbuild@0.25.8)(jiti@2.5.1)(less@4.4.2)(sass-embedded@1.86.0)(sass@1.97.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.7.0)
+    optionalDependencies:
+      '@oxc-angular/binding-darwin-arm64': 0.0.10
+      '@oxc-angular/binding-darwin-x64': 0.0.10
+      '@oxc-angular/binding-linux-arm64-gnu': 0.0.10
+      '@oxc-angular/binding-linux-arm64-musl': 0.0.10
+      '@oxc-angular/binding-linux-x64-gnu': 0.0.10
+      '@oxc-angular/binding-linux-x64-musl': 0.0.10
+      '@oxc-angular/binding-win32-arm64-msvc': 0.0.10
+      '@oxc-angular/binding-win32-x64-msvc': 0.0.10
 
   '@oxc-project/runtime@0.110.0': {}
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

When using the `analog()` plugin, the internal Vite plugin from `@analogjs/vite-plugin-angular` can be disabled. This allows another plugin to be provided for Angular compilation, while still using Analog-specific features with Vite.

Below is an example Analog project that uses the [@oxc-angular/vite](https://npmx.dev/package/@oxc-angular/vite) plugin for compilation, and the Analog plugin for the meta-framework.

```ts
/// <reference types="vitest" />

import { defineConfig } from 'vite';
import analog from '@analogjs/platform';
import { angular } from '@oxc-angular/vite';

// https://vitejs.dev/config/
export default defineConfig(({ mode }) => ({
  build: {
    target: ['es2020'],
  },
  resolve: {
    mainFields: ['module'],
  },
  plugins: [
    analog({
      ssr: false,
      static: true,
      prerender: {
        routes: [],
      },
      vite: false,
    }),
    angular()
  ],
}));
```

The experimental OXC-based Angular Compiler has shown significantly faster compilation times, so this enables developers to try it within their existing Analog projects.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdleDBucTRteWtudGpoOWVlNGdsOHVqYjBocWIzbWR6bnF3NDkyMWRjNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/HFe8qjKRQNlLQkbjXM/giphy.gif"/>