### PR TITLE
fix(angular-compiler): support Angular v19, v20, and v22-next

### DIFF
--- a/.github/workflows/angular-compiler-compat.yml
+++ b/.github/workflows/angular-compiler-compat.yml
@@ -35,24 +35,17 @@ name: Angular Compiler Compatibility Tests
 
 on:
   workflow_dispatch:
-  # Automatic triggers are intentionally disabled until the matrix has
-  # been validated end-to-end via manual workflow_dispatch runs. Once
-  # the auto-issue path and the install-with-overrides flow are proven
-  # green on each numeric matrix slot, uncomment the blocks below to
-  # re-enable PR and beta-push triggers (filtered to compiler-relevant
-  # paths to avoid running on unrelated PRs).
-  #
-  # pull_request:
-  #   paths:
-  #     - 'packages/angular-compiler/**'
-  #     - 'package.json'
-  #     - '.github/workflows/angular-compiler-compat.yml'
-  # push:
-  #   branches: [beta]
-  #   paths:
-  #     - 'packages/angular-compiler/**'
-  #     - 'package.json'
-  #     - '.github/workflows/angular-compiler-compat.yml'
+  pull_request:
+    paths:
+      - 'packages/angular-compiler/**'
+      - 'package.json'
+      - '.github/workflows/angular-compiler-compat.yml'
+  push:
+    branches: [beta]
+    paths:
+      - 'packages/angular-compiler/**'
+      - 'package.json'
+      - '.github/workflows/angular-compiler-compat.yml'
 
 env:
   NODE_OPTIONS: --max-old-space-size=16384
@@ -134,12 +127,7 @@ jobs:
         # PRs already surface failures via the check status — auto-opening
         # issues for PRs would create spam. Only fire on direct beta pushes
         # so the issue tracker reflects the state of `main`-ish branches.
-        #
-        # DISABLED for now: validating the matrix end-to-end via manual
-        # workflow_dispatch runs first. The bash body, GH_TOKEN env, and
-        # dedup logic stay intact so re-enabling is a one-line edit —
-        # remove `false &&` from the `if:` condition below.
-        if: false && failure() && github.event_name == 'push'
+        if: failure() && github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/packages/angular-compiler/src/lib/angular-version.ts
+++ b/packages/angular-compiler/src/lib/angular-version.ts
@@ -1,0 +1,44 @@
+import * as o from '@angular/compiler';
+
+// Detect the installed @angular/compiler major version once at module load
+// time and expose helpers for version-aware code paths.
+//
+// Why this matters: Angular's compiler API surface (enum members,
+// metadata shapes, output formats) shifts between major versions in ways
+// that can't always be papered over with duck typing. The compatibility
+// matrix in .github/workflows/angular-compiler-compat.yml runs the test
+// suite against multiple installed versions to catch this drift, and the
+// version-aware code paths in compile.ts / js-emitter.ts / metadata.ts
+// gate behavior on `ANGULAR_MAJOR` to keep the compiler working across
+// the supported `peerDependencies` range (currently >=19.0.0).
+//
+// Default fallback: when the version string is missing or unparseable
+// (vendored builds, monkey-patched test environments), assume the latest
+// known major. This biases toward the most-tested code path.
+const DEFAULT_ASSUMED_MAJOR = 22;
+
+/**
+ * The major version of the installed `@angular/compiler` package, parsed
+ * from `o.VERSION.major`. Falls back to `DEFAULT_ASSUMED_MAJOR` when the
+ * version is unavailable.
+ */
+export const ANGULAR_MAJOR: number = (() => {
+  const major = Number.parseInt(o.VERSION?.major ?? '', 10);
+  return Number.isFinite(major) && major > 0 ? major : DEFAULT_ASSUMED_MAJOR;
+})();
+
+/**
+ * Returns `true` when the installed Angular major is at least `major`.
+ * Use this to gate code paths that depend on APIs introduced in a
+ * specific Angular release.
+ *
+ * @example
+ *   if (angularVersionAtLeast(21)) {
+ *     // Use Angular 21+ API
+ *   } else {
+ *     // Fall back to v19/v20 behavior
+ *   }
+ */
+export function angularVersionAtLeast(major: number): boolean {
+  return ANGULAR_MAJOR >= major;
+}

--- a/packages/angular-compiler/src/lib/compile.ts
+++ b/packages/angular-compiler/src/lib/compile.ts
@@ -55,12 +55,7 @@ import {
 } from './metadata.js';
 import { buildDeferDependencyMap } from './defer.js';
 import { debugCompile, debugEmit } from './debug.js';
-
-/** Detect installed Angular major version for compatibility. Supports 19+. */
-const ANGULAR_MAJOR = (() => {
-  const major = Number.parseInt(o.VERSION?.major ?? '', 10);
-  return Number.isFinite(major) && major > 0 ? major : 22;
-})();
+import { ANGULAR_MAJOR } from './angular-version.js';
 
 /**
  * COMPLETE EXHAUSTIVE ANGULAR LITE COMPILER

--- a/packages/angular-compiler/src/lib/compile.ts
+++ b/packages/angular-compiler/src/lib/compile.ts
@@ -680,6 +680,21 @@ export function compile(
             isStandalone: meta.standalone,
             imports: meta.imports,
             lifecycle: { usesOnChanges: false },
+            // Angular v19/v20's `createComponentDefinitionMap` reads
+            // `meta.interpolation.start` and `meta.interpolation.end`
+            // unconditionally (the `!== DEFAULT_INTERPOLATION_CONFIG` check
+            // is reference-equality, so a missing field enters the block
+            // and crashes with `Cannot read properties of undefined`). v21
+            // dropped the field from `createComponentDefinitionMap`
+            // entirely. Use the v19/v20 singleton when the Angular package
+            // exports it (matches the reference-equality check, skipping
+            // the partial-mode emission block) and fall back to a plain
+            // shape on v21+ where the field is ignored anyway.
+            interpolation: (
+              o as {
+                DEFAULT_INTERPOLATION_CONFIG?: { start: string; end: string };
+              }
+            ).DEFAULT_INTERPOLATION_CONFIG ?? { start: '{{', end: '}}' },
             usesInheritance,
             defer: {
               mode: 0,

--- a/packages/angular-compiler/src/lib/component.spec.ts
+++ b/packages/angular-compiler/src/lib/component.spec.ts
@@ -7,6 +7,18 @@ import {
 import { compile as rawCompile } from './compile';
 import { scanFile } from './registry';
 import { inlineResourceUrls, extractInlineStyles } from './resource-inliner';
+import { ANGULAR_MAJOR } from './angular-version';
+
+// Angular 19 ships several features in fundamentally different shapes
+// from v20+: `@defer` dependency emission predates the
+// `import('./x').then(m => m.X)` runtime ABI, and the `??` operator is
+// polyfilled to a `tmp !== null && tmp !== void 0 ? tmp : default`
+// chain instead of being emitted directly. The compiler still produces
+// runtime-correct output for both shapes — we just can't assert against
+// v20+ string patterns on v19. Tests that depend on the v20+ shapes are
+// gated on this constant.
+const SUPPORTS_DEFER_DYNAMIC_IMPORTS = ANGULAR_MAJOR >= 20;
+const SUPPORTS_DIRECT_NULLISH_COALESCE_EMISSION = ANGULAR_MAJOR >= 20;
 
 describe('@Component', () => {
   it('compiles a component with template and styles', () => {
@@ -580,20 +592,22 @@ describe('@Component', () => {
       expect(result).toContain('ɵɵdeferOnTimer');
     });
 
-    it('generates lazy import() for defer-only components', () => {
-      const heavySrc = `
+    it.skipIf(!SUPPORTS_DEFER_DYNAMIC_IMPORTS)(
+      'generates lazy import() for defer-only components',
+      () => {
+        const heavySrc = `
         import { Component } from '@angular/core';
         @Component({ selector: 'heavy-widget', template: '<p>Heavy</p>' })
         export class HeavyWidget {}
       `;
 
-      const registry = new Map();
-      for (const entry of scanFile(heavySrc, 'heavy.ts')) {
-        registry.set(entry.className, entry);
-      }
+        const registry = new Map();
+        for (const entry of scanFile(heavySrc, 'heavy.ts')) {
+          registry.set(entry.className, entry);
+        }
 
-      const result = rawCompile(
-        `
+        const result = rawCompile(
+          `
         import { Component } from '@angular/core';
         import { HeavyWidget } from './heavy-widget';
         @Component({
@@ -610,17 +624,18 @@ describe('@Component', () => {
         })
         export class LazyDeferComponent {}
       `,
-        'lazy-defer.ts',
-        { registry },
-      );
+          'lazy-defer.ts',
+          { registry },
+        );
 
-      expectCompiles(result.code);
-      expect(result.code).toContain('ɵɵdefer');
-      // Dynamic import for lazy loading
-      expect(result.code).toContain('import("./heavy-widget")');
-      // Dependency function generated (not null)
-      expect(result.code).toContain('DepsFn');
-    });
+        expectCompiles(result.code);
+        expect(result.code).toContain('ɵɵdefer');
+        // Dynamic import for lazy loading
+        expect(result.code).toContain('import("./heavy-widget")');
+        // Dependency function generated (not null)
+        expect(result.code).toContain('DepsFn');
+      },
+    );
   });
 
   describe('Content Projection', () => {
@@ -1437,9 +1452,14 @@ describe('Assignment precedence in ternary', () => {
 });
 
 describe('Operator precedence in template expressions', () => {
-  it('preserves grouping for ?? mixed with + in attribute binding', () => {
-    const result = compile(
-      `
+  // Angular 19 polyfills `??` to `(tmp = ctx.value() !== null && tmp !== void 0
+  // ? tmp : 0) + 15` instead of emitting the literal `??` operator. The
+  // semantics are equivalent but the string assertion only matches v20+.
+  it.skipIf(!SUPPORTS_DIRECT_NULLISH_COALESCE_EMISSION)(
+    'preserves grouping for ?? mixed with + in attribute binding',
+    () => {
+      const result = compile(
+        `
       import { Component, signal } from '@angular/core';
       @Component({
         selector: 'app-node',
@@ -1449,14 +1469,15 @@ describe('Operator precedence in template expressions', () => {
         value = signal<number | null>(null);
       }
     `,
-      'node.ts',
-    );
+        'node.ts',
+      );
 
-    expectCompiles(result);
-    // The ?? subexpression must be parenthesized to prevent:
-    // ctx.value() ?? 0 + 15  →  ctx.value() ?? (0 + 15)
-    expect(result).toContain('(ctx.value() ?? 0) + 15');
-  });
+      expectCompiles(result);
+      // The ?? subexpression must be parenthesized to prevent:
+      // ctx.value() ?? 0 + 15  →  ctx.value() ?? (0 + 15)
+      expect(result).toContain('(ctx.value() ?? 0) + 15');
+    },
+  );
 });
 
 describe('templateUrl inlining in metadata', () => {
@@ -2596,14 +2617,21 @@ describe('Signal query read/descendants options', () => {
   });
 });
 
-describe('@defer dependency import shape', () => {
-  it('emits import().then(m => m.X) for named imports', () => {
-    const childSrc = `
+// Angular 19's @defer uses a different runtime ABI: it emits static
+// `i0.ɵɵtemplate(...)` references and `i0.ɵɵdefer(slot, idx)` calls
+// without per-block dynamic `import('./x').then(m => m.X)` resolvers.
+// The dynamic-import shape was introduced in v20 and is what these
+// tests assert. Skip the entire describe on v19.
+describe.skipIf(!SUPPORTS_DEFER_DYNAMIC_IMPORTS)(
+  '@defer dependency import shape',
+  () => {
+    it('emits import().then(m => m.X) for named imports', () => {
+      const childSrc = `
       import { Component } from '@angular/core';
       @Component({ selector: 'app-lazy', template: 'lazy' })
       export class LazyCmp {}
     `;
-    const parentSrc = `
+      const parentSrc = `
       import { Component } from '@angular/core';
       import { LazyCmp } from './lazy';
       @Component({
@@ -2613,19 +2641,19 @@ describe('@defer dependency import shape', () => {
       })
       export class Parent {}
     `;
-    const registry = buildRegistry({ 'lazy.ts': childSrc });
-    const result = compile(parentSrc, 'parent.ts', registry);
-    expectCompiles(result);
-    expect(result).toMatch(/import\(['"]\.\/lazy['"]\).*then.*m\.LazyCmp/);
-  });
+      const registry = buildRegistry({ 'lazy.ts': childSrc });
+      const result = compile(parentSrc, 'parent.ts', registry);
+      expectCompiles(result);
+      expect(result).toMatch(/import\(['"]\.\/lazy['"]\).*then.*m\.LazyCmp/);
+    });
 
-  it('uses original export name for aliased imports, not the local binding', () => {
-    const childSrc = `
+    it('uses original export name for aliased imports, not the local binding', () => {
+      const childSrc = `
       import { Component } from '@angular/core';
       @Component({ selector: 'app-heavy', template: 'heavy' })
       export class HeavyWidget {}
     `;
-    const parentSrc = `
+      const parentSrc = `
       import { Component } from '@angular/core';
       import { HeavyWidget as Widget } from './heavy';
       @Component({
@@ -2635,25 +2663,25 @@ describe('@defer dependency import shape', () => {
       })
       export class Parent {}
     `;
-    const registry = buildRegistry({ 'heavy.ts': childSrc });
-    const result = compile(parentSrc, 'parent.ts', registry);
-    expectCompiles(result);
-    // Must reference the original export name `HeavyWidget`, NOT the
-    // local alias `Widget`. The module namespace exposes the original
-    // name regardless of how the consumer aliased it locally.
-    expect(result).toMatch(
-      /import\(['"]\.\/heavy['"]\)\.then\(\([^)]*\)\s*=>\s*\w+\.HeavyWidget\)/,
-    );
-    expect(result).not.toMatch(/m\.Widget(?!\w)/);
-  });
+      const registry = buildRegistry({ 'heavy.ts': childSrc });
+      const result = compile(parentSrc, 'parent.ts', registry);
+      expectCompiles(result);
+      // Must reference the original export name `HeavyWidget`, NOT the
+      // local alias `Widget`. The module namespace exposes the original
+      // name regardless of how the consumer aliased it locally.
+      expect(result).toMatch(
+        /import\(['"]\.\/heavy['"]\)\.then\(\([^)]*\)\s*=>\s*\w+\.HeavyWidget\)/,
+      );
+      expect(result).not.toMatch(/m\.Widget(?!\w)/);
+    });
 
-  it('emits import().then(m => m.default) for default imports', () => {
-    const childSrc = `
+    it('emits import().then(m => m.default) for default imports', () => {
+      const childSrc = `
       import { Component } from '@angular/core';
       @Component({ selector: 'app-lazy', template: 'lazy' })
       export default class LazyCmp {}
     `;
-    const parentSrc = `
+      const parentSrc = `
       import { Component } from '@angular/core';
       import LazyCmp from './lazy';
       @Component({
@@ -2663,9 +2691,10 @@ describe('@defer dependency import shape', () => {
       })
       export class Parent {}
     `;
-    const registry = buildRegistry({ 'lazy.ts': childSrc });
-    const result = compile(parentSrc, 'parent.ts', registry);
-    expectCompiles(result);
-    expect(result).toMatch(/import\(['"]\.\/lazy['"]\).*then.*m\.default/);
-  });
-});
+      const registry = buildRegistry({ 'lazy.ts': childSrc });
+      const result = compile(parentSrc, 'parent.ts', registry);
+      expectCompiles(result);
+      expect(result).toMatch(/import\(['"]\.\/lazy['"]\).*then.*m\.default/);
+    });
+  },
+);

--- a/packages/angular-compiler/src/lib/component.spec.ts
+++ b/packages/angular-compiler/src/lib/component.spec.ts
@@ -786,7 +786,18 @@ export class BottomNav {}
   });
 
   describe('Component Options', () => {
-    it('handles OnPush change detection', () => {
+    // Angular v22+ inverts the changeDetection default: OnPush is now the
+    // default strategy, so a component declaring `OnPush` matches the
+    // default and the field is OMITTED from `ɵɵdefineComponent` output
+    // (compiler.mjs line ~25363: emit only when `meta.changeDetection !==
+    // ChangeDetectionStrategy.OnPush`). The literal `'changeDetection: 0'`
+    // string therefore does not appear on v22+, even though the compiled
+    // component is semantically correct.
+    //
+    // Skip on v22+ for now. When v22 becomes a numeric matrix slot we can
+    // add an inverted test that asserts `'changeDetection: 1'` is emitted
+    // for components declaring `Default`/`Eager` (the new non-default).
+    it.skipIf(ANGULAR_MAJOR > 21)('handles OnPush change detection', () => {
       const result = compile(
         `
         import { Component, ChangeDetectionStrategy } from '@angular/core';

--- a/packages/angular-compiler/src/lib/js-emitter.spec.ts
+++ b/packages/angular-compiler/src/lib/js-emitter.spec.ts
@@ -2,6 +2,20 @@ import { describe, it, expect } from 'vitest';
 import * as o from '@angular/compiler';
 import { emitAngularExpr } from './js-emitter';
 
+// Version-aware test gates. Angular's `BinaryOperator` enum is missing
+// 11–13 members on v19/v20 (Assign, all 9 compound assignments, Exponen-
+// tiation/In on v19, InstanceOf on v19/v20). Tests that explicitly
+// construct expressions with those operators are nonsensical on versions
+// where the enum members don't exist — `o.BinaryOperator.Assign` would
+// evaluate to `undefined` and the test would assert against an
+// expression with `operator: undefined`. Skip such tests on versions
+// where the operator is missing rather than leaving them broken.
+const HAS_EXPONENTIATION =
+  typeof (o.BinaryOperator as Record<string, unknown>)['Exponentiation'] ===
+  'number';
+const HAS_ASSIGN_OPS =
+  typeof (o.BinaryOperator as Record<string, unknown>)['Assign'] === 'number';
+
 function bin(op: o.BinaryOperator, lhs: o.Expression, rhs: o.Expression) {
   return new o.BinaryOperatorExpr(op, lhs, rhs);
 }
@@ -124,25 +138,30 @@ describe('JSEmitter – operator precedence', () => {
     });
   });
 
-  describe('right-associative exponentiation', () => {
-    it('parenthesizes LHS of **: (a ** b) ** c', () => {
-      const expr = bin(
-        o.BinaryOperator.Exponentiation,
-        bin(o.BinaryOperator.Exponentiation, v('a'), v('b')),
-        v('c'),
-      );
-      expect(emitAngularExpr(expr)).toBe('(a ** b) ** c');
-    });
+  // `Exponentiation` was added to `BinaryOperator` in Angular 20 — these
+  // tests are nonsensical on v19 where the enum member doesn't exist.
+  describe.skipIf(!HAS_EXPONENTIATION)(
+    'right-associative exponentiation',
+    () => {
+      it('parenthesizes LHS of **: (a ** b) ** c', () => {
+        const expr = bin(
+          o.BinaryOperator.Exponentiation,
+          bin(o.BinaryOperator.Exponentiation, v('a'), v('b')),
+          v('c'),
+        );
+        expect(emitAngularExpr(expr)).toBe('(a ** b) ** c');
+      });
 
-    it('does not parenthesize RHS of **: a ** b ** c', () => {
-      const expr = bin(
-        o.BinaryOperator.Exponentiation,
-        v('a'),
-        bin(o.BinaryOperator.Exponentiation, v('b'), v('c')),
-      );
-      expect(emitAngularExpr(expr)).toBe('a ** b ** c');
-    });
-  });
+      it('does not parenthesize RHS of **: a ** b ** c', () => {
+        const expr = bin(
+          o.BinaryOperator.Exponentiation,
+          v('a'),
+          bin(o.BinaryOperator.Exponentiation, v('b'), v('c')),
+        );
+        expect(emitAngularExpr(expr)).toBe('a ** b ** c');
+      });
+    },
+  );
 
   describe('original bug scenario', () => {
     it('preserves parens: (a ?? 0) + (b || c) + 15', () => {
@@ -159,7 +178,9 @@ describe('JSEmitter – operator precedence', () => {
     });
   });
 
-  describe('assignments remain wrapped', () => {
+  // `Assign` and the 9 compound assignment operators were added to
+  // `BinaryOperator` in Angular 21 — these tests cannot run on v19/v20.
+  describe.skipIf(!HAS_ASSIGN_OPS)('assignments remain wrapped', () => {
     it('wraps simple assignment in parens', () => {
       const expr = bin(o.BinaryOperator.Assign, v('x'), lit(1));
       expect(emitAngularExpr(expr)).toBe('(x = 1)');

--- a/packages/angular-compiler/src/lib/js-emitter.ts
+++ b/packages/angular-compiler/src/lib/js-emitter.ts
@@ -10,78 +10,93 @@ const emptySourceFile = ts.createSourceFile(
   false,
 );
 
-const BINARY_OP_STR: Record<number, string> = {
-  [o.BinaryOperator.Equals]: '==',
-  [o.BinaryOperator.NotEquals]: '!=',
-  [o.BinaryOperator.Assign]: '=',
-  [o.BinaryOperator.Identical]: '===',
-  [o.BinaryOperator.NotIdentical]: '!==',
-  [o.BinaryOperator.Minus]: '-',
-  [o.BinaryOperator.Plus]: '+',
-  [o.BinaryOperator.Divide]: '/',
-  [o.BinaryOperator.Multiply]: '*',
-  [o.BinaryOperator.Modulo]: '%',
-  [o.BinaryOperator.And]: '&&',
-  [o.BinaryOperator.Or]: '||',
-  [o.BinaryOperator.BitwiseOr]: '|',
-  [o.BinaryOperator.BitwiseAnd]: '&',
-  [o.BinaryOperator.Lower]: '<',
-  [o.BinaryOperator.LowerEquals]: '<=',
-  [o.BinaryOperator.Bigger]: '>',
-  [o.BinaryOperator.BiggerEquals]: '>=',
-  [o.BinaryOperator.NullishCoalesce]: '??',
-  [o.BinaryOperator.Exponentiation]: '**',
-  [o.BinaryOperator.In]: 'in',
-  [o.BinaryOperator.InstanceOf]: 'instanceof',
-  [o.BinaryOperator.AdditionAssignment]: '+=',
-  [o.BinaryOperator.SubtractionAssignment]: '-=',
-  [o.BinaryOperator.MultiplicationAssignment]: '*=',
-  [o.BinaryOperator.DivisionAssignment]: '/=',
-  [o.BinaryOperator.RemainderAssignment]: '%=',
-  [o.BinaryOperator.ExponentiationAssignment]: '**=',
-  [o.BinaryOperator.AndAssignment]: '&&=',
-  [o.BinaryOperator.OrAssignment]: '||=',
-  [o.BinaryOperator.NullishCoalesceAssignment]: '??=',
-};
+// Operator metadata table — name, JS string, and precedence (higher = tighter
+// binding). Used to build version-aware lookup maps below.
+//
+// Why a runtime build instead of static `[o.BinaryOperator.Equals]: '=='`
+// literals: Angular's `BinaryOperator` enum gains members between major
+// versions (Assign and the 9 compound assignments were added in v21,
+// Exponentiation/In in v20, InstanceOf in v21). On older Angular versions
+// the missing members evaluate to `undefined` at module load time, and
+// every `[undefined]: '...'` entry collides on the single string key
+// `"undefined"` — last write wins. Pre-Phase-1, that gave the v19 install
+// `BINARY_OP_STR["undefined"] === '??='`, so any expression with an
+// unknown operator emitted `??=` instead of failing loudly. Building the
+// table by iterating known names and skipping `undefined` values
+// eliminates the collision: members that don't exist on the installed
+// Angular are simply absent from the map.
+//
+// Precedence values match MDN's table, skipping levels not used by Angular
+// (bitwise XOR, shifts).
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence
+const OP_DEFINITIONS: ReadonlyArray<
+  readonly [name: string, str: string, precedence: number]
+> = [
+  ['Assign', '=', 2],
+  ['AdditionAssignment', '+=', 2],
+  ['SubtractionAssignment', '-=', 2],
+  ['MultiplicationAssignment', '*=', 2],
+  ['DivisionAssignment', '/=', 2],
+  ['RemainderAssignment', '%=', 2],
+  ['ExponentiationAssignment', '**=', 2],
+  ['AndAssignment', '&&=', 2],
+  ['OrAssignment', '||=', 2],
+  ['NullishCoalesceAssignment', '??=', 2],
+  ['NullishCoalesce', '??', 4],
+  ['Or', '||', 4],
+  ['And', '&&', 5],
+  ['BitwiseOr', '|', 6],
+  ['BitwiseAnd', '&', 8],
+  ['Equals', '==', 9],
+  ['NotEquals', '!=', 9],
+  ['Identical', '===', 9],
+  ['NotIdentical', '!==', 9],
+  ['Lower', '<', 10],
+  ['LowerEquals', '<=', 10],
+  ['Bigger', '>', 10],
+  ['BiggerEquals', '>=', 10],
+  ['In', 'in', 10],
+  ['InstanceOf', 'instanceof', 10],
+  ['Plus', '+', 12],
+  ['Minus', '-', 12],
+  ['Multiply', '*', 13],
+  ['Divide', '/', 13],
+  ['Modulo', '%', 13],
+  ['Exponentiation', '**', 14],
+];
 
-/**
- * JavaScript operator precedence (higher = tighter binding).
- * Values match MDN's table, skipping levels not used by Angular (bitwise XOR, shifts).
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence
- */
-const BINARY_PRECEDENCE: Record<number, number> = {
-  [o.BinaryOperator.Assign]: 2,
-  [o.BinaryOperator.AdditionAssignment]: 2,
-  [o.BinaryOperator.SubtractionAssignment]: 2,
-  [o.BinaryOperator.MultiplicationAssignment]: 2,
-  [o.BinaryOperator.DivisionAssignment]: 2,
-  [o.BinaryOperator.RemainderAssignment]: 2,
-  [o.BinaryOperator.ExponentiationAssignment]: 2,
-  [o.BinaryOperator.AndAssignment]: 2,
-  [o.BinaryOperator.OrAssignment]: 2,
-  [o.BinaryOperator.NullishCoalesceAssignment]: 2,
-  [o.BinaryOperator.Or]: 4,
-  [o.BinaryOperator.NullishCoalesce]: 4,
-  [o.BinaryOperator.And]: 5,
-  [o.BinaryOperator.BitwiseOr]: 6,
-  [o.BinaryOperator.BitwiseAnd]: 8,
-  [o.BinaryOperator.Equals]: 9,
-  [o.BinaryOperator.NotEquals]: 9,
-  [o.BinaryOperator.Identical]: 9,
-  [o.BinaryOperator.NotIdentical]: 9,
-  [o.BinaryOperator.Lower]: 10,
-  [o.BinaryOperator.LowerEquals]: 10,
-  [o.BinaryOperator.Bigger]: 10,
-  [o.BinaryOperator.BiggerEquals]: 10,
-  [o.BinaryOperator.In]: 10,
-  [o.BinaryOperator.InstanceOf]: 10,
-  [o.BinaryOperator.Plus]: 12,
-  [o.BinaryOperator.Minus]: 12,
-  [o.BinaryOperator.Multiply]: 13,
-  [o.BinaryOperator.Divide]: 13,
-  [o.BinaryOperator.Modulo]: 13,
-  [o.BinaryOperator.Exponentiation]: 14,
-};
+/** Operator integer values that represent assignment forms (`=`, `+=`, etc.). */
+const ASSIGNMENT_OP_NAMES: ReadonlySet<string> = new Set([
+  'Assign',
+  'AdditionAssignment',
+  'SubtractionAssignment',
+  'MultiplicationAssignment',
+  'DivisionAssignment',
+  'RemainderAssignment',
+  'ExponentiationAssignment',
+  'AndAssignment',
+  'OrAssignment',
+  'NullishCoalesceAssignment',
+]);
+
+const BINARY_OP_STR = new Map<number, string>();
+const BINARY_PRECEDENCE = new Map<number, number>();
+const ASSIGNMENT_OP_VALUES = new Set<number>();
+
+for (const [name, str, precedence] of OP_DEFINITIONS) {
+  const value = (o.BinaryOperator as Record<string, unknown>)[name];
+  if (typeof value !== 'number') continue;
+  BINARY_OP_STR.set(value, str);
+  BINARY_PRECEDENCE.set(value, precedence);
+  if (ASSIGNMENT_OP_NAMES.has(name)) {
+    ASSIGNMENT_OP_VALUES.add(value);
+  }
+}
+
+/** Returns true when `op` represents any kind of assignment (`=`, `+=`, etc.). */
+function isAssignmentOperator(op: o.BinaryOperator): boolean {
+  return ASSIGNMENT_OP_VALUES.has(op);
+}
 
 /**
  * Determine whether a child expression needs parentheses when it appears
@@ -95,8 +110,8 @@ function childNeedsParens(
   if (!(child instanceof o.BinaryOperatorExpr)) return false;
 
   const childOp = child.operator;
-  const parentPrec = BINARY_PRECEDENCE[parentOp];
-  const childPrec = BINARY_PRECEDENCE[childOp];
+  const parentPrec = BINARY_PRECEDENCE.get(parentOp);
+  const childPrec = BINARY_PRECEDENCE.get(childOp);
   if (parentPrec === undefined || childPrec === undefined) return false;
 
   // ?? cannot appear with || or && without explicit grouping (JS spec)
@@ -262,7 +277,18 @@ class JSEmitter implements o.ExpressionVisitor, o.StatementVisitor {
     );
   }
   visitBinaryOperatorExpr(ast: o.BinaryOperatorExpr) {
-    const op = BINARY_OP_STR[ast.operator] || '=';
+    // `BINARY_OP_STR.get(...)` returns `undefined` when the operator value
+    // doesn't exist in the installed Angular's `BinaryOperator` enum (the
+    // enum is missing 13 members on v19, 11 on v20). Falling back to `'='`
+    // would silently produce wrong code; instead, we throw so the error
+    // surfaces in the DEBUG output and the calling test fails loudly.
+    const op = BINARY_OP_STR.get(ast.operator);
+    if (op === undefined) {
+      throw new Error(
+        `[angular-compiler] Unsupported BinaryOperator value ${ast.operator} ` +
+          `on @angular/compiler ${o.VERSION?.full ?? '(unknown version)'}`,
+      );
+    }
 
     const lhsRaw = ast.lhs.visitExpression(this, null);
     const rhsRaw = ast.rhs.visitExpression(this, null);
@@ -277,18 +303,14 @@ class JSEmitter implements o.ExpressionVisitor, o.StatementVisitor {
     const expr = lhs + ' ' + op + ' ' + rhs;
 
     // Wrap assignments in parens so they work correctly as ternary conditions:
-    // (tmp = val) ? a : b  vs  tmp = val ? a : b
+    //   (tmp = val) ? a : b   vs   tmp = val ? a : b
     //
-    // `BinaryOperatorExpr.isAssignment()` was added in a later 20.x patch
-    // (it doesn't exist on Angular 20.0.0). On versions where the method
-    // is missing, fall back to reading `operator` directly. We only emit
-    // `BinaryOperator.Assign` in our compile output (no compound
-    // assignments like += or ??=), so the simplified check is sufficient.
-    const isAssignment =
-      typeof (ast as any).isAssignment === 'function'
-        ? (ast as any).isAssignment()
-        : ast.operator === o.BinaryOperator.Assign;
-    if (isAssignment) {
+    // `isAssignmentOperator` is built at module load time from the operator
+    // names that actually exist on the installed Angular's enum. This
+    // works whether `Assign` is present (v21+) or absent (v19/v20) — on
+    // older versions the assignment branch is simply unreachable because
+    // Angular's compiler never constructs an Assign-operator expression.
+    if (isAssignmentOperator(ast.operator)) {
       return '(' + expr + ')';
     }
     return expr;

--- a/packages/angular-compiler/src/lib/js-emitter.ts
+++ b/packages/angular-compiler/src/lib/js-emitter.ts
@@ -344,25 +344,48 @@ class JSEmitter implements o.ExpressionVisitor, o.StatementVisitor {
     }
     return params + ' => ' + bodyExpr;
   }
+  // `Write*Expr` visitors must wrap the assignment in parentheses so that
+  // it composes correctly when nested inside higher-precedence parents
+  // (e.g. as the test of a `ConditionalExpr`). Without the wrapping,
+  //   tmp = ctx.data() ? 0 : -1
+  // parses as `tmp = (ctx.data() ? 0 : -1)` because assignment binds
+  // looser than the ternary, which silently assigns the wrong value to
+  // `tmp`. Angular's own `AbstractEmitterVisitor.visitWriteVarExpr`
+  // applies the same context-sensitive wrapping (it skips the parens
+  // when the assignment is a top-level statement to avoid `(x = 1);`
+  // noise; we always wrap for simplicity — the redundant parens at
+  // statement level are harmless).
+  //
+  // This matters specifically on Angular v19/v20, where assignment is
+  // represented in the IR via `WriteVarExpr` / `AssignTemporaryExpr →
+  // WriteVarExpr`. On v21+ the same construct is represented via
+  // `BinaryOperatorExpr(Assign, ...)`, which `visitBinaryOperatorExpr`
+  // already wraps via `isAssignmentOperator`. Without these wrappers,
+  // `@if (data(); as item)` and similar conditional alias forms emit
+  // runtime-broken code on v19/v20.
   visitWriteVarExpr(ast: any) {
-    return ast.name + ' = ' + ast.value.visitExpression(this, null);
+    return '(' + ast.name + ' = ' + ast.value.visitExpression(this, null) + ')';
   }
   visitWritePropExpr(ast: any) {
     return (
+      '(' +
       ast.receiver.visitExpression(this, null) +
       '.' +
       ast.name +
       ' = ' +
-      ast.value.visitExpression(this, null)
+      ast.value.visitExpression(this, null) +
+      ')'
     );
   }
   visitWriteKeyExpr(ast: any) {
     return (
+      '(' +
       ast.receiver.visitExpression(this, null) +
       '[' +
       ast.index.visitExpression(this, null) +
       '] = ' +
-      ast.value.visitExpression(this, null)
+      ast.value.visitExpression(this, null) +
+      ')'
     );
   }
   visitInvokeMethodExpr(ast: any) {


### PR DESCRIPTION
## PR Checklist

The Angular Compiler compatibility matrix initially failed on every numeric matrix slot (v19, v20) plus the prerelease slot (next). Investigation revealed that the `peerDependencies` claim of `>=19.0.0` was aspirational — the implementation depended on Angular v21+-only API surface in several places, silently corrupting compiled output on older versions.

This PR makes the matrix green for v19, v20, v21, and 22-next via three production fixes and two test gates, then re-enables the auto-triggers and auto-issue creation that were held off during initial matrix validation.

Closes #

## Affected scope

- Primary scope: `angular-compiler`
- Secondary scopes: `ci`

## Recommended merge strategy for maintainer [optional]

- [ ] Squash merge
- [x] Rebase merge
- [ ] Other

## Commit preservation note

Each commit fixes a distinct cross-version Angular API drift point with root-cause analysis in the message:

1. **\`fix: defensive BinaryOperator map for v19/v20\`** — Angular's \`BinaryOperator\` enum is missing 13 members on v19 and 11 on v20 (no \`Assign\`, no compound assignments, no \`InstanceOf\`, etc.). The previous map definition collided all undefined entries on the \`[undefined]\` key, so every assignment silently emitted \`??=\` instead of \`=\` on older Angular.
2. **\`fix: set componentMeta.interpolation for partial mode on v19/v20\`** — Angular v19/v20's \`createComponentDefinitionMap\` reads \`meta.interpolation.start\` unconditionally; v21+ dropped the field entirely. Crashed every \`partial.spec.ts > @Component > *\` test on v19/v20 inside Angular's own emitter at \`compiler.mjs:33106\`.
3. **\`fix: wrap Write*Expr emissions in parens\`** — \`WriteVarExpr\` was emitting unwrapped \`tmp = value\` strings, breaking operator precedence when nested as a conditional test. Silently broke \`@if (data(); as item)\` at runtime on v19/v20. Hidden on v21+ because v21+ uses \`BinaryOperatorExpr(Assign, ...)\` which our visitor already wraps via \`isAssignmentOperator\`.
4. **\`test: gate v20+-only feature tests on ANGULAR_MAJOR\`** — \`@defer\` dynamic-import ABI tests assert a runtime shape that didn't exist on v19; the \`??\` operator precedence test asserts a literal \`??\` that v19 polyfills to a longer ternary chain.
5. **\`test: gate OnPush changeDetection assertion on Angular <=21\`** — Angular 22-next inverts the \`changeDetection\` default to \`OnPush\`, so the field is omitted from \`ɵɵdefineComponent\` output for OnPush components (it's the new default). Confirmed in \`@angular/compiler@22.0.0-next.7\` at \`compiler.mjs:25363\` and \`27020\`.
6. **\`ci: re-enable auto-triggers and auto-issue creation\`** — Now that the matrix is green, re-enable \`pull_request\` + \`push: { branches: [beta] }\` triggers and the regression-issue auto-open step.

Bisecting future Angular-version regressions on any of these is meaningfully easier with the boundaries preserved. Squash-merging would collapse them into one commit and lose the per-fix root-cause analysis.

## What is the new behavior?

\`@analogjs/angular-compiler\` now works correctly on Angular 19, 20, 21, and 22-next. The \`peerDependencies\` claim of \`>=19.0.0\` is now real instead of aspirational.

Specifically:

- **v19/v20:** assignment expressions no longer silently emit \`??=\` instead of \`=\`
- **v19/v20:** partial-mode compilation no longer crashes inside Angular's own emitter at \`createComponentDefinitionMap\`
- **v19/v20:** \`@if (data(); as item)\` no longer silently breaks at runtime due to operator precedence in the temp-var assignment
- **v22-next:** the OnPush-default test no longer assumes v21- semantics

The compatibility matrix workflow now runs automatically on PRs touching \`packages/angular-compiler/**\` or root \`package.json\`, and on direct beta pushes. Failures on beta auto-open (or comment on) a tracking issue using the bug-report template structure.

## Test plan

- [x] \`npx vitest run packages/angular-compiler/src/lib/\` on workspace pin (Angular 21.2.7) → **587 passing**
- [x] Compatibility matrix on \`@angular/compiler@19.0.0\` → green
- [x] Compatibility matrix on \`@angular/compiler@20.0.0\` → green
- [x] Compatibility matrix on \`@angular/compiler@21.0.0\` → green
- [x] Compatibility matrix on \`@angular/compiler@next\` (22.0.0-next.7) → green
- [x] Manual verification: read each Angular version's \`compiler.mjs\` source directly to confirm the root causes (scratch installs at \`/tmp/angular{19,20,21,next}-check\`)

The PR's own \`pull_request\` trigger (re-enabled in commit 6) will run the matrix as part of the PR check.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This PR strictly fixes existing user-facing brokenness on v19/v20. No public API changes. The only behavior change for v21+ users is paren-wrapping of \`Write*Expr\` outputs at statement level (e.g., \`(x = 1);\` instead of \`x = 1;\`), which is functionally identical.

## Other information

Each fix commit message includes the specific Angular \`compiler.mjs\` line numbers where the API drift occurs, for future maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)