### PR TITLE
chore: update vite-tsconfig-paths to version ^7.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "vite": "^8.0.2",
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-inspect": "12.0.0-beta.1",
-    "vite-tsconfig-paths": "github:benpsnyder/vite-tsconfig-paths#feat/oxc-upgrade",
+    "vite-tsconfig-paths": "^7.0.0-alpha.1",
     "vitefu": "^1.1.2",
     "vitest": "4.1.1",
     "xmlbuilder2": "^4.0.3"

--- a/packages/create-analog/template-angular-v18/package.json
+++ b/packages/create-analog/template-angular-v18/package.json
@@ -46,7 +46,7 @@
     "jsdom": "^22.0.0",
     "typescript": "6.0.2",
     "vite": "^6.0.0",
-    "vite-tsconfig-paths": "^4.2.0",
+    "vite-tsconfig-paths": "^7.0.0-alpha.1",
     "vitest": "^1.3.1"
   }
 }

--- a/packages/create-analog/template-angular-v19/package.json
+++ b/packages/create-analog/template-angular-v19/package.json
@@ -47,7 +47,7 @@
     "jsdom": "^22.0.0",
     "typescript": "6.0.2",
     "vite": "^6.0.0",
-    "vite-tsconfig-paths": "^4.2.0",
+    "vite-tsconfig-paths": "^7.0.0-alpha.1",
     "vitest": "^3.0.0"
   }
 }

--- a/packages/create-analog/template-angular-v20/package.json
+++ b/packages/create-analog/template-angular-v20/package.json
@@ -47,7 +47,7 @@
     "jsdom": "^22.0.0",
     "typescript": "6.0.2",
     "vite": "^7.0.0",
-    "vite-tsconfig-paths": "^4.2.0",
+    "vite-tsconfig-paths": "^7.0.0-alpha.1",
     "vitest": "^4.0.0"
   },
   "overrides": {

--- a/packages/create-analog/template-blog/package.json
+++ b/packages/create-analog/template-blog/package.json
@@ -44,7 +44,7 @@
     "jsdom": "^22.0.0",
     "typescript": "6.0.2",
     "vite": "^8.0.0",
-    "vite-tsconfig-paths": "^4.2.0",
+    "vite-tsconfig-paths": "^7.0.0-alpha.1",
     "vitest": "^4.0.0"
   },
   "overrides": {

--- a/packages/create-analog/template-latest/package.json
+++ b/packages/create-analog/template-latest/package.json
@@ -45,7 +45,7 @@
     "jsdom": "^22.0.0",
     "typescript": "6.0.2",
     "vite": "^8.0.0",
-    "vite-tsconfig-paths": "^4.2.0",
+    "vite-tsconfig-paths": "^7.0.0-alpha.1",
     "vitest": "^4.0.0"
   },
   "overrides": {

--- a/packages/create-analog/template-minimal/package.json
+++ b/packages/create-analog/template-minimal/package.json
@@ -45,7 +45,7 @@
     "jsdom": "^22.0.0",
     "typescript": "6.0.2",
     "vite": "^8.0.0",
-    "vite-tsconfig-paths": "^4.2.0",
+    "vite-tsconfig-paths": "^7.0.0-alpha.1",
     "vitest": "^4.0.0"
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,8 +487,8 @@ importers:
         specifier: 12.0.0-beta.1
         version: 12.0.0-beta.1(typescript@6.0.2)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(ws@8.20.0)
       vite-tsconfig-paths:
-        specifier: github:benpsnyder/vite-tsconfig-paths#feat/oxc-upgrade
-        version: https://codeload.github.com/benpsnyder/vite-tsconfig-paths/tar.gz/28d26208f2e5c880b0a33ea27b0a24b64e98f0ba(typescript@6.0.2)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
+        specifier: ^7.0.0-alpha.1
+        version: 7.0.0-alpha.1(typescript@6.0.2)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
       vitefu:
         specifier: ^1.1.2
         version: 1.1.2(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
@@ -14985,9 +14985,8 @@ packages:
       '@nuxt/kit':
         optional: true
 
-  vite-tsconfig-paths@https://codeload.github.com/benpsnyder/vite-tsconfig-paths/tar.gz/28d26208f2e5c880b0a33ea27b0a24b64e98f0ba:
-    resolution: {tarball: https://codeload.github.com/benpsnyder/vite-tsconfig-paths/tar.gz/28d26208f2e5c880b0a33ea27b0a24b64e98f0ba}
-    version: 7.0.0-alpha.1
+  vite-tsconfig-paths@7.0.0-alpha.1:
+    resolution: {integrity: sha512-R2xUKqgU3lETsbx66sOoVj6/2hf9J9Aizavs03obMY5TxC99UbF1tM4bSfn1KZ8HxtOEaK3gdm/CEutS3yBvog==}
     engines: {node: '>=18'}
     peerDependencies:
       vite: '>=5.0.0'
@@ -33279,7 +33278,7 @@ snapshots:
       - typescript
       - ws
 
-  vite-tsconfig-paths@https://codeload.github.com/benpsnyder/vite-tsconfig-paths/tar.gz/28d26208f2e5c880b0a33ea27b0a24b64e98f0ba(typescript@6.0.2)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)):
+  vite-tsconfig-paths@7.0.0-alpha.1(typescript@6.0.2)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3
       oxc-resolver: 11.19.1


### PR DESCRIPTION
## PR Checklist

Closes #2119

## Affected scope

- Primary scope: `workspace root`

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Replaces the GitHub fork reference (`benpsnyder/vite-tsconfig-paths#feat/oxc-upgrade`) with the published npm alpha release (`^7.0.0-alpha.1`) for `vite-tsconfig-paths` across the workspace root and all `create-analog` starter templates (`template-angular-v18`, `template-angular-v19`, `template-angular-v20`, `template-blog`, `template-latest`, `template-minimal`).

The v7 alpha uses `oxc-resolver` under the hood (replacing the previous `tsconfck` resolver), aligning with the Rolldown/OXC toolchain direction on `alpha`.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [x] Manual verification — `pnpm i` resolves correctly against the published npm registry tarball

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This follows up on the fork-based upgrade in #2119 by switching to the official npm pre-release now that it has been published. Starter templates previously pinned to `^4.2.0` are bumped directly to `^7.0.0-alpha.1` since they target Vite 6–8.