### PR TITLE
fix(angular-compiler): skip arrow fn types when finding assignment = …

### DIFF
--- a/packages/angular-compiler/src/lib/class-field-lowering.spec.ts
+++ b/packages/angular-compiler/src/lib/class-field-lowering.spec.ts
@@ -285,4 +285,62 @@ export default class TestComponent {
     expect(result).toContain(`this[KEY] = 'value'`);
     expect(result).not.toContain(`this.[KEY]`);
   });
+
+  it('does not mangle private field with arrow function type and initializer', () => {
+    const result = compileWithLowering(`
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-test', template: '' })
+      export class TestComponent {
+        #registeredClearUserData: (() => void) | null = null;
+      }
+    `);
+
+    expectCompiles(result);
+    // Initializer should be in constructor
+    expect(result).toContain('this.#registeredClearUserData = null');
+    // Type annotation should be fully preserved (not mangled to "(() ;")
+    expect(result).not.toContain('(() ;');
+  });
+
+  it('does not mangle private field with fn type annotation and fn initializer', () => {
+    const result = compileWithLowering(`
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-test', template: '' })
+      export class TestComponent {
+        #onChange: (value: string) => void = () => {};
+      }
+    `);
+
+    expectCompiles(result);
+    expect(result).toContain('this.#onChange = () => {}');
+    expect(result).not.toContain('(value: string) ;');
+  });
+
+  it('does not mangle private field with generic arrow type and initializer', () => {
+    const result = compileWithLowering(`
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-test', template: '' })
+      export class TestComponent {
+        #openChangeFns: Array<(open: boolean) => void> = [];
+      }
+    `);
+
+    expectCompiles(result);
+    expect(result).toContain('this.#openChangeFns = []');
+    expect(result).not.toContain('(open: boolean) ;');
+  });
+
+  it('preserves private field with simple type and initializer', () => {
+    const result = compileWithLowering(`
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-test', template: '' })
+      export class TestComponent {
+        #name: string = 'hello';
+      }
+    `);
+
+    expectCompiles(result);
+    expect(result).toContain("this.#name = 'hello'");
+    expect(result).toMatch(/#name/);
+  });
 });

--- a/packages/angular-compiler/src/lib/class-field-lowering.ts
+++ b/packages/angular-compiler/src/lib/class-field-lowering.ts
@@ -113,9 +113,14 @@ function lowerClassFieldsForClass(
   for (const field of fieldsToLower) {
     if (field.isPrivate) {
       // Keep declaration without initializer: `#field;`
+      // Start scanning after the type annotation (if present) to avoid
+      // matching `=` inside `=>` of arrow function type annotations.
+      const scanFrom = field.node.typeAnnotation
+        ? field.node.typeAnnotation.end
+        : field.node.key.end;
       const eqStart = findEqualsSign(
         sourceCode,
-        field.node.key.end,
+        scanFrom,
         field.node.value.start,
       );
       ms.remove(eqStart, field.node.value.end);


### PR DESCRIPTION
`findEqualsSign()` in class field lowering scanned from `key.end` to `value.start` for the assignment `=`, but for private    
  fields with arrow function type annotations (e.g. `#cb: (() => void) | null = null`) it matched the `=` inside `=>` first,    
  removing part of the type annotation and producing invalid output like `#cb: (() ;`.   

Fix: when a type annotation is present, start scanning from typeAnnotation.end instead of key.end.

## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## Affected scope

<!-- List the primary scope from CONTRIBUTING.md and any closely related secondary scopes. -->

- Primary scope: angular-compiler
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

<!-- Squash merge is highly preferred. -->
<!-- Recommend a non-squash merge only if you can justify why the PR should bypass focused changes per package. -->

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

<!-- If you recommend a non-squash merge, briefly explain why the commit boundaries matter and why this PR should bypass focused changes per package. -->

## What is the new behavior?

When a private class field has a type annotation, `findEqualsSign()` now starts scanning from `typeAnnotation.end` instead of `key.end`, skipping past any `=` characters inside arrow function type annotations (`=>`). This ensures only the actual assignment `=` is matched.                                                                                                    
                                                                  
  ```typescript
  // Previously mangled output:
  #registeredClearUserData: (() ;
  #onChange: (value: string) ;                                                                                                  
   
  // Now correctly preserved:                                                                                                   
  #registeredClearUserData: (() => void) | null;                  
  #onChange: (value: string) => void;    
```

## Test plan

<!-- List the commands you ran and any manual verification you performed. -->

- [X] `nx format:check`
- [X] `pnpm build`
- [X] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
