### PR TITLE
fix(angular-compiler): make hoisting dependency-aware to prevent TDZ

### DIFF
--- a/packages/angular-compiler/src/lib/compile.ts
+++ b/packages/angular-compiler/src/lib/compile.ts
@@ -123,12 +123,20 @@ function hasExportModifier(node: ts.Node): boolean {
   );
 }
 
-/** Collect all identifier names referenced in a node's subtree. */
+/**
+ * Collect identifier names referenced in eagerly-evaluated code only.
+ * Skips function/arrow/class bodies so that lazy references
+ * (e.g. `const TOKEN = () => LaterClass`) are not treated as dependencies.
+ */
 function collectIdentifiers(node: ts.Node): Set<string> {
   const ids = new Set<string>();
   function walk(n: ts.Node) {
     if (ts.isIdentifier(n)) {
       ids.add(n.text);
+    }
+    // Stop recursing into lazily-evaluated scopes
+    if (ts.isFunctionLike(n) || ts.isClassLike(n)) {
+      return;
     }
     ts.forEachChild(n, walk);
   }

--- a/packages/angular-compiler/src/lib/compile.ts
+++ b/packages/angular-compiler/src/lib/compile.ts
@@ -123,6 +123,53 @@ function hasExportModifier(node: ts.Node): boolean {
   );
 }
 
+/** Collect all identifier names referenced in a node's subtree. */
+function collectIdentifiers(node: ts.Node): Set<string> {
+  const ids = new Set<string>();
+  function walk(n: ts.Node) {
+    if (ts.isIdentifier(n)) {
+      ids.add(n.text);
+    }
+    ts.forEachChild(n, walk);
+  }
+  ts.forEachChild(node, walk);
+  return ids;
+}
+
+/** Extract the names defined by a top-level statement. */
+function getDefinedNames(stmt: ts.Statement): string[] {
+  if (ts.isVariableStatement(stmt)) {
+    const names: string[] = [];
+    for (const decl of stmt.declarationList.declarations) {
+      collectBindingNames(decl.name, names);
+    }
+    return names;
+  }
+  if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+    return [stmt.name.text];
+  }
+  if (ts.isClassDeclaration(stmt) && stmt.name) {
+    return [stmt.name.text];
+  }
+  return [];
+}
+
+/** Recursively collect all bound identifiers from a binding name/pattern. */
+function collectBindingNames(name: ts.BindingName, out: string[]): void {
+  if (ts.isIdentifier(name)) {
+    out.push(name.text);
+  } else if (
+    ts.isObjectBindingPattern(name) ||
+    ts.isArrayBindingPattern(name)
+  ) {
+    for (const el of name.elements) {
+      if (!ts.isOmittedExpression(el)) {
+        collectBindingNames(el.name, out);
+      }
+    }
+  }
+}
+
 export function compile(
   sourceCode: string,
   fileName: string,
@@ -1173,25 +1220,84 @@ export function compile(
   // 2a. Hoist non-exported variable/function declarations that appear after
   // a class to just before the first class. This avoids TDZ errors when
   // static ɵcmp references file-level constants declared after the class.
+  //
+  // We must NOT hoist a statement whose initializer references a name
+  // (class, exported const/let) that is defined between firstClassPos and
+  // the statement itself — doing so would move the reference before the
+  // definition and cause a TDZ error at runtime.
   if (classResults.length > 0) {
-    const firstClassStart = classResults[0].classEnd - 1; // approx
-    // Find the position right before the first class
+    // Find the position right before the first class (any class, not just Angular-decorated)
     let firstClassPos = Infinity;
+    const nonHoistableNames = new Set<string>();
     for (const stmt of origSourceFile.statements) {
       if (ts.isClassDeclaration(stmt)) {
         firstClassPos = stmt.getStart(origSourceFile);
+        // The first class itself is non-hoistable — statements hoisted
+        // before it must not reference it.
+        if (stmt.name) {
+          nonHoistableNames.add(stmt.name.text);
+        }
         break;
       }
     }
+
+    // Pass 1: collect names defined by statements that will NOT be hoisted
+    // (classes, exported vars/functions) and therefore remain after firstClassPos.
     for (const stmt of origSourceFile.statements) {
       const stmtStart = stmt.getStart(origSourceFile);
-      // Only hoist statements that come after the first class
       if (stmtStart <= firstClassPos) continue;
-      // Hoist variable statements and function declarations (not exported)
-      const isHoistable =
+
+      if (ts.isClassDeclaration(stmt) && stmt.name) {
+        nonHoistableNames.add(stmt.name.text);
+      }
+      if (ts.isEnumDeclaration(stmt)) {
+        nonHoistableNames.add(stmt.name.text);
+      }
+      if (ts.isVariableStatement(stmt) && hasExportModifier(stmt)) {
+        for (const decl of stmt.declarationList.declarations) {
+          const names: string[] = [];
+          collectBindingNames(decl.name, names);
+          for (const n of names) {
+            nonHoistableNames.add(n);
+          }
+        }
+      }
+      if (
+        ts.isFunctionDeclaration(stmt) &&
+        hasExportModifier(stmt) &&
+        stmt.name
+      ) {
+        nonHoistableNames.add(stmt.name.text);
+      }
+    }
+
+    // Pass 2: for each hoist candidate, check if it references any
+    // non-hoistable name. If it does, skip it and add its own names to the
+    // non-hoistable set (transitivity).
+    for (const stmt of origSourceFile.statements) {
+      const stmtStart = stmt.getStart(origSourceFile);
+      if (stmtStart <= firstClassPos) continue;
+
+      const isCandidate =
         (ts.isVariableStatement(stmt) && !hasExportModifier(stmt)) ||
         (ts.isFunctionDeclaration(stmt) && !hasExportModifier(stmt));
-      if (isHoistable) {
+      if (!isCandidate) continue;
+
+      const referencedIds = collectIdentifiers(stmt);
+      let referencesNonHoistable = false;
+      for (const id of referencedIds) {
+        if (nonHoistableNames.has(id)) {
+          referencesNonHoistable = true;
+          break;
+        }
+      }
+
+      if (referencesNonHoistable) {
+        // Don't hoist — mark this statement's names as non-hoistable too
+        for (const name of getDefinedNames(stmt)) {
+          nonHoistableNames.add(name);
+        }
+      } else {
         const text = stmt.getText(origSourceFile);
         ms.remove(stmtStart, stmt.getEnd());
         ms.appendLeft(firstClassPos, text + '\n');

--- a/packages/angular-compiler/src/lib/component.spec.ts
+++ b/packages/angular-compiler/src/lib/component.spec.ts
@@ -2714,6 +2714,28 @@ describe('Ivy definitions as static class members with TDZ hoisting', () => {
     expect(fullUrlIdx).toBeGreaterThan(classIdx);
   });
 
+  it('hoists a const whose initializer lazily references a later class via arrow function', () => {
+    const result = compile(
+      `
+      import { Component } from '@angular/core';
+
+      @Component({ selector: 'app-test', template: '<p>hi</p>' })
+      export class TestComponent {}
+
+      const TOKEN = () => LaterClass;
+      class LaterClass {}
+      `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    const tokenIdx = result.indexOf('const TOKEN');
+    const classIdx = result.indexOf('class TestComponent');
+    // TOKEN only lazily references LaterClass, so it should be hoisted before the class
+    expect(tokenIdx).toBeGreaterThan(-1);
+    expect(tokenIdx).toBeLessThan(classIdx);
+  });
+
   it('does not hoist a const that references the first class in the file', () => {
     const result = compile(
       `

--- a/packages/angular-compiler/src/lib/component.spec.ts
+++ b/packages/angular-compiler/src/lib/component.spec.ts
@@ -2507,6 +2507,31 @@ describe('Ivy definitions as static class members with TDZ hoisting', () => {
     expect(helperIdx).toBeLessThan(classIdx);
   });
 
+  it('hoists a non-exported const used by a later component providers array', () => {
+    const result = compile(
+      `
+      import { Component, InjectionToken } from '@angular/core';
+      @Component({
+        selector: 'app-test',
+        template: '<p>hi</p>',
+        providers: [{ provide: TOKEN, useValue: 42 }],
+      })
+      export class TestComponent {}
+
+      const TOKEN = new InjectionToken<number>('token');
+      `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    // TOKEN is referenced in the compiled ɵcmp providers — it must be
+    // defined before the class so the static initializer can read it.
+    const tokenIdx = result.indexOf('const TOKEN');
+    const classIdx = result.indexOf('class TestComponent');
+    expect(tokenIdx).toBeGreaterThan(-1);
+    expect(tokenIdx).toBeLessThan(classIdx);
+  });
+
   it('does not hoist exported declarations', () => {
     const result = compile(
       `
@@ -2524,6 +2549,195 @@ describe('Ivy definitions as static class members with TDZ hoisting', () => {
     const classIdx = result.indexOf('class TestComponent');
     const tokenIdx = result.indexOf('SOME_TOKEN');
     expect(tokenIdx).toBeGreaterThan(classIdx);
+  });
+
+  it('does not hoist a const that instantiates a class defined after the first class', () => {
+    const result = compile(
+      `
+      import { Injectable } from '@angular/core';
+      @Injectable({ providedIn: 'root' })
+      export class AppService {}
+
+      class Converter<A, B> {
+        private map = new Map<A, B>();
+        add(a: A, b: B) { this.map.set(a, b); return this; }
+      }
+
+      const typeConverter = new Converter<string, number>().add('x', 1);
+      `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    // Converter class must appear before the const that instantiates it
+    const converterClassIdx = result.indexOf('class Converter');
+    const converterConstIdx = result.indexOf('const typeConverter');
+    expect(converterClassIdx).toBeGreaterThan(-1);
+    expect(converterConstIdx).toBeGreaterThan(-1);
+    expect(converterClassIdx).toBeLessThan(converterConstIdx);
+  });
+
+  it('still hoists a simple const with no class dependencies', () => {
+    const result = compile(
+      `
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-test', template: '<p>hi</p>' })
+      export class TestComponent {}
+
+      const utilFn = () => 'hello';
+      `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    const utilIdx = result.indexOf('const utilFn');
+    const classIdx = result.indexOf('class TestComponent');
+    expect(utilIdx).toBeGreaterThan(-1);
+    expect(utilIdx).toBeLessThan(classIdx);
+  });
+
+  it('does not hoist a const that transitively depends on a non-hoistable class', () => {
+    const result = compile(
+      `
+      import { Injectable } from '@angular/core';
+      @Injectable({ providedIn: 'root' })
+      export class AppService {}
+
+      class Settings { defaultLimit = 50; }
+      const cfg = new Settings();
+      const cfgLimit = cfg.defaultLimit;
+      `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    // cfg references Settings (a class after the first class), so it must not be hoisted.
+    // cfgLimit references cfg, so it must not be hoisted either.
+    const settingsIdx = result.indexOf('class Settings');
+    const cfgIdx = result.indexOf('const cfg');
+    const cfgLimitIdx = result.indexOf('const cfgLimit');
+    expect(settingsIdx).toBeGreaterThan(-1);
+    expect(cfgIdx).toBeGreaterThan(-1);
+    expect(cfgLimitIdx).toBeGreaterThan(-1);
+    expect(settingsIdx).toBeLessThan(cfgIdx);
+    expect(cfgIdx).toBeLessThan(cfgLimitIdx);
+  });
+
+  it('does not hoist a const that references an exported const after the first class', () => {
+    const result = compile(
+      `
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-test', template: '<p>hi</p>' })
+      export class TestComponent {}
+
+      export const BASE_PATH = '/api';
+      const fullPath = BASE_PATH + '/data';
+      `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    const classIdx = result.indexOf('class TestComponent');
+    const fullPathIdx = result.indexOf('const fullPath');
+    // BASE_PATH is exported so not hoisted; fullPath references it, so also not hoisted
+    expect(fullPathIdx).toBeGreaterThan(classIdx);
+  });
+
+  it('does not hoist a const that references an enum defined after the first class', () => {
+    const result = compile(
+      `
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-test', template: '<p>hi</p>' })
+      export class TestComponent {}
+
+      enum Priority { Low, Medium, High }
+      const defaultPriority = Priority.Medium;
+      `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    const enumIdx = result.indexOf('enum Priority');
+    const constIdx = result.indexOf('const defaultPriority');
+    const classIdx = result.indexOf('class TestComponent');
+    expect(enumIdx).toBeGreaterThan(-1);
+    expect(constIdx).toBeGreaterThan(-1);
+    // enum stays in place, and const must stay after it
+    expect(enumIdx).toBeGreaterThan(classIdx);
+    expect(enumIdx).toBeLessThan(constIdx);
+  });
+
+  it('does not hoist a const that transitively depends via destructured binding', () => {
+    const result = compile(
+      `
+      import { Injectable } from '@angular/core';
+      @Injectable({ providedIn: 'root' })
+      export class AppService {}
+
+      class Dimensions { width = 100; height = 200; }
+      const { width, height } = new Dimensions();
+      const area = width * height;
+      `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    // width/height come from a destructured binding that references Dimensions,
+    // so area (which references width/height) must not be hoisted either.
+    const classIdx = result.indexOf('class Dimensions');
+    const destructIdx = result.indexOf('const { width, height }');
+    const areaIdx = result.indexOf('const area');
+    expect(classIdx).toBeGreaterThan(-1);
+    expect(destructIdx).toBeGreaterThan(-1);
+    expect(areaIdx).toBeGreaterThan(-1);
+    expect(classIdx).toBeLessThan(destructIdx);
+    expect(destructIdx).toBeLessThan(areaIdx);
+  });
+
+  it('does not hoist a const that references an exported destructured binding', () => {
+    const result = compile(
+      `
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-test', template: '<p>hi</p>' })
+      export class TestComponent {}
+
+      export const { baseUrl, timeout } = { baseUrl: '/api', timeout: 3000 };
+      const fullUrl = baseUrl + '/data';
+      `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    const classIdx = result.indexOf('class TestComponent');
+    const fullUrlIdx = result.indexOf('const fullUrl');
+    // baseUrl is from an exported destructured binding, so fullUrl must not be hoisted
+    expect(fullUrlIdx).toBeGreaterThan(classIdx);
+  });
+
+  it('does not hoist a const that references the first class in the file', () => {
+    const result = compile(
+      `
+      import { Component } from '@angular/core';
+
+      class Formatter {
+        static capitalize(s: string) { return s.toUpperCase(); }
+      }
+
+      @Component({ selector: 'app-test', template: '<p>hi</p>' })
+      export class TestComponent {}
+
+      const label = Formatter.capitalize('hello');
+      `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    // Formatter is the first class; label references it and must stay after it
+    const formatterIdx = result.indexOf('class Formatter');
+    const labelIdx = result.indexOf('const label');
+    expect(formatterIdx).toBeGreaterThan(-1);
+    expect(labelIdx).toBeGreaterThan(-1);
+    expect(formatterIdx).toBeLessThan(labelIdx);
   });
 });
 


### PR DESCRIPTION
Currently the compile.ts file hoists non-exported variable/function statements before the first class so Ivy static definitions can reference file-level constants. However, it indiscriminately hoisted all such statements, including user-authored code that references classes, enums, or exported names defined after the first class - moving the reference before its definition and creating a TDZ error.

 Replace the single-pass hoist with a two-pass dependency-aware algorithm (two lightweight iterations over the same top-level statements):                                                        
  - Pass 1: collect names from statements that won't be hoisted (classes, enums, exported vars/functions after the first class)
  - Pass 2: for each candidate, check if it references any non-hoistable name; if so, skip it and mark its own names as        
  non-hoistable (transitivity) 

## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## Affected scope

<!-- List the primary scope from CONTRIBUTING.md and any closely related secondary scopes. -->

- Primary scope: angular-compiler
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

<!-- Squash merge is highly preferred. -->
<!-- Recommend a non-squash merge only if you can justify why the PR should bypass focused changes per package. -->

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

<!-- If you recommend a non-squash merge, briefly explain why the commit boundaries matter and why this PR should bypass focused changes per package. -->

## What is the new behavior?

## Test plan

<!-- List the commands you ran and any manual verification you performed. -->

- [X] `nx format:check`
- [X] `pnpm build`
- [X] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
