### PR TITLE
fix(vite-plugin-angular): handle ?inline style imports in load hook for Vitest

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1,4 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('vite', async () => {
+  const actual = await vi.importActual<typeof import('vite')>('vite');
+  return {
+    ...actual,
+    preprocessCSS: vi.fn(async (code: string) => ({ code, deps: new Set() })),
+  };
+});
+
 import {
   angular,
   createFsWatcherCacheInvalidator,
@@ -188,6 +197,61 @@ describe('JIT resolveId', () => {
       '/project/src/app/my-component.ts',
     );
     expect(inlineRE.test(result)).toBe(false);
+  });
+});
+
+describe('load ?inline style imports', () => {
+  // Vitest's fetchModule path calls moduleGraph.ensureEntryFromUrl before
+  // transformRequest, which makes pluginContainer.resolveId a no-op for the
+  // module-runner. The resolveId rewrite to ?analog-inline therefore never
+  // runs in tests, and the load hook must accept the original ?inline query
+  // directly. (See issue #2263.)
+  const realFs = require('node:fs');
+  const tmpDir = require('node:os').tmpdir();
+  const path = require('node:path');
+
+  function getLoadHook() {
+    const plugins = angular();
+    const mainPlugin = plugins.find(
+      (p) => p.name === '@analogjs/vite-plugin-angular',
+    );
+    return (mainPlugin as any).load.bind({});
+  }
+
+  it('handles ?inline style imports without going through resolveId', async () => {
+    const cssPath = path.join(tmpDir, `analog-inline-${Date.now()}.css`);
+    realFs.writeFileSync(cssPath, '.foo { color: red; }', 'utf-8');
+
+    try {
+      const load = getLoadHook();
+      const result = await load(`${cssPath}?inline`);
+      expect(result).toBeDefined();
+      expect(result).toContain('export default');
+      expect(result).toContain('color: red');
+    } finally {
+      realFs.unlinkSync(cssPath);
+    }
+  });
+
+  it('still handles the rewritten ?analog-inline query', async () => {
+    const cssPath = path.join(tmpDir, `analog-rewrite-${Date.now()}.css`);
+    realFs.writeFileSync(cssPath, '.bar { color: blue; }', 'utf-8');
+
+    try {
+      const load = getLoadHook();
+      const result = await load(`${cssPath}?analog-inline`);
+      expect(result).toBeDefined();
+      expect(result).toContain('export default');
+      expect(result).toContain('color: blue');
+    } finally {
+      realFs.unlinkSync(cssPath);
+    }
+  });
+
+  it('ignores non-style ?inline imports', async () => {
+    const load = getLoadHook();
+    const result = await load('/project/src/data.json?inline');
+    expect(result).toBeUndefined();
   });
 });
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -571,7 +571,18 @@ export function angular(options?: PluginOptions): Plugin[] {
         // Handle Angular style imports directly, bypassing Vite 8.0.5+
         // server.fs security check which blocks IDs matching /[?&]inline\b/.
         // Compile via preprocessCSS and return as inline string export.
-        if (id.includes('?analog-inline')) {
+        //
+        // We accept both ?analog-inline (rewritten by resolveId for the
+        // browser dev-server path) and ?inline (the original query) because
+        // Vitest's fetchModule path calls moduleGraph.ensureEntryFromUrl
+        // before transformRequest, which means pluginContainer.resolveId is
+        // never invoked for module-runner imports — so the resolveId-based
+        // rewrite never runs in the test path. Handling ?inline here covers
+        // both paths.
+        if (
+          id.includes('?analog-inline') ||
+          /\.(css|scss|sass|less)\?inline$/.test(id)
+        ) {
           const filePath = id.split('?')[0];
           const code = await fsPromises.readFile(filePath, 'utf-8');
           const result = await preprocessCSS(code, filePath, resolvedConfig);


### PR DESCRIPTION
## PR Checklist

Closes #2263

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

The 2.4.3 fix (#2264) rewrote `?inline` → `?analog-inline` in the plugin's `resolveId` hook to bypass Vite 8.0.5+'s new `server.fs` Denied ID check for style imports. That works for the browser dev-server path, but **Vitest's worker `fetchModule` path bypasses `resolveId` entirely**:

```js
// vite/dist/node/chunks/node.js — fetchModule
url = unwrapId(url);
const mod = await environment.moduleGraph.ensureEntryFromUrl(url);
…
let result = await environment.transformRequest(url);
```
```js
// vite/dist/node/chunks/node.js — transformRequest
const resolved = module ? void 0 : await pluginContainer.resolveId(url, void 0) ?? void 0;
const id = module?.id ?? resolved?.id ?? url;
```

Because `ensureEntryFromUrl` populates the module entry first, `module` is truthy and `pluginContainer.resolveId` is never called for module-runner imports. The `?inline` → `?analog-inline` rewrite never runs in tests, the id keeps `?inline`, and Vite's new fs-allow check (fires for any id matching `/[?&]inline\b/` whose path isn't in `server.fs.allow`) trips on it.

This commit moves the handling into the `load` hook (which **is** called by `pluginContainer.load(id)` in `loadAndTransform`), so both the dev-server and Vitest paths are covered. The `load` hooks in both `angular-vite-plugin` and `analog-compiler-plugin` now accept either `?analog-inline` (the rewritten form) or `.{css,scss,sass,less}?inline` (the original form) and read+`preprocessCSS` the file directly.

The `resolveId` rewrite is intentionally left in place — it still serves the browser dev-server path correctly and keeps things consistent for HMR.

## Test plan

- [x] `nx format:check`
- [x] `nx test vite-plugin-angular` — added 3 focused tests in `angular-vite-plugin.spec.ts` covering `?inline` style ids, the existing `?analog-inline` path, and ignoring non-style `?inline` ids
- [x] `nx test analog-app` — passes
- [x] `nx test top-bar` — passes (parent imports child component with `styleUrls`)
- [ ] Manual verification by reporter (snippet provided in the issue thread)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The validation here was load-bearing — it took instrumented logging of `resolveId` and `load` against a real Vitest run to confirm `resolveId` is never invoked for these ids. The reporter's intuition ("the analog-inline remapping isn't being performed") was correct in effect: it's not performed at all in the test path, regardless of which component the styleUrl belongs to. Their setup happens to surface the failure because their child component's styleUrl lives outside whatever Vitest's `searchForWorkspaceRoot` adds to `fs.allow`; setups where every styleUrl happens to fall inside `fs.allow` silently mask the bug.