### PR TITLE
fix(content): resolve content files by bare slug lookup

### DIFF
--- a/packages/content/resources/src/content-file-resource.spec.ts
+++ b/packages/content/resources/src/content-file-resource.spec.ts
@@ -124,6 +124,31 @@ slug: 'docs'
     });
   });
 
+  it('finds a file by bare slug without path prefix', async () => {
+    const contentFiles = {
+      '/src/content/blog/my-post.md': () =>
+        Promise.resolve(`---
+slug: 'my-post'
+---
+# My Post`),
+    };
+    setup({
+      routeParams: { slug: 'my-post' },
+      contentFiles,
+    });
+
+    const result = TestBed.inject(TEST_RESOURCE_TOKEN);
+    await settleResource(result);
+
+    expect(result.value()).toEqual({
+      filename: '/src/content/blog/my-post',
+      slug: 'my-post',
+      attributes: { slug: 'my-post' },
+      content: '# My Post',
+      toc: [{ id: 'my-post', level: 1, text: 'My Post' }],
+    });
+  });
+
   it('resolves nested paths that include a content segment name', async () => {
     const contentFiles = {
       '/src/content/docs/reference/api/nested/content.md': () =>

--- a/packages/content/resources/src/content-file-resource.ts
+++ b/packages/content/resources/src/content-file-resource.ts
@@ -28,6 +28,7 @@ async function getContentFile<
   // Normalize file keys so both "/src/content/..." and "/<project>/src/content/..." resolve.
   // This mirrors normalization used elsewhere in the content pipeline.
   const normalizedFiles: Record<string, () => Promise<string>> = {};
+  const stemToKey: Record<string, string> = {};
   for (const [key, resolver] of Object.entries(contentFiles)) {
     const normalizedKey = key
       // replace any prefix up to the content directory with /src/content
@@ -36,9 +37,17 @@ async function getContentFile<
       // normalize duplicate slashes
       .replace(/\/{2,}/g, '/');
     normalizedFiles[normalizedKey] = resolver;
+    // Index by bare filename stem so slug-only lookups work
+    const stem = normalizedKey
+      .split('/')
+      .pop()
+      ?.replace(/\.[^.]+$/, '');
+    if (stem && !stemToKey[stem]) {
+      stemToKey[stem] = normalizedKey;
+    }
   }
 
-  // Try direct file first, then directory index variants
+  // Try direct file first, then directory index variants, then bare slug via stem
   const base = `/src/content/${slug}`.replace(/\/{2,}/g, '/');
   const candidates = [
     `${base}.md`,
@@ -47,7 +56,8 @@ async function getContentFile<
     `${base}/index.agx`,
   ];
 
-  const matchKey = candidates.find((k) => k in normalizedFiles);
+  const matchKey =
+    candidates.find((k) => k in normalizedFiles) ?? stemToKey[slug];
   const contentFile = matchKey ? normalizedFiles[matchKey] : undefined;
 
   if (!contentFile) {


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## Affected scope

<!-- List the primary scope from CONTRIBUTING.md and any closely related secondary scopes. -->

- Primary scope:
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

<!-- Squash merge is highly preferred. -->
<!-- Recommend a non-squash merge only if you can justify why the PR should bypass focused changes per package. -->

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

<!-- If you recommend a non-squash merge, briefly explain why the commit boundaries matter and why this PR should bypass focused changes per package. -->

## What is the new behavior?

Add a stem-based index during path normalization so contentFileResource can find files when given just a slug (e.g. "my-post") without requiring the full /src/content/<slug>.md path.

## Test plan

<!-- List the commands you ran and any manual verification you performed. -->

- [ ] `nx format:check`
- [ ] `pnpm build`
- [x] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
