### PR TITLE
fix: support astro v6 using vite environment api

### DIFF
--- a/packages/astro-angular/src/index.ts
+++ b/packages/astro-angular/src/index.ts
@@ -14,7 +14,7 @@ function getRenderer(): AstroRenderer {
   };
 }
 
-function getViteConfiguration(vite?: PluginOptions) {
+function getViteConfiguration(vite?: PluginOptions): ViteUserConfig {
   return {
     esbuild: {
       jsxDev: true,
@@ -48,6 +48,20 @@ function getViteConfiguration(vite?: PluginOptions) {
           }
 
           return;
+        },
+      },
+      {
+        name: 'analogjs-astro-client-ngservermode',
+        configEnvironment(name: string) {
+          if (name === 'client') {
+            return {
+              define: {
+                ngServerMode: 'false',
+              },
+            };
+          }
+
+          return undefined;
         },
       },
     ],


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2112

## What is the new behavior?

During the client build in astro projects, this will set the `ngServerMode` define global to `'false'`. This avoids building an invalid, broken client bundle.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

![Flex seal](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNDluYWQ1YTFvODJjZ3UwbDNxdjJsdHcxbng0aTdjMDlsdXd1bGM3OSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fADf4RUs3hUFvHz18o/giphy.gif)
