### PR TITLE
fix(nx-plugin): restore Angular schematic compatibility with named exports

### DIFF
--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -33,5 +33,30 @@
       "description": "Migrate and configure an Angular SPA to use Analog.",
       "aliases": ["migrate"]
     }
+  },
+  "schematics": {
+    "application": {
+      "factory": "./src/generators/app/compat#applicationSchematic",
+      "schema": "./src/generators/app/schema.json",
+      "description": "Generates an Analog application",
+      "aliases": ["app"]
+    },
+    "page": {
+      "factory": "./src/generators/page/compat#pageSchematic",
+      "schema": "./src/generators/page/schema.json",
+      "description": "Creates a new Analog page in the given or default project.",
+      "aliases": ["p"]
+    },
+    "setup-vitest": {
+      "factory": "./src/generators/setup-vitest/compat#setupVitestSchematic",
+      "schema": "./src/generators/setup-vitest/schema.json",
+      "description": "Setup the Vitest configuration."
+    },
+    "init": {
+      "factory": "./src/generators/init/compat#initSchematic",
+      "schema": "./src/generators/init/schema.json",
+      "description": "Migrate and configure an Angular SPA to use Analog.",
+      "aliases": ["migrate"]
+    }
   }
 }

--- a/packages/nx-plugin/src/generators/app/compat.ts
+++ b/packages/nx-plugin/src/generators/app/compat.ts
@@ -1,7 +1,12 @@
 import { convertNxGenerator } from '@nx/devkit';
 import generator from './generator';
 
-const compat: ReturnType<typeof convertNxGenerator> = convertNxGenerator(
-  generator,
-) as ReturnType<typeof convertNxGenerator>;
-export default compat;
+/**
+ * Angular CLI schematic wrapper for the Analog application generator.
+ * Referenced by `generators.json#schematics.application.factory` so that
+ * `ng generate @analogjs/platform:application` resolves through the
+ * Angular schematics engine (which uses named exports, not default).
+ */
+export const applicationSchematic: ReturnType<typeof convertNxGenerator> =
+  convertNxGenerator(generator) as ReturnType<typeof convertNxGenerator>;
+export default applicationSchematic;

--- a/packages/nx-plugin/src/generators/init/compat.ts
+++ b/packages/nx-plugin/src/generators/init/compat.ts
@@ -2,7 +2,14 @@ import { convertNxGenerator } from '@nx/devkit';
 
 import setupAnalogGenerator from './generator';
 
-const compat: ReturnType<typeof convertNxGenerator> = convertNxGenerator(
-  setupAnalogGenerator,
-) as ReturnType<typeof convertNxGenerator>;
-export default compat;
+/**
+ * Angular CLI schematic wrapper for the Analog init/migrate generator.
+ * Referenced by `generators.json#schematics.init.factory` so that
+ * `ng generate @analogjs/platform:migrate` resolves through the
+ * Angular schematics engine.
+ */
+export const initSchematic: ReturnType<typeof convertNxGenerator> =
+  convertNxGenerator(setupAnalogGenerator) as ReturnType<
+    typeof convertNxGenerator
+  >;
+export default initSchematic;

--- a/packages/nx-plugin/src/generators/page/compat.ts
+++ b/packages/nx-plugin/src/generators/page/compat.ts
@@ -1,0 +1,15 @@
+import { convertNxGenerator } from '@nx/devkit';
+
+import analogPageGenerator from './generator';
+
+/**
+ * Angular CLI schematic wrapper for the Analog page generator.
+ * Referenced by `generators.json#schematics.page.factory` so that
+ * `ng generate @analogjs/platform:page` resolves through the
+ * Angular schematics engine.
+ */
+export const pageSchematic: ReturnType<typeof convertNxGenerator> =
+  convertNxGenerator(analogPageGenerator) as ReturnType<
+    typeof convertNxGenerator
+  >;
+export default pageSchematic;

--- a/packages/nx-plugin/src/generators/schematics.spec.ts
+++ b/packages/nx-plugin/src/generators/schematics.spec.ts
@@ -1,0 +1,65 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import { Tree } from '@angular-devkit/schematics';
+import * as path from 'path';
+
+// Must use the built generators.json because the schematic runner resolves
+// the compiled CommonJS output rather than the TypeScript sources.
+const collectionPath = path.join(
+  __dirname,
+  '../../../../node_modules/@analogjs/platform/src/lib/nx-plugin/generators.json',
+);
+
+describe('platform schematics', () => {
+  let runner: SchematicTestRunner;
+  let tree: UnitTestTree;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('schematics', collectionPath);
+    tree = new UnitTestTree(Tree.empty());
+  });
+
+  describe('page', () => {
+    beforeEach(() => {
+      tree.create(
+        '/workspace.json',
+        JSON.stringify({
+          version: 2,
+          projects: {
+            'test-app': {
+              root: 'test-app',
+              sourceRoot: 'test-app/src',
+              projectType: 'application',
+            },
+          },
+        }),
+      );
+    });
+
+    it('should create a page file', async () => {
+      const resultTree = await runner.runSchematic(
+        'page',
+        { pathname: 'home', project: 'test-app' },
+        tree,
+      );
+
+      expect(
+        resultTree.exists('/test-app/src/app/pages/home.page.ts'),
+      ).toBeTruthy();
+    });
+
+    it('should create a page with subfolder', async () => {
+      const resultTree = await runner.runSchematic(
+        'page',
+        { pathname: 'blog/post', project: 'test-app' },
+        tree,
+      );
+
+      expect(
+        resultTree.exists('/test-app/src/app/pages/blog/post.page.ts'),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/packages/nx-plugin/src/generators/setup-vitest/compat.ts
+++ b/packages/nx-plugin/src/generators/setup-vitest/compat.ts
@@ -2,7 +2,14 @@ import { convertNxGenerator } from '@nx/devkit';
 
 import setupVitestGenerator from './generator';
 
-const compat: ReturnType<typeof convertNxGenerator> = convertNxGenerator(
-  setupVitestGenerator,
-) as ReturnType<typeof convertNxGenerator>;
-export default compat;
+/**
+ * Angular CLI schematic wrapper for the Vitest setup generator.
+ * Referenced by `generators.json#schematics.setup-vitest.factory` so that
+ * `ng generate @analogjs/platform:setup-vitest` resolves through the
+ * Angular schematics engine.
+ */
+export const setupVitestSchematic: ReturnType<typeof convertNxGenerator> =
+  convertNxGenerator(setupVitestGenerator) as ReturnType<
+    typeof convertNxGenerator
+  >;
+export default setupVitestSchematic;

--- a/packages/nx-plugin/vite.config.lib.ts
+++ b/packages/nx-plugin/vite.config.lib.ts
@@ -98,6 +98,10 @@ export default defineConfig({
           pkgDir,
           'src/generators/page/generator.ts',
         ),
+        'src/generators/page/compat': resolve(
+          pkgDir,
+          'src/generators/page/compat.ts',
+        ),
         'src/generators/init/generator': resolve(
           pkgDir,
           'src/generators/init/generator.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,8 +598,8 @@ importers:
   packages/astro-angular:
     dependencies:
       '@analogjs/vite-plugin-angular':
-        specifier: ^3.0.0-alpha.14
-        version: 3.0.0-alpha.14(@angular-devkit/build-angular@21.2.3(0e669fa03dcf3bc0f2262460e97290aa))(@angular/build@21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2))
+        specifier: ^3.0.0-alpha.15
+        version: 3.0.0-alpha.15(@angular-devkit/build-angular@21.2.3(0e669fa03dcf3bc0f2262460e97290aa))(@angular/build@21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2))
       '@angular/animations':
         specifier: '>=20.0.0'
         version: 21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.16.1))
@@ -727,11 +727,11 @@ importers:
   packages/platform:
     dependencies:
       '@analogjs/vite-plugin-angular':
-        specifier: ^3.0.0-alpha.14
-        version: 3.0.0-alpha.14(@angular-devkit/build-angular@21.2.3(0e669fa03dcf3bc0f2262460e97290aa))(@angular/build@21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2))
+        specifier: ^3.0.0-alpha.15
+        version: 3.0.0-alpha.15(@angular-devkit/build-angular@21.2.3(0e669fa03dcf3bc0f2262460e97290aa))(@angular/build@21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2))
       '@analogjs/vite-plugin-nitro':
-        specifier: ^3.0.0-alpha.14
-        version: 3.0.0-alpha.14(chokidar@5.0.0)(dotenv@16.4.7)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
+        specifier: ^3.0.0-alpha.15
+        version: 3.0.0-alpha.15(chokidar@5.0.0)(dotenv@16.4.7)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
       '@nx/angular':
         specifier: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0 || ^22
         version: 22.6.1(3d962bc1922fba0fca0cb5e3b6e560fe)
@@ -781,8 +781,8 @@ importers:
   packages/router:
     dependencies:
       '@analogjs/content':
-        specifier: ^3.0.0-alpha.14
-        version: 3.0.0-alpha.14(6a659000af8ba4ae3a203940aef75a3c)
+        specifier: ^3.0.0-alpha.15
+        version: 3.0.0-alpha.15(6a659000af8ba4ae3a203940aef75a3c)
       '@angular/core':
         specifier: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
         version: 21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.16.1)
@@ -806,8 +806,8 @@ importers:
         version: 2.8.1
     devDependencies:
       '@analogjs/vite-plugin-angular':
-        specifier: ^3.0.0-alpha.14
-        version: 3.0.0-alpha.14(@angular-devkit/build-angular@21.2.3(0e669fa03dcf3bc0f2262460e97290aa))(@angular/build@21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2))
+        specifier: ^3.0.0-alpha.15
+        version: 3.0.0-alpha.15(@angular-devkit/build-angular@21.2.3(0e669fa03dcf3bc0f2262460e97290aa))(@angular/build@21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2))
 
   packages/storybook-angular:
     dependencies:
@@ -1047,8 +1047,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@analogjs/content@3.0.0-alpha.14':
-    resolution: {integrity: sha512-HXf+RGXmVIsjXoZkDULcuhJg3qGLIyzW+HNpqJWvBjLRFcv8PgqD/HfE7PpadcpnFOVom+pvhFQ4aaGp/8Mr+A==}
+  '@analogjs/content@3.0.0-alpha.15':
+    resolution: {integrity: sha512-GMRODiBJmjG3+laVJ/PePL6GDXzasLtl1W6Qkcwp2uzG0mplMwhtLsM+xX7A/GmJRmEspP7vZLsdazTko0ZpPw==}
     peerDependencies:
       '@angular/common': ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
       '@angular/core': ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
@@ -1092,8 +1092,8 @@ packages:
       '@angular/build':
         optional: true
 
-  '@analogjs/vite-plugin-angular@3.0.0-alpha.14':
-    resolution: {integrity: sha512-nrczljwU5R5oalI+1e5k6I505XrAUHY9+/jfIiKfqjxEh80NXAILfiKHd/+AQiKhvs2ngDpgaNC+VNjjvpyDMA==}
+  '@analogjs/vite-plugin-angular@3.0.0-alpha.15':
+    resolution: {integrity: sha512-//K0jaswIRSkSfnFyVeXqaaSpCAcZZRq/5h7/CB00I0ze/j/97A6bJwRixGlevBWexe3f+hrI39NeWTOQlY8dg==}
     peerDependencies:
       '@angular-devkit/build-angular': ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
       '@angular/build': ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
@@ -1103,8 +1103,8 @@ packages:
       '@angular/build':
         optional: true
 
-  '@analogjs/vite-plugin-nitro@3.0.0-alpha.14':
-    resolution: {integrity: sha512-vjWS1ABKisblz3TGXt6fH4uYZP7G204GO5RBO7J/YHYe0T6i2CYq06M/42hDNORcz/KO4WZzCI5EqBgtEi3OPw==}
+  '@analogjs/vite-plugin-nitro@3.0.0-alpha.15':
+    resolution: {integrity: sha512-hQy10ukLJ/ldGkEaNAvqXq5OWSr2Ebr3h4xilQsO1+osjAAwDB8GKtL27RjglKlwcuZHBAoIXXiXkJSC6XD50g==}
 
   '@angular-devkit/architect@0.2102.3':
     resolution: {integrity: sha512-G4wSWUbtWp1WCKw5GMRqHH8g4m5RBpIyzt8n8IX5Pm6iYe/rwCBSKL3ktEkk7AYMwjtonkRlDtAK1GScFsf1Sg==}
@@ -15698,7 +15698,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@analogjs/content@3.0.0-alpha.14(6a659000af8ba4ae3a203940aef75a3c)':
+  '@analogjs/content@3.0.0-alpha.15(6a659000af8ba4ae3a203940aef75a3c)':
     dependencies:
       '@angular/common': 21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2)
       '@angular/core': 21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.16.1)
@@ -15728,7 +15728,7 @@ snapshots:
       '@angular-devkit/build-angular': 21.2.3(0e669fa03dcf3bc0f2262460e97290aa)
       '@angular/build': 21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2)
 
-  '@analogjs/vite-plugin-angular@3.0.0-alpha.14(@angular-devkit/build-angular@21.2.3(0e669fa03dcf3bc0f2262460e97290aa))(@angular/build@21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2))':
+  '@analogjs/vite-plugin-angular@3.0.0-alpha.15(@angular-devkit/build-angular@21.2.3(0e669fa03dcf3bc0f2262460e97290aa))(@angular/build@21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2))':
     dependencies:
       oxc-parser: 0.121.0
       oxc-resolver: 11.19.1
@@ -15738,7 +15738,7 @@ snapshots:
       '@angular-devkit/build-angular': 21.2.3(0e669fa03dcf3bc0f2262460e97290aa)
       '@angular/build': 21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2)
 
-  '@analogjs/vite-plugin-nitro@3.0.0-alpha.14(chokidar@5.0.0)(dotenv@16.4.7)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))':
+  '@analogjs/vite-plugin-nitro@3.0.0-alpha.15(chokidar@5.0.0)(dotenv@16.4.7)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       defu: 6.1.4
       nitro: 3.0.260311-beta(chokidar@5.0.0)(dotenv@16.4.7)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))


### PR DESCRIPTION
## PR Checklist

Closes #2168

## Affected scope

- Primary scope: nx-plugin
- Secondary scopes: platform

## Recommended merge strategy for maintainer

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

- Adds a `schematics` section to `generators.json` mapping Angular CLI schematic entries (`application`, `page`, `setup-vitest`, `init`) to `convertNxGenerator` compat wrappers
- Fixes a pre-existing bug where all compat wrappers used `export default` which compiled to `module.exports = fn` in CJS — the Angular schematics engine resolves factories via `require(module)[name || 'default']`, so `require(module)['default']` returned `undefined`. Fixed by adding named exports and using `#name` syntax in factory paths
- Adds the missing `page` generator compat wrapper (`compat.ts`) and its build entry point
- Adds `SchematicTestRunner`-based tests verifying the `page` schematic works through the Angular CLI compat layer
- Adds inline JSDoc to all compat wrappers explaining why named exports are required

### Overlapping work

`e74fa682` on beta (`fix(nx-plugin): restore schematics configuration #2167`) added a `schematics` section to `generators.json` but:
- Used `export default` (broken with the schematics engine as described above)
- Referenced `page` via `generator#analogPageGeneratorSchematic` — a named export that doesn't exist
- This PR supersedes that fix with working named exports and the `#` factory syntax

## Test plan

- [x] `nx build platform` — passes (includes nx-plugin build)
- [x] `nx test nx-plugin` — 6 files, 57 tests passed (includes new schematic tests)
- [x] Verified `SchematicTestRunner` resolves `page` and `init` schematics through the compat layer
- [x] Verified built output contains `exports.pageSchematic`, `exports.applicationSchematic`, etc.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- The `preset` generator is intentionally excluded from the `schematics` section — it is hidden and Nx-only (`create-nx-workspace`)
- The `platform/package.json` already points both `generators` and `schematics` to the same `generators.json`, so no metadata changes are needed — both Nx and Angular CLI read their respective sections from the same file