### PR TITLE
fix(vite-plugin-angular): use virtual module IDs for inline style imports

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -67,7 +67,7 @@ describe('isTestWatchMode', () => {
 });
 
 describe('JIT resolveId', () => {
-  it('should resolve style files with ?analog-inline suffix', () => {
+  it('should resolve style files as virtual analog-inline module', () => {
     const plugins = angular({ jit: true });
     const mainPlugin = plugins.find(
       (p) => p.name === '@analogjs/vite-plugin-angular',
@@ -83,8 +83,10 @@ describe('JIT resolveId', () => {
     );
 
     expect(result).toBeDefined();
-    expect(result).toContain('?analog-inline');
+    expect(result).toContain('\0analog-inline:');
     expect(result).not.toContain('?inline');
+    // Extension is moved into the prefix, not at the end
+    expect(result).not.toMatch(/\.scss$/);
   });
 
   it('should resolve template files with ?analog-raw suffix', () => {
@@ -145,7 +147,7 @@ describe('JIT resolveId', () => {
     expect(result).toContain('?analog-raw');
   });
 
-  it('should intercept style ?inline imports and remap to ?analog-inline', () => {
+  it('should intercept style ?inline imports and remap to virtual analog-inline', () => {
     const plugins = angular({ jit: true });
     const mainPlugin = plugins.find(
       (p) => p.name === '@analogjs/vite-plugin-angular',
@@ -158,14 +160,14 @@ describe('JIT resolveId', () => {
       './my-component.scss?inline',
       '/project/src/app/my-component.ts',
     );
-    expect(result).toBe('/project/src/app/my-component.scss?analog-inline');
+    expect(result).toBe('\0analog-inline:scss:/project/src/app/my-component');
 
     // Absolute .css?inline
     const result2 = resolveId(
       '/project/src/app/my-component.css?inline',
       '/project/src/app/other.ts',
     );
-    expect(result2).toBe('/project/src/app/my-component.css?analog-inline');
+    expect(result2).toBe('\0analog-inline:css:/project/src/app/my-component');
   });
 
   it('should intercept style ?inline imports even without jit mode', () => {
@@ -180,10 +182,10 @@ describe('JIT resolveId', () => {
       './my-component.scss?inline',
       '/project/src/app/my-component.ts',
     );
-    expect(result).toContain('?analog-inline');
+    expect(result).toContain('\0analog-inline:');
   });
 
-  it('should not match Vite inline security regex /[?&]inline\\b/', () => {
+  it('should not match Vite inline security regex or cssLangRE', () => {
     const plugins = angular();
     const mainPlugin = plugins.find(
       (p) => p.name === '@analogjs/vite-plugin-angular',
@@ -191,12 +193,15 @@ describe('JIT resolveId', () => {
 
     const resolveId = (mainPlugin as any).resolveId;
     const inlineRE = /[?&]inline\b/;
+    const cssLangRE =
+      /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/;
 
     const result = resolveId(
       './my-component.scss?inline',
       '/project/src/app/my-component.ts',
     );
     expect(inlineRE.test(result)).toBe(false);
+    expect(cssLangRE.test(result)).toBe(false);
   });
 });
 
@@ -233,13 +238,17 @@ describe('load ?inline style imports', () => {
     }
   });
 
-  it('still handles the rewritten ?analog-inline query', async () => {
+  it('handles the virtual \\0analog-inline module id', async () => {
     const cssPath = path.join(tmpDir, `analog-rewrite-${Date.now()}.css`);
     realFs.writeFileSync(cssPath, '.bar { color: blue; }', 'utf-8');
 
     try {
       const load = getLoadHook();
-      const result = await load(`${cssPath}?analog-inline`);
+      // Build the virtual id: \0analog-inline:css:/path/to/file (no extension)
+      const ext = path.extname(cssPath).slice(1);
+      const base = cssPath.slice(0, -(ext.length + 1));
+      const virtualId = `\0analog-inline:${ext}:${base}`;
+      const result = await load(virtualId);
       expect(result).toBeDefined();
       expect(result).toContain('export default');
       expect(result).toContain('color: blue');

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -56,6 +56,11 @@ import {
   angularFullVersion,
 } from './utils/devkit.js';
 import { type SourceFileCache as SourceFileCacheType } from './utils/source-file-cache.js';
+import {
+  toAnalogInlineRequest,
+  resolveAnalogInlineId,
+  fromAnalogInlineId,
+} from './utils/analog-inline-id.js';
 
 const require = createRequire(import.meta.url);
 
@@ -509,11 +514,22 @@ export function angular(options?: PluginOptions): Plugin[] {
         return ctx.modules;
       },
       resolveId(id, importer) {
+        // Resolve analog-inline: request specifiers (emitted by the
+        // transform hook) to \0-prefixed virtual module IDs.
+        const analogResolved = resolveAnalogInlineId(id);
+        if (analogResolved) {
+          return analogResolved;
+        }
+
         if (jit && id.startsWith('angular:jit:')) {
           const path = id.split(';')[1];
-          return `${normalizePath(
+          const resolved = normalizePath(
             resolve(dirname(importer as string), path),
-          )}?${id.includes(':style') ? 'analog-inline' : 'analog-raw'}`;
+          );
+          if (id.includes(':style')) {
+            return resolveAnalogInlineId(toAnalogInlineRequest(resolved));
+          }
+          return resolved + '?analog-raw';
         }
 
         // Intercept .html?raw imports to bypass Vite 7.3.2+ server.fs restrictions
@@ -532,9 +548,8 @@ export function angular(options?: PluginOptions): Plugin[] {
         }
 
         // Intercept style ?inline imports to bypass Vite 8.0.5+ server.fs
-        // restrictions. Vite's security check matches /[?&]inline\b/ so we
-        // use ?analog-inline which avoids the regex while we handle CSS
-        // preprocessing and inline export ourselves in the load hook.
+        // restrictions. Route through a virtual module so Vite's vite:css
+        // plugin does not re-process the already-compiled JS export.
         if (/\.(css|scss|sass|less)\?inline$/.test(id)) {
           const filePath = id.split('?')[0];
           const resolved = isAbsolute(filePath)
@@ -543,7 +558,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               ? normalizePath(resolve(dirname(importer), filePath))
               : undefined;
           if (resolved) {
-            return resolved + '?analog-inline';
+            return resolveAnalogInlineId(toAnalogInlineRequest(resolved));
           }
         }
 
@@ -572,20 +587,18 @@ export function angular(options?: PluginOptions): Plugin[] {
         // server.fs security check which blocks IDs matching /[?&]inline\b/.
         // Compile via preprocessCSS and return as inline string export.
         //
-        // We accept both ?analog-inline (rewritten by resolveId for the
-        // browser dev-server path) and ?inline (the original query) because
-        // Vitest's fetchModule path calls moduleGraph.ensureEntryFromUrl
-        // before transformRequest, which means pluginContainer.resolveId is
-        // never invoked for module-runner imports — so the resolveId-based
-        // rewrite never runs in the test path. Handling ?inline here covers
-        // both paths.
-        if (
-          id.includes('?analog-inline') ||
-          /\.(css|scss|sass|less)\?inline$/.test(id)
-        ) {
-          const filePath = id.split('?')[0];
-          const code = await fsPromises.readFile(filePath, 'utf-8');
-          const result = await preprocessCSS(code, filePath, resolvedConfig);
+        // Virtual \0analog-inline IDs are produced by resolveId for the
+        // browser dev-server path. We also accept ?inline (the original
+        // query) because Vitest's fetchModule path calls
+        // moduleGraph.ensureEntryFromUrl before transformRequest, which
+        // means pluginContainer.resolveId is never invoked for
+        // module-runner imports — so the resolveId-based rewrite never
+        // runs in the test path. Handling ?inline here covers both paths.
+        const filePath = fromAnalogInlineId(id);
+        if (filePath || /\.(css|scss|sass|less)\?inline$/.test(id)) {
+          const cssPath = filePath || id.split('?')[0];
+          const code = await fsPromises.readFile(cssPath, 'utf-8');
+          const result = await preprocessCSS(code, cssPath, resolvedConfig);
           return `export default ${JSON.stringify(result.code)}`;
         }
 
@@ -757,7 +770,7 @@ export function angular(options?: PluginOptions): Plugin[] {
               const [styleFile, resolvedStyleUrl] = styleUrlSet.split('|');
               data = data.replace(
                 `angular:jit:style:file;${styleFile}`,
-                `${resolvedStyleUrl}?analog-inline`,
+                toAnalogInlineRequest(resolvedStyleUrl),
               );
             });
           }

--- a/packages/vite-plugin-angular/src/lib/utils/analog-inline-id.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/analog-inline-id.ts
@@ -1,0 +1,56 @@
+import { extname } from 'node:path';
+
+/**
+ * Request prefix used in source code (import statements).
+ * Does NOT include the \0 virtual-module marker because \0 is
+ * invalid inside import specifiers — Vite's import-analysis
+ * plugin strips it and then cannot resolve the remaining path.
+ */
+const ANALOG_INLINE_REQUEST = 'analog-inline:';
+
+/**
+ * Resolved prefix returned from resolveId.  The \0 marks it as
+ * a Rollup virtual module so other plugins (including vite:css)
+ * skip it.
+ */
+const ANALOG_INLINE_RESOLVED = '\0analog-inline:';
+
+/**
+ * Build an import specifier for use in transformed source code.
+ * The stylesheet extension is moved into the prefix so the final
+ * specifier does not end with a CSS extension — this prevents
+ * Vite's vite:css plugin (cssLangRE) from matching.
+ *
+ * Format: analog-inline:scss:/absolute/path/to/foo.component
+ */
+export function toAnalogInlineRequest(filePath: string): string {
+  const ext = extname(filePath).slice(1);
+  const base = filePath.slice(0, -(ext.length + 1));
+  return `${ANALOG_INLINE_REQUEST}${ext}:${base}`;
+}
+
+/**
+ * If `id` is an analog-inline request (emitted by the transform
+ * hook), return the \0-prefixed resolved virtual module ID.
+ */
+export function resolveAnalogInlineId(id: string): string | undefined {
+  if (!id.startsWith(ANALOG_INLINE_REQUEST)) {
+    return undefined;
+  }
+  return `\0${id}`;
+}
+
+/**
+ * Parse a resolved \0analog-inline virtual module ID back to the
+ * original file path.  Returns undefined if the ID is not one.
+ */
+export function fromAnalogInlineId(id: string): string | undefined {
+  if (!id.startsWith(ANALOG_INLINE_RESOLVED)) {
+    return undefined;
+  }
+  const rest = id.slice(ANALOG_INLINE_RESOLVED.length);
+  const colonIdx = rest.indexOf(':');
+  const ext = rest.slice(0, colonIdx);
+  const base = rest.slice(colonIdx + 1);
+  return `${base}.${ext}`;
+}


### PR DESCRIPTION
## PR Checklist

Closes #2280

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Inline style imports now use `\0`-prefixed virtual module IDs with the stylesheet extension moved out of the trailing position. This prevents Vite's `vite:css` plugin (`cssLangRE`) from matching and double-processing the already-compiled JS export.

The transform hook emits `analog-inline:ext:path` request specifiers (without `\0`) in import statements, then `resolveId` maps them to `\0analog-inline:ext:path` virtual modules that the `load` hook serves. This two-step approach is necessary because `\0` is invalid inside import specifiers — Vite's import-analysis plugin strips it and cannot resolve the remaining path.

The shared helper functions (`toAnalogInlineRequest`, `resolveAnalogInlineId`, `fromAnalogInlineId`) are extracted into `utils/analog-inline-id.ts`.

## Test plan

- [x] `nx test vite-plugin-angular` — 58 tests pass
- [x] Manual verification against [issue repro](https://github.com/kSherp/analog-repro) — browser test passes
- [x] Manual verification with Storybook project — `test-storybook` (9 tests pass), `build-storybook`, and `storybook` dev server all work without errors

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The previous `?analog-inline` suffix (introduced in 2.4.x to bypass Vite 8.0.5+ `server.fs` security checks) kept the `.scss` extension at the end of the resolved ID. Vite's `cssLangRE` (`/\.(scss|...)(?:$|\?)/`) matched this and fed the already-compiled JS string to Sass, causing `expected "{"` errors in browser-mode Vitest.