### PR TITLE
fix(vite-plugin-angular): skip esm transform with Rolldown for Vitest

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -34,18 +34,7 @@ export function angularVitestPlugin(): Plugin {
         (/fesm2022/.test(id) && _code.includes('async ')) ||
         _code.includes('@angular/cdk')
       ) {
-        if (vite.rolldownVersion) {
-          const { code, map } = await vite.transformWithOxc(_code, id, {
-            lang: 'js',
-            target: 'es2016',
-            sourcemap: true,
-          });
-
-          return {
-            code,
-            map,
-          };
-        } else {
+        if (!vite.rolldownVersion) {
           const { code, map } = await vite.transformWithEsbuild(_code, id, {
             loader: 'js',
             format: 'esm',


### PR DESCRIPTION
## PR Checklist

Skip the ESM downlevel transform when running Vitest with Rolldown, since Rolldown already handles ES2022+ syntax natively.

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

- When Rolldown is detected (`vite.rolldownVersion` is truthy), the Vitest Angular plugin now skips the `transform` hook entirely instead of downleveling via `transformWithOxc` to `es2016`.
- The `esbuild`-based transform remains for non-Rolldown environments (Vite with esbuild).
- This avoids unnecessary/broken ESM transforms since Rolldown natively supports ES2022 async syntax in Angular FESM bundles.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The previous `transformWithOxc` call was targeting `es2016` which could produce incorrect output or was unnecessary given Rolldown's native ES2022+ support.

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlY2NnajRqZjd6eWhqaGRzdG5lbXVmOHRmb2VqajY0d3g2OW4wODUxZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/UvBxwmRFCPGWhdj7LN/giphy.gif"/>