### PR TITLE
fix(vite-plugin-angular): emit ?analog-{inline,raw} from JIT transform output

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -727,12 +727,29 @@ export function angular(options?: PluginOptions): Plugin[] {
               'virtual:angular:jit:style:inline;',
             );
 
+            // Emit ?analog-raw and ?analog-inline directly (instead of
+            // ?raw / ?inline) so the import ids in the compiled JS never
+            // match Vite 8.0.5+'s [?&](raw|inline)\b security regex during
+            // loadAndTransform.
+            //
+            // Why this matters: Vite's Denied ID check fires for any id
+            // matching that regex whose path is outside server.fs.allow,
+            // and it runs *before* pluginContainer.load. Vitest's worker
+            // fetchModule path also bypasses pluginContainer.resolveId
+            // (it calls moduleGraph.ensureEntryFromUrl first, which makes
+            // the resolveId chain a no-op for the module-runner). So
+            // neither the resolveId-based ?inline -> ?analog-inline rewrite
+            // nor the load-hook fallback (added in 2.4.4) gets a chance to
+            // run for cross-library imports — the security check has
+            // already thrown by then. Emitting the safe query directly in
+            // the transform output is the only place we can guarantee Vite
+            // never sees the dangerous form. (#2263)
             templateUrls.forEach((templateUrlSet) => {
               const [templateFile, resolvedTemplateUrl] =
                 templateUrlSet.split('|');
               data = data.replace(
                 `angular:jit:template:file;${templateFile}`,
-                `${resolvedTemplateUrl}?raw`,
+                `${resolvedTemplateUrl}?analog-raw`,
               );
             });
 
@@ -740,7 +757,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               const [styleFile, resolvedStyleUrl] = styleUrlSet.split('|');
               data = data.replace(
                 `angular:jit:style:file;${styleFile}`,
-                `${resolvedStyleUrl}?inline`,
+                `${resolvedStyleUrl}?analog-inline`,
               );
             });
           }


### PR DESCRIPTION
## PR Checklist

Follow-up to #2271 (2.4.4). Fully closes #2263.

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

The 2.4.4 fix added a `load`-hook fallback for `?inline` style imports, but Vite 8.0.5+'s `server.fs` Denied ID check fires **before** `pluginContainer.load` for any id matching `/[?&](raw|inline)\b/` whose path is outside `server.fs.allow`. The reporter on #2263 instrumented the load hook and confirmed that for cross-library imports (parent component imports a child component from another library outside `fs.allow`), `load` is **never called** for the `.scss?inline` id — Vite throws Denied ID before the plugin can intervene.

Combined with the fact that Vitest's worker `fetchModule` path bypasses `pluginContainer.resolveId` entirely (it calls `moduleGraph.ensureEntryFromUrl` first, which makes the resolveId chain a no-op for the module-runner), neither the resolveId rewrite nor the load fallback ever runs for cross-library imports. The only place left to intercept is the JIT transform output itself, which is what emits the dangerous import strings.

This PR changes the JIT marker replacement at `angular-vite-plugin.ts:730-762` to emit `?analog-raw` / `?analog-inline` directly instead of `?raw` / `?inline`. The compiled JS now contains imports like `import '/abs/path/icon.component.scss?analog-inline'` which never match Vite's `[?&](raw|inline)\b` security regex, so the Denied ID check passes and the existing `load` handlers (`?analog-raw` at line 565, `?analog-inline` at line 583) take over and return the inline string export.

Two literal string changes in the transform body, surrounded by an explanatory comment so the next person to touch this code understands why the query strings look unusual.

## Test plan

- [x] `nx format:check`
- [x] `pnpm vitest run` in `packages/vite-plugin-angular` — all 58 tests pass (existing coverage of the load + resolveId paths is unchanged; this commit only changes the literal query strings the transform emits)
- [ ] Manual verification by reporter on the cross-library scenario from #2263

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Why no new unit test for the transform output: the transform handler is a closure inside the plugin factory that depends on the live Angular fileEmitter, so testing it in isolation would require either refactoring out the marker-replacement block or stubbing the whole Angular compilation API. I didn't want to do speculative refactoring inside a bug fix. The downstream `load` handlers for both `?analog-raw` and `?analog-inline` are already covered by the existing tests added in #2262 / #2271.

Note for forward-port to `beta`: `packages/vite-plugin-angular/src/lib/analog-compiler-plugin.ts` (which only exists on `beta`) has its own `resolveId` and `load` hooks for these queries. If/when this PR is forward-ported to `beta`, the equivalent change should also be applied to that file's transform path if it has one, otherwise the resolveId+load handlers there are sufficient for the dev-server path but will have the same Vitest gap.