### PR TITLE
fix(astro-angular): move vite-plugin-angular to peerDependencies

### DIFF
--- a/packages/astro-angular/package.json
+++ b/packages/astro-angular/package.json
@@ -31,10 +31,8 @@
     "type": "github",
     "url": "https://github.com/sponsors/brandonroberts"
   },
-  "dependencies": {
-    "@analogjs/vite-plugin-angular": "^3.0.0-alpha.18"
-  },
   "peerDependencies": {
+    "@analogjs/vite-plugin-angular": "^3.0.0-alpha.0",
     "@angular/build": ">=20.0.0",
     "@angular/animations": ">=20.0.0",
     "@angular/common": ">=20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,7 +655,7 @@ importers:
   packages/astro-angular:
     dependencies:
       '@analogjs/vite-plugin-angular':
-        specifier: ^3.0.0-alpha.18
+        specifier: ^3.0.0-alpha.0
         version: 3.0.0-alpha.18(@angular-devkit/build-angular@21.2.3(0e669fa03dcf3bc0f2262460e97290aa))(@angular/build@21.2.3(2ff5cda3dc109b46b3a06057c3cebdd2))
       '@angular/animations':
         specifier: '>=20.0.0'

--- a/release.config.ts
+++ b/release.config.ts
@@ -16,7 +16,6 @@ const versionFiles = [
 ];
 
 const replacementFiles = [
-  'packages/astro-angular/package.json',
   'packages/create-analog/template-angular-v17/package.json',
   'packages/create-analog/template-angular-v18/package.json',
   'packages/create-analog/template-angular-v19/package.json',


### PR DESCRIPTION
## Summary
- Moves `@analogjs/vite-plugin-angular` from `dependencies` to `peerDependencies` in `astro-angular` with a broad range (`^3.0.0-alpha.0`)
- Removes `packages/astro-angular/package.json` from `replacementFiles` in `release.config.ts` since the version no longer needs per-release bumps
- Eliminates `pnpm-lock.yaml` conflicts on long-lived branches caused by semantic-release bumping the hard dep on every release

## Test plan
- [ ] Verify `pnpm i` resolves correctly with the peer dep
- [ ] Verify `nx build astro-angular` succeeds
- [ ] Confirm `astro-angular` is no longer in `replacementFiles` regex targets