### PR TITLE
feat(platform): add shiki skipLangs option for analog v3

### DIFF
--- a/apps/docs-app/docs/features/routing/content.md
+++ b/apps/docs-app/docs/features/routing/content.md
@@ -197,11 +197,11 @@ export default defineConfig({
         shikiOptions: {
           highlight: {
             // alternate theme
-            theme: 'ayu-dark'
-          }
+            theme: 'ayu-dark',
+          },
           highlighter: {
-             // add more languages
-            additionalLangs: ['mermaid'],
+            // add more languages for Shiki itself
+            additionalLangs: ['diff'],
           },
         },
       },
@@ -209,6 +209,31 @@ export default defineConfig({
   ],
 });
 ```
+
+For Mermaid-heavy content, keep the existing `loadMermaid` runtime path and skip Mermaid grammar loading in Shiki to avoid unnecessary server-side highlighting work in constrained CI environments:
+
+```ts
+import { defineConfig } from 'vite';
+import analog from '@analogjs/platform';
+
+export default defineConfig({
+  plugins: [
+    analog({
+      content: {
+        highlighter: 'shiki',
+        shikiOptions: {
+          highlighter: {
+            additionalLangs: ['mermaid'],
+            skipLangs: ['mermaid'],
+          },
+        },
+      },
+    }),
+  ],
+});
+```
+
+With `skipLangs: ['mermaid']`, Analog keeps Mermaid blocks on the existing `<pre class="mermaid">` path for `loadMermaid`, while Shiki skips loading and tokenizing the Mermaid grammar.
 
 By default, `shikiOptions` has the following options.
 

--- a/packages/platform/src/lib/content/shiki/index.spec.ts
+++ b/packages/platform/src/lib/content/shiki/index.spec.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createHighlighterMock = vi.fn(async () => ({
+  codeToHtml: vi.fn((_code: string, options: { lang: string }) => {
+    return `<pre class="shiki" data-lang="${options.lang}"></pre>`;
+  }),
+}));
+
+vi.mock('shiki', () => ({
+  createHighlighter: createHighlighterMock,
+}));
+
+vi.mock('marked-shiki', () => ({
+  default: (options: unknown) => options,
+}));
+
+let getShikiHighlighter: typeof import('./index.js').getShikiHighlighter;
+
+beforeEach(async () => {
+  vi.resetModules();
+  createHighlighterMock.mockClear();
+  ({ getShikiHighlighter } = await import('./index.js'));
+});
+
+describe('getShikiHighlighter', () => {
+  it('does not load skipped languages into shiki and preserves the mermaid render path', async () => {
+    const highlighter = getShikiHighlighter({
+      highlighter: {
+        additionalLangs: ['mermaid'],
+        skipLangs: ['mermaid'],
+      },
+    });
+
+    expect(createHighlighterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        langs: expect.not.arrayContaining(['mermaid']),
+      }),
+    );
+
+    const extension = highlighter.getHighlightExtension() as {
+      highlight: (
+        code: string,
+        lang: string,
+        props: string[],
+      ) => Promise<string>;
+    };
+
+    await expect(extension.highlight('graph TD;', 'mermaid', [])).resolves.toBe(
+      '<pre class="mermaid">graph TD;</pre>',
+    );
+  });
+
+  it('returns plain fenced code blocks for skipped non-mermaid languages', async () => {
+    const highlighter = getShikiHighlighter({
+      highlighter: {
+        additionalLangs: ['yaml'],
+        skipLangs: ['yaml'],
+      },
+    });
+
+    const extension = highlighter.getHighlightExtension() as {
+      highlight: (
+        code: string,
+        lang: string,
+        props: string[],
+      ) => Promise<string>;
+    };
+
+    await expect(extension.highlight('name: analog', 'yaml', [])).resolves.toBe(
+      '<pre class="language-yaml"><code class="language-yaml">name: analog</code></pre>',
+    );
+  });
+
+  it('escapes HTML when rendering skipped languages', async () => {
+    const highlighter = getShikiHighlighter({
+      highlighter: {
+        additionalLangs: ['yaml'],
+        skipLangs: ['yaml'],
+      },
+    });
+
+    const extension = highlighter.getHighlightExtension() as {
+      highlight: (
+        code: string,
+        lang: string,
+        props: string[],
+      ) => Promise<string>;
+    };
+
+    await expect(
+      extension.highlight(`<div class="x">Tom & 'Jerry'</div>`, 'yaml', []),
+    ).resolves.toBe(
+      '<pre class="language-yaml"><code class="language-yaml">&lt;div class=&quot;x&quot;&gt;Tom &amp; &#39;Jerry&#39;&lt;/div&gt;</code></pre>',
+    );
+  });
+
+  it('still returns mermaid blocks when loadMermaid handling is enabled and the language is not skipped', async () => {
+    const highlighter = getShikiHighlighter({
+      highlighter: {
+        additionalLangs: ['mermaid'],
+      },
+    });
+
+    const extension = highlighter.getHighlightExtension() as {
+      highlight: (
+        code: string,
+        lang: string,
+        props: string[],
+      ) => Promise<string>;
+    };
+
+    await expect(extension.highlight('graph TD;', 'mermaid', [])).resolves.toBe(
+      '<pre class="mermaid">graph TD;</pre>',
+    );
+  });
+});

--- a/packages/platform/src/lib/content/shiki/index.ts
+++ b/packages/platform/src/lib/content/shiki/index.ts
@@ -18,6 +18,12 @@ export function getShikiHighlighter({
     return highlighterInstance;
   }
 
+  const additionalLangs = highlighter.additionalLangs ?? [];
+  const skipLangs = highlighter.skipLangs ?? [];
+  const hasMermaidSupport =
+    highlighter.langs?.includes('mermaid') ||
+    additionalLangs.includes('mermaid');
+
   if (!highlighter.themes) {
     if (highlight.theme) {
       highlighter.themes = [highlight.theme];
@@ -29,19 +35,28 @@ export function getShikiHighlighter({
   }
 
   if (!highlighter.langs) {
-    highlighter.langs = defaultHighlighterOptions.langs;
+    highlighter.langs = [...defaultHighlighterOptions.langs];
   }
 
-  if (highlighter.additionalLangs) {
-    highlighter.langs.push(...highlighter.additionalLangs);
-    delete highlighter.additionalLangs;
+  if (additionalLangs.length > 0) {
+    highlighter.langs.push(...additionalLangs);
   }
+
+  if (skipLangs.length > 0) {
+    highlighter.langs = highlighter.langs.filter(
+      (lang) => !skipLangs.includes(lang),
+    );
+  }
+
+  delete highlighter.additionalLangs;
+  delete highlighter.skipLangs;
 
   highlighterInstance = new ShikiHighlighter(
     highlighter as ShikiHighlighterOptions,
     highlight,
     container,
-    !!highlighter.langs.includes('mermaid'),
+    hasMermaidSupport,
+    skipLangs,
   );
 
   return highlighterInstance;

--- a/packages/platform/src/lib/content/shiki/options.ts
+++ b/packages/platform/src/lib/content/shiki/options.ts
@@ -8,6 +8,7 @@ import { BundledLanguage } from 'shiki/langs';
 export interface WithShikiHighlighterOptions {
   highlighter?: Partial<ShikiHighlighterOptions> & {
     additionalLangs?: BundledLanguage[];
+    skipLangs?: BundledLanguage[];
   };
   highlight?: ShikiHighlightOptions;
   container?: string;

--- a/packages/platform/src/lib/content/shiki/shiki-highlighter.ts
+++ b/packages/platform/src/lib/content/shiki/shiki-highlighter.ts
@@ -37,6 +37,15 @@ export const defaultHighlighterOptions: {
   themes: ['github-dark', 'github-light'],
 };
 
+function escapeHtml(code: string): string {
+  return code
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
 export class ShikiHighlighter extends MarkedContentHighlighter {
   private readonly highlighter: ReturnType<typeof createHighlighter>;
 
@@ -45,6 +54,7 @@ export class ShikiHighlighter extends MarkedContentHighlighter {
     private highlightOptions: ShikiHighlightOptions,
     private container: string,
     private hasLoadMermaid = false,
+    private skipLangs: string[] = [],
   ) {
     super();
     this.highlighter = createHighlighter(this.highlighterOptions);
@@ -55,6 +65,12 @@ export class ShikiHighlighter extends MarkedContentHighlighter {
       highlight: async (code, lang, props) => {
         if (this.hasLoadMermaid && lang === 'mermaid') {
           return `<pre class="mermaid">${code}</pre>`;
+        }
+
+        if (this.skipLangs.includes(lang as string)) {
+          const escapedCode = escapeHtml(code);
+
+          return `<pre class="language-${lang}"><code class="language-${lang}">${escapedCode}</code></pre>`;
         }
 
         const { codeToHtml } = await this.highlighter;


### PR DESCRIPTION
## PR Checklist

Closes analogjs/analog#2029

## Affected scope

- Primary scope: `platform`
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

This adds `shikiOptions.highlighter.skipLangs` to the platform content Shiki integration.

When a fenced code block language is listed in `skipLangs`, the block bypasses Shiki and is rendered as a plain fenced code block instead of going through Shiki's highlighter pipeline.

That gives users a supported way to exclude languages like `mermaid` from Shiki while still keeping Shiki enabled for the rest of the markdown pipeline. This follows the maintainer direction in the issue thread that `skipLangs` looked like the right option.

## Test plan

- [ ] `nx format:check`
- [x] `pnpm build`
- [x] `pnpm test`
- [ ] Manual verification

Commands run:

- `pnpm nx test platform --runTestsByPath packages/platform/src/lib/content/shiki/index.spec.ts`
- `pnpm nx build platform`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The behavior is intentionally narrow:
- skipped languages are rendered as plain fenced code blocks
- existing Mermaid handling stays unchanged when `mermaid` is not listed in `skipLangs`
