### PR TITLE
fix(vitest-angular): fix imports for snapshot serializers

### DIFF
--- a/packages/vitest-angular/setup-serializers.ts
+++ b/packages/vitest-angular/setup-serializers.ts
@@ -1,7 +1,7 @@
 import {
   createHtmlCommentSnapshotSerializer,
   createNoNgAttributesSnapshotSerializer,
-} from './snapshot-serializers';
+} from './snapshot-serializers.js';
 
 const env = globalThis as any;
 

--- a/packages/vitest-angular/setup-snapshots.ts
+++ b/packages/vitest-angular/setup-snapshots.ts
@@ -1,4 +1,4 @@
-import { createAngularFixtureSnapshotSerializer } from './snapshot-serializers';
+import { createAngularFixtureSnapshotSerializer } from './snapshot-serializers.js';
 
 const env = globalThis as any;
 

--- a/packages/vitest-angular/snapshot-serializers.ts
+++ b/packages/vitest-angular/snapshot-serializers.ts
@@ -2,4 +2,4 @@ export {
   createNoNgAttributesSnapshotSerializer,
   createAngularFixtureSnapshotSerializer,
   createHtmlCommentSnapshotSerializer,
-} from './src/lib/snapshot-serializers';
+} from './src/lib/snapshot-serializers/index.js';

--- a/packages/vitest-angular/src/lib/snapshot-serializers/index.ts
+++ b/packages/vitest-angular/src/lib/snapshot-serializers/index.ts
@@ -1,3 +1,3 @@
-export { createAngularFixtureSnapshotSerializer } from './angular-fixture';
-export { createHtmlCommentSnapshotSerializer } from './html-comment';
-export { createNoNgAttributesSnapshotSerializer } from './no-ng-attributes';
+export { createAngularFixtureSnapshotSerializer } from './angular-fixture.js';
+export { createHtmlCommentSnapshotSerializer } from './html-comment.js';
+export { createNoNgAttributesSnapshotSerializer } from './no-ng-attributes.js';


### PR DESCRIPTION
## PR Checklist

Closes #

## Affected scope

- Primary scope: vitest-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

- All relative imports in `packages/vitest-angular` snapshot serializer files now include explicit `.js` extensions, ensuring compatibility with ESM module resolution (e.g., Node `--experimental-vm-modules` / Vitest ESM mode).

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a straightforward import-path fix — adding `.js` extensions to four files so that snapshot serializer setup modules resolve correctly under ESM.
