### PR TITLE
refactor(nx-plugin): remove standalone true from page templates

### DIFF
--- a/packages/nx-plugin/src/generators/page/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/generators/page/__snapshots__/generator.spec.ts.snap
@@ -4,7 +4,6 @@ exports[`analog-page generator > should create analog page correctly > page 1`] 
 "import { Component } from '@angular/core';
 
 @Component({
-  standalone: true,
   imports: [],
   template: \` <p>home page works!!</p> \`,
 })
@@ -21,7 +20,6 @@ export const routeMeta: RouteMeta = {
 };
 
 @Component({
-  standalone: true,
   imports: [],
   template: \` <p>home page works!!</p> \`,
 })
@@ -43,7 +41,6 @@ exports[`analog-page generator > should create analog page with subfolder correc
 "import { Component } from '@angular/core';
 
 @Component({
-  standalone: true,
   imports: [],
   template: \` <p>post page works!!</p> \`,
 })
@@ -55,7 +52,6 @@ exports[`analog-page generator > should create analog page with subfolder correc
 "import { Component } from '@angular/core';
 
 @Component({
-  standalone: true,
   imports: [],
   template: \` <p>products page works!!</p> \`,
 })
@@ -67,7 +63,6 @@ exports[`analog-page generator > should create analog page with subfolder correc
 "import { Component } from '@angular/core';
 
 @Component({
-  standalone: true,
   imports: [],
   template: \` <p>home page works!!</p> \`,
 })
@@ -79,7 +74,6 @@ exports[`analog-page generator > should create analog page with subfolder correc
 "import { Component } from '@angular/core';
 
 @Component({
-  standalone: true,
   imports: [],
   template: \` <p>productsProductId page works!!</p> \`,
 })
@@ -91,7 +85,6 @@ exports[`analog-page generator > should create analog page with subfolder correc
 "import { Component } from '@angular/core';
 
 @Component({
-  standalone: true,
   imports: [],
   template: \` <p>blog page works!!</p> \`,
 })

--- a/packages/nx-plugin/src/generators/page/files/__fileName__.page.ts__template__
+++ b/packages/nx-plugin/src/generators/page/files/__fileName__.page.ts__template__
@@ -8,7 +8,6 @@ export const routeMeta: RouteMeta = {
 };
 <% } %>
 @Component({
-  standalone: true,
   imports: [],
   template: `
      <p><%= propertyName %> page works!!</p>


### PR DESCRIPTION
## PR Checklist

Closes analogjs/analog#2076

## Affected scope

- Primary scope: `nx-plugin`
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

Stops the Nx page generator from emitting redundant `standalone: true` for generated page components in the modern template path.

The matching generator snapshots were updated to keep the expected output aligned with current Angular style.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [x] Manual verification

Manual verification:
- `pnpm nx test nx-plugin --runTestsByPath packages/nx-plugin/src/generators/page/generator.spec.ts`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This intentionally leaves the version-gated Angular 17/18 compatibility templates unchanged.

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
