### PR TITLE
fix(vite-plugin-angular): normalize paths across plugin & live reload

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -379,9 +379,8 @@ export function angular(options?: PluginOptions): Plugin[] {
             result?.hmrEligible &&
             classNames.get(fileId)
           ) {
-            const relativeFileId = `${relative(
-              process.cwd(),
-              fileId,
+            const relativeFileId = `${normalizePath(
+              relative(process.cwd(), fileId),
             )}@${classNames.get(fileId)}`;
 
             sendHMRComponentUpdate(ctx.server, relativeFileId);
@@ -476,9 +475,8 @@ export function angular(options?: PluginOptions): Plugin[] {
             pendingCompilation = null;
 
             updates.forEach((updateId) => {
-              const impRelativeFileId = `${relative(
-                process.cwd(),
-                updateId,
+              const impRelativeFileId = `${normalizePath(
+                relative(process.cwd(), updateId),
               )}@${classNames.get(updateId)}`;
 
               sendHMRComponentUpdate(ctx.server, impRelativeFileId);

--- a/packages/vite-plugin-angular/src/lib/live-reload-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/live-reload-plugin.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
 import { ServerResponse } from 'node:http';
-import { Connect, Plugin, ViteDevServer } from 'vite';
+import { Connect, normalizePath, Plugin, ViteDevServer } from 'vite';
 
 import { EmitFileResult } from './models.js';
 
@@ -44,7 +44,7 @@ export function liveReloadPlugin({
         }
 
         const [fileId] = decodeURIComponent(componentId).split('@');
-        const resolvedId = resolve(process.cwd(), fileId);
+        const resolvedId = normalizePath(resolve(process.cwd(), fileId));
         const invalidated =
           !!server.moduleGraph.getModuleById(resolvedId)
             ?.lastInvalidationTimestamp && classNames.get(resolvedId);
@@ -86,7 +86,12 @@ export function liveReloadPlugin({
         }
 
         const result = fileEmitter(
-          resolve(process.cwd(), decodeURIComponent(componentId).split('@')[0]),
+          normalizePath(
+            resolve(
+              process.cwd(),
+              decodeURIComponent(componentId).split('@')[0],
+            ),
+          ),
         );
 
         return result?.hmrUpdateCode || '';


### PR DESCRIPTION
## PR Checklist

Node's path.resolve and path.normalize produce backslashes on windows.
Angular updated AOT to use posix paths angular/angular-cli@5ea9ce3 and vite uses posix paths for its module graph.
This wraps the remaining path calls in normalizePath and fixes HMR on windows.

## What is the new behavior?

HMR is now working on windows.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
![it-all-happened-so-fast](https://github.com/user-attachments/assets/83dd2e12-ca5a-4124-8cac-4763ee34b0cc)
