### PR TITLE
fix(angular-compiler): constant pool helpers survive unused import elision

### DIFF
--- a/packages/angular-compiler/src/lib/compile.ts
+++ b/packages/angular-compiler/src/lib/compile.ts
@@ -1181,7 +1181,17 @@ export function compile(
     // be fully removed by elideTypeOnlyImportsMagicString (step 4).
     // Inserting at a position inside a soon-to-be-removed range would cause
     // MagicString to discard the helpers along with the import.
-    const willElide = detectTypeOnlyImportNames(ms.toString());
+    // Include pending sideEffects (setClassMetadata IIFEs) in the detection
+    // string — they reference decorator names like `Component` in value
+    // position but haven't been appended to `ms` yet. Without this,
+    // decorator names are falsely flagged as type-only, causing the import
+    // to be skipped, insertPos to stay at 0, and helpers to be placed at
+    // position 0 where they get wiped by the subsequent import overwrite.
+    const codeForDetection =
+      sideEffects.length > 0
+        ? ms.toString() + '\n' + sideEffects.join('\n')
+        : ms.toString();
+    const willElide = detectTypeOnlyImportNames(codeForDetection);
 
     let insertPos = 0;
     for (const stmt of origSourceFile.statements) {

--- a/packages/angular-compiler/src/lib/integration.spec.ts
+++ b/packages/angular-compiler/src/lib/integration.spec.ts
@@ -1889,6 +1889,37 @@ describe('constant pool helpers survive type-only import elision', () => {
     expect(result).not.toContain('import { Item }');
   });
 
+  // Regression: when ALL specifiers in the only import are falsely detected as
+  // type-only (because setClassMetadata hasn't been appended to MagicString yet),
+  // insertPos stays at 0 and helpers get wiped by the subsequent import overwrite.
+  // The source string must start at position 0 with `import` (no leading whitespace)
+  // to reproduce — real .ts files on disk always satisfy this condition.
+  it('emits constant pool helpers when unused imports are present', () => {
+    const result = compile(
+      // No leading whitespace — import starts at position 0, matching real files
+      `import { Component, signal, computed } from '@angular/core';
+
+@Component({
+  selector: 'app-counter',
+  template: \`<ng-content></ng-content>\`,
+})
+export class Counter {
+}
+`,
+      'counter.ts',
+    );
+
+    expectCompiles(result);
+    // The ngContentSelectors constant (e.g. _c0) must be defined, not just referenced
+    const selectorMatch = result.match(/ngContentSelectors:\s*(\w+)/);
+    expect(selectorMatch).toBeTruthy();
+    const constName = selectorMatch![1];
+    expect(result).toMatch(new RegExp(`const ${constName}\\s*=`));
+    // Unused imports should still be elided
+    expect(result).not.toContain('signal');
+    expect(result).not.toContain('computed');
+  });
+
   it('emits helpers when multiple trailing imports are type-only', () => {
     const result = compile(
       `


### PR DESCRIPTION
Include pending sideEffects (containing `setClassMetadata` IIFEs) in the string passed to `detectTypeOnlyImportNames` when calculating the helper insertion position. This ensures decorator names like `Component` - which are referenced in value position inside `setClassMetadata` - are not falsely flagged as type-only, so the import is not skipped and helpers are placed at a safe position that survives the downstream import overwrite.

Example

Given this input:

```ts
  import { Component, signal, computed } from '@angular/core';

  @Component({
    selector: 'app-counter',
    template: `<ng-content></ng-content>`,
  })                                                                                      
  export class Counter {}
```
                                                                                          
Before (broken) `_c0` is referenced but never defined:                                  
  
```ts
  import * as i0 from "@angular/core";                                                    
  import { Component } from '@angular/core';                                              
   
  export class Counter {                                                                  
    static ɵfac = /*@__PURE__*/ (__ngFactoryType__) => {return new (__ngFactoryType__ || Counter)();};                                                                           
    static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type: Counter, selectors: [["app-counter"]], ngContentSelectors: _c0, /* ... */});                                
  }                                                               
```                                                                                  
  After (fixed) - `_c0` is correctly emitted before the class:                              
   
```ts
  import * as i0 from "@angular/core";                                                    
  import { Component } from '@angular/core';                      

  const _c0 = ["*"];

  export class Counter {
    static ɵfac = /*@__PURE__*/ (__ngFactoryType__) => {return new (__ngFactoryType__ || Counter)();};                                                                           
    static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type: Counter, selectors: [["app-counter"]], ngContentSelectors: _c0, /* ... */});                                
  }   
```

## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## Affected scope

<!-- List the primary scope from CONTRIBUTING.md and any closely related secondary scopes. -->

- Primary scope: angular-compiler
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

<!-- Squash merge is highly preferred. -->
<!-- Recommend a non-squash merge only if you can justify why the PR should bypass focused changes per package. -->

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

<!-- If you recommend a non-squash merge, briefly explain why the commit boundaries matter and why this PR should bypass focused changes per package. -->

## What is the new behavior?

## Test plan

<!-- List the commands you ran and any manual verification you performed. -->

- [X] `nx format:check`
- [X] `pnpm build`
- [X] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
