### PR TITLE
fix(nx-plugin): restore schematics configuration

### DIFF
--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -33,5 +33,30 @@
       "description": "Migrate and configure an Angular SPA to use Analog.",
       "aliases": ["migrate"]
     }
+  },
+  "schematics": {
+    "application": {
+      "factory": "./src/generators/app/compat",
+      "schema": "./src/generators/app/schema.json",
+      "description": "Generates an Analog application",
+      "aliases": ["app"]
+    },
+    "page": {
+      "factory": "./src/generators/page/generator#analogPageGeneratorSchematic",
+      "schema": "./src/generators/page/schema.json",
+      "description": "Creates a new Analog page in the given or default project.",
+      "aliases": ["p"]
+    },
+    "setup-vitest": {
+      "factory": "./src/generators/setup-vitest/compat",
+      "schema": "./src/generators/setup-vitest/schema.json",
+      "description": "Setup the Vitest configuration."
+    },
+    "init": {
+      "factory": "./src/generators/init/compat",
+      "schema": "./src/generators/init/schema.json",
+      "description": "Migrate and configure an Angular SPA to use Analog.",
+      "aliases": ["migrate"]
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

Restore the `schematics` configuration block in `generators.json` for backwards compatibility with Angular CLI `ng generate` commands.

Closes #

## Affected scope

- Primary scope: nx-plugin
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

- Re-adds the `schematics` section to `packages/nx-plugin/generators.json` with compat factory entries for `application`, `page`, `setup-vitest`, and `init` generators. This restores support for Angular CLI schematic invocations (`ng generate`) that was previously removed.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
