### PR TITLE
fix(nx-plugin): remove full path to main.ts for Nx projects

### DIFF
--- a/packages/nx-plugin/src/generators/init/lib/update-index-html.ts
+++ b/packages/nx-plugin/src/generators/init/lib/update-index-html.ts
@@ -13,7 +13,7 @@ export function updateIndex(tree: Tree, schema: SetupAnalogGeneratorSchema) {
     const indexContents = tree.read(indexPath, 'utf-8');
     let updatedIndex = indexContents.replace(
       '</body>',
-      `<script type="module" src="${projectConfig.root && projectConfig.root !== '.' ? `/${projectConfig.root}` : ''}/src/main.ts"></script></body>`,
+      `<script type="module" src="/src/main.ts"></script></body>`,
     );
     updatedIndex = updatedIndex.replace(`"favicon.ico"`, `"/favicon.ico"`);
     tree.write(indexPath, updatedIndex);

--- a/packages/nx-plugin/src/generators/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/generators/preset/__snapshots__/generator.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`preset generator > should match index.html 1`] = `
   </head>
   <body>
     <app-root></app-root>
-    <script type="module" src="/my-app/src/main.ts"></script>
+    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>
 "


### PR DESCRIPTION
## PR Checklist

Fix the `index.html` script src to use a relative `/src/main.ts` path instead of prepending the full Nx project root.

Closes #

## Affected scope

- Primary scope: nx-plugin
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

The `updateIndex` generator no longer prepends the project root path to the `main.ts` script src in `index.html`. Previously, non-root Nx projects would get a src like `/apps/my-app/src/main.ts`, which is incorrect for Vite's dev server. The src is now always `/src/main.ts`.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
