### PR TITLE
test(platform): restore frontmatter attribute cache coverage

### DIFF
--- a/packages/platform/src/lib/content-plugin.spec.ts
+++ b/packages/platform/src/lib/content-plugin.spec.ts
@@ -1,11 +1,27 @@
-import { describe, expect } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 
-vi.mock('fs');
+vi.mock('node:fs');
+vi.mock('front-matter', () => ({
+  default: vi.fn((fileContents: string) => ({
+    attributes: {
+      title: 'My First Post',
+      slug: '2022-12-27-my-first-post',
+      description: 'My First Post Description',
+    },
+    body: fileContents,
+    frontmatter:
+      'title: My First Post\nslug: 2022-12-27-my-first-post\ndescription: My First Post Description',
+  })),
+}));
 
 import { contentPlugin } from './content-plugin';
 
 describe('content plugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   const [plugin] = contentPlugin({ highlighter: 'prism' });
 
   // In Vite 8+ the transform hook uses the filtered-transform shape:
@@ -31,7 +47,7 @@ describe('content plugin', () => {
     ).toBe(true);
   });
 
-  it.skip('should cache parsed attributes if the code is the same', async () => {
+  it('should cache parsed attributes if the code is the same', async () => {
     // Arrange
     const code =
       '---\n' +
@@ -42,7 +58,9 @@ describe('content plugin', () => {
       '\n' +
       'Hello World\n';
     const id = '/src/content/post.md?analog-content-list=true';
-    const readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockReturnValue(code);
+    const readFileSyncSpy = vi
+      .spyOn(fs, 'readFileSync')
+      .mockReturnValue(code as any);
     const result = {
       code: 'export default {"title":"My First Post","slug":"2022-12-27-my-first-post","description":"My First Post Description"}',
       moduleSideEffects: false,


### PR DESCRIPTION
## Affected scope

- Primary scope: platform
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

This PR restores active coverage for the content frontmatter attribute cache path in `contentPlugin`.

It makes the cache test deterministic by mocking `front-matter`, clearing Vitest mocks before each run, and unskipping the assertion that repeated transforms of the same `?analog-content-list=true` module reuse cached attributes instead of reading and parsing the file again.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

Ran:
- `pnpm nx test platform`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No