### PR TITLE
fix(vite-plugin-angular): use virtual modules for external JIT styles

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1,4 +1,6 @@
+import * as path from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
+import { normalizePath, preprocessCSS } from 'vite';
 
 vi.mock('vite', async () => {
   const actual = await vi.importActual<typeof import('vite')>('vite');
@@ -67,7 +69,7 @@ describe('isTestWatchMode', () => {
 });
 
 describe('JIT resolveId', () => {
-  it('should resolve style files with ?analog-inline suffix', () => {
+  it('should resolve style files to virtual style ids', () => {
     const plugins = angular({ jit: true });
     const mainPlugin = plugins.find(
       (p) => p.name === '@analogjs/vite-plugin-angular',
@@ -82,8 +84,10 @@ describe('JIT resolveId', () => {
       '/project/src/app/my-component.ts',
     );
 
-    expect(result).toBeDefined();
-    expect(result).toContain('?analog-inline');
+    expect(result).toContain(
+      'virtual:@analogjs/vite-plugin-angular:inline-style:',
+    );
+    expect(result).not.toContain('?analog-inline');
     expect(result).not.toContain('?inline');
   });
 
@@ -105,6 +109,20 @@ describe('JIT resolveId', () => {
     expect(result).toBeDefined();
     expect(result).toContain('?analog-raw');
     expect(result).not.toContain('??analog-raw');
+  });
+
+  it('should resolve bare virtual style ids to rollup virtual modules', () => {
+    const plugins = angular({ jit: true });
+    const mainPlugin = plugins.find(
+      (p) => p.name === '@analogjs/vite-plugin-angular',
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const resolveId = (mainPlugin as any).resolveId;
+    const virtualId =
+      'virtual:@analogjs/vite-plugin-angular:inline-style:test-style-id';
+
+    expect(resolveId(virtualId)).toBe(`\0${virtualId}`);
   });
 
   it('should intercept .html?raw imports and remap to ?analog-raw', () => {
@@ -152,20 +170,24 @@ describe('JIT resolveId', () => {
     );
 
     const resolveId = (mainPlugin as any).resolveId;
+    const importer = '/project/src/app/my-component.ts';
+    const expectedScssPath = `${normalizePath(
+      path.resolve(path.dirname(importer), './my-component.scss'),
+    )}?analog-inline`;
+    const expectedCssPath = `${normalizePath(
+      '/project/src/app/my-component.css',
+    )}?analog-inline`;
 
     // Relative .scss?inline
-    const result = resolveId(
-      './my-component.scss?inline',
-      '/project/src/app/my-component.ts',
-    );
-    expect(result).toBe('/project/src/app/my-component.scss?analog-inline');
+    const result = resolveId('./my-component.scss?inline', importer);
+    expect(result).toBe(expectedScssPath);
 
     // Absolute .css?inline
     const result2 = resolveId(
       '/project/src/app/my-component.css?inline',
       '/project/src/app/other.ts',
     );
-    expect(result2).toBe('/project/src/app/my-component.css?analog-inline');
+    expect(result2).toBe(expectedCssPath);
   });
 
   it('should intercept style ?inline imports even without jit mode', () => {
@@ -198,17 +220,33 @@ describe('JIT resolveId', () => {
     );
     expect(inlineRE.test(result)).toBe(false);
   });
+
+  it('should emit virtual style ids that do not look like stylesheet resources', () => {
+    const cssLangRE =
+      /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)($|\?)/;
+    const plugins = angular({ jit: true });
+    const mainPlugin = plugins.find(
+      (p) => p.name === '@analogjs/vite-plugin-angular',
+    );
+
+    const resolveId = (mainPlugin as any).resolveId;
+    const virtualId = resolveId(
+      'angular:jit:style:file;./my-component.scss',
+      '/project/src/app/my-component.ts',
+    );
+
+    expect(cssLangRE.test(virtualId)).toBe(false);
+  });
 });
 
 describe('load ?inline style imports', () => {
   // Vitest's fetchModule path calls moduleGraph.ensureEntryFromUrl before
   // transformRequest, which makes pluginContainer.resolveId a no-op for the
-  // module-runner. The resolveId rewrite to ?analog-inline therefore never
-  // runs in tests, and the load hook must accept the original ?inline query
-  // directly. (See issue #2263.)
+  // module-runner. Direct ?inline imports therefore bypass the resolveId
+  // rewrites in tests, and the load hook must still accept the original
+  // query directly. (See issue #2263.)
   const realFs = require('node:fs');
   const tmpDir = require('node:os').tmpdir();
-  const path = require('node:path');
 
   function getLoadHook() {
     const plugins = angular();
@@ -217,6 +255,37 @@ describe('load ?inline style imports', () => {
     );
     return (mainPlugin as any).load.bind({});
   }
+
+  it('handles virtual style imports and watches the backing file', async () => {
+    const cssPath = path.join(tmpDir, `analog-virtual-${Date.now()}.scss`);
+    realFs.writeFileSync(cssPath, '.foo { color: red; }', 'utf-8');
+
+    try {
+      const plugins = angular({ jit: true });
+      const mainPlugin = plugins.find(
+        (p) => p.name === '@analogjs/vite-plugin-angular',
+      );
+
+      const resolveId = (mainPlugin as any).resolveId;
+      const addWatchFile = vi.fn();
+      const load = (mainPlugin as any).load.bind({ addWatchFile });
+      const virtualId = resolveId(
+        `angular:jit:style:file;./${path.basename(cssPath)}`,
+        path.join(tmpDir, 'host.component.ts'),
+      );
+      const result = await load(virtualId);
+
+      expect(result).toBeDefined();
+      expect(result).toContain('export default');
+      expect(result).toContain('color: red');
+      expect(addWatchFile).toHaveBeenCalledWith(normalizePath(cssPath));
+
+      const calls = vi.mocked(preprocessCSS).mock.calls;
+      expect(calls[calls.length - 1][1]).toBe(normalizePath(cssPath));
+    } finally {
+      realFs.unlinkSync(cssPath);
+    }
+  });
 
   it('handles ?inline style imports without going through resolveId', async () => {
     const cssPath = path.join(tmpDir, `analog-inline-${Date.now()}.css`);

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -120,6 +120,31 @@ interface DeclarationFile {
   data: string;
 }
 
+const VIRTUAL_STYLE_PREFIX =
+  'virtual:@analogjs/vite-plugin-angular:inline-style:';
+
+function toVirtualStyleId(absPath: string): string {
+  return `${VIRTUAL_STYLE_PREFIX}${Buffer.from(absPath, 'utf-8').toString(
+    'base64url',
+  )}`;
+}
+
+function isVirtualStyleId(id: string): boolean {
+  return id.replace(/^\0/, '').startsWith(VIRTUAL_STYLE_PREFIX);
+}
+
+function fromVirtualStyleId(id: string): string {
+  const normalizedId = id.replace(/^\0/, '');
+  if (!normalizedId.startsWith(VIRTUAL_STYLE_PREFIX)) {
+    throw new Error(`Invalid virtual style id: ${id}`);
+  }
+
+  return Buffer.from(
+    normalizedId.slice(VIRTUAL_STYLE_PREFIX.length),
+    'base64url',
+  ).toString('utf-8');
+}
+
 export function angular(options?: PluginOptions): Plugin[] {
   /**
    * Normalize plugin options so defaults
@@ -373,6 +398,21 @@ export function angular(options?: PluginOptions): Plugin[] {
 
         if (/\.(html|htm|css|less|sass|scss)$/.test(ctx.file)) {
           fileTransformMap.delete(ctx.file.split('?')[0]);
+
+          // Virtual style modules (used for JIT external styleUrls) are not
+          // found by moduleGraph.getModulesByFile because their module id is
+          // a virtual prefix, not the real file path. Look up the virtual
+          // module manually and include it so HMR propagation works.
+          const virtualStyleId = `\0${toVirtualStyleId(
+            normalizePath(ctx.file),
+          )}`;
+          const virtualMod =
+            ctx.server.moduleGraph.getModuleById(virtualStyleId);
+          if (virtualMod && !ctx.modules.includes(virtualMod)) {
+            ctx.server.moduleGraph.invalidateModule(virtualMod);
+            ctx.modules.push(virtualMod);
+          }
+
           /**
            * Check to see if this was a direct request
            * for an external resource (styles, html).
@@ -475,11 +515,17 @@ export function angular(options?: PluginOptions): Plugin[] {
         return ctx.modules;
       },
       resolveId(id, importer) {
+        if (id.startsWith(VIRTUAL_STYLE_PREFIX)) {
+          return `\0${id}`;
+        }
+
         if (jit && id.startsWith('angular:jit:')) {
-          const path = id.split(';')[1];
-          return `${normalizePath(
-            resolve(dirname(importer as string), path),
-          )}?${id.includes(':style') ? 'analog-inline' : 'analog-raw'}`;
+          const filePath = normalizePath(
+            resolve(dirname(importer as string), id.split(';')[1]),
+          );
+          return id.includes(':style')
+            ? toVirtualStyleId(filePath)
+            : `${filePath}?analog-raw`;
         }
 
         // Intercept .html?raw imports to bypass Vite 7.3.2+ server.fs restrictions
@@ -526,6 +572,14 @@ export function angular(options?: PluginOptions): Plugin[] {
         return undefined;
       },
       async load(id) {
+        if (isVirtualStyleId(id)) {
+          const filePath = fromVirtualStyleId(id);
+          this.addWatchFile(filePath);
+          const code = await fsPromises.readFile(filePath, 'utf-8');
+          const result = await preprocessCSS(code, filePath, resolvedConfig);
+          return `export default ${JSON.stringify(result.code)}`;
+        }
+
         // Handle Angular template raw imports directly to bypass Vite server.fs
         // restrictions on ?raw query parameters (Vite 7.3.2+)
         if (id.endsWith('?analog-raw')) {
@@ -708,10 +762,11 @@ export function angular(options?: PluginOptions): Plugin[] {
               'virtual:angular:jit:style:inline;',
             );
 
-            // Emit ?analog-raw and ?analog-inline directly (instead of
-            // ?raw / ?inline) so the import ids in the compiled JS never
-            // match Vite 8.0.5+'s [?&](raw|inline)\b security regex during
-            // loadAndTransform.
+            // Emit safe resource ids directly in the transformed JS so Vite
+            // never sees the dangerous ?raw / ?inline form during
+            // loadAndTransform. Templates still use ?analog-raw, while
+            // external styles now use virtual module ids with no stylesheet
+            // extension to avoid vite:css re-processing.
             //
             // Why this matters: Vite's Denied ID check fires for any id
             // matching that regex whose path is outside server.fs.allow,
@@ -719,12 +774,12 @@ export function angular(options?: PluginOptions): Plugin[] {
             // fetchModule path also bypasses pluginContainer.resolveId
             // (it calls moduleGraph.ensureEntryFromUrl first, which makes
             // the resolveId chain a no-op for the module-runner). So
-            // neither the resolveId-based ?inline -> ?analog-inline rewrite
-            // nor the load-hook fallback (added in 2.4.4) gets a chance to
-            // run for cross-library imports — the security check has
-            // already thrown by then. Emitting the safe query directly in
-            // the transform output is the only place we can guarantee Vite
-            // never sees the dangerous form. (#2263)
+            // neither the resolveId-based rewrites nor the load-hook
+            // fallback (added in 2.4.4) get a chance to run for
+            // cross-library imports — the security check has already thrown
+            // by then. Emitting the safe ids directly in transform is the
+            // only place we can guarantee Vite never sees the dangerous
+            // form. (#2263)
             templateUrls.forEach((templateUrlSet) => {
               const [templateFile, resolvedTemplateUrl] =
                 templateUrlSet.split('|');
@@ -738,7 +793,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               const [styleFile, resolvedStyleUrl] = styleUrlSet.split('|');
               data = data.replace(
                 `angular:jit:style:file;${styleFile}`,
-                `${resolvedStyleUrl}?analog-inline`,
+                toVirtualStyleId(resolvedStyleUrl),
               );
             });
           }


### PR DESCRIPTION
## PR Checklist

In JIT mode (used implicitly by Vitest browser module-runner), external `styleUrl` / `styleUrls` imports were rewritten to ids like `/path/to/component.scss?analog-inline`. That id still resembles a stylesheet resource to Vite, so `vite:css` re-entered after this plugin's `load()` hook had already called `preprocessCSS()` and returned a JavaScript module (`export default "..."`). For external `.scss` / `.sass` / `.less` styles, this caused the CSS pipeline to try compiling JavaScript as stylesheet source — see the error trace and minimal reproduction in the issue.

Closes #2280

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

This change routes external JIT style-file imports through virtual module ids instead: `virtual:@analogjs/vite-plugin-angular:inline-style:<base64url-encoded-absolute-path>`. That keeps the final id opaque to Vite's CSS pipeline while preserving the existing JIT contract:

- `transform` rewrites `angular:jit:style:file;...` imports to the new virtual id
- `resolveId` maps that virtual prefix to a `\0`-prefixed Rollup virtual module id
- `load` decodes the path, reads the stylesheet, runs `preprocessCSS()`, and returns `export default "..."`
- `handleHotUpdate` now manually finds and invalidates the corresponding virtual style module so HMR / live-reload propagation still works when the backing stylesheet changes

Only the external JIT style-file path is changed. The existing inline JIT style path (`angular:jit:style:inline`) is unchanged and still goes through the existing `virtual:angular:jit:style:inline;...` flow.

## Test plan

- [x] `nx format:check`
- [x] `pnpm build`
- [~] `pnpm test` — three unrelated Windows-only test failures remain due to platform-sensitive path assertions, and all are path-normalization issues rather than regressions from this change. I verified locally that these assertions pass once the expected paths are normalized for Windows as well. If maintainers want, I can add those path-normalization adjustments in a follow-up or fold them into this PR.
- [x] Manual verification — browser repro passed with the locally built `@analogjs/vite-plugin-angular`

Targeted coverage added/updated in `angular-vite-plugin.spec.ts`:

- `resolveId` asserts the new virtual-id contract for external JIT styles
- virtual ids resolve to `\0`-prefixed Rollup virtual modules
- virtual ids do not match the stylesheet-resource regex that would send them back through Vite's CSS pipeline
- `load` roundtrip verifies virtual-id resolution back to the source file, then `readFile` -> `preprocessCSS()` -> `export default`
- existing `?inline` and rewritten `?analog-inline` load-hook compatibility paths are both covered

A dedicated `transform` unit test was not added because that path is tightly coupled to Angular compilation state and would require heavier integration-style mocking than the rest of this spec file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

`experimental.useAnalogCompiler` is intentionally untouched for scope control. The default `angular-vite-plugin` path is fixed here, but there may be a similar issue in the experimental compiler path. I can investigate and follow up with a parity fix separately if wanted.