### PR TITLE
fix(router): reset cached tViews between SSR requests for correct i18n locale switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@angular/compiler": "21.2.7",
     "@angular/core": "21.2.7",
     "@angular/forms": "21.2.7",
+    "@angular/localize": "21.2.7",
     "@angular/material": "21.2.5",
     "@angular/platform-browser": "21.2.7",
     "@angular/platform-browser-dynamic": "21.2.7",

--- a/packages/platform/src/lib/i18n-component-registry-plugin.ts
+++ b/packages/platform/src/lib/i18n-component-registry-plugin.ts
@@ -1,0 +1,163 @@
+import type { Plugin, TransformResult } from 'vite';
+import MagicString from 'magic-string';
+
+/**
+ * Vite plugin that instruments compiled Angular component definitions with
+ * calls to `registerI18nComponentDef()` from `@analogjs/router`. This
+ * populates a process-level registry of component definitions that the
+ * server renderer uses to null cached `tView` objects between SSR requests,
+ * allowing `$localize` tagged templates in `consts()` to re-evaluate with
+ * the freshly loaded translations for each request's locale.
+ *
+ * The plugin runs in `enforce: 'post'` so that it sees the compiled
+ * JavaScript output from the Angular compiler (which contains the
+ * `ClassName.ɵcmp = ɵɵdefineComponent({...})` assignments).
+ *
+ * Only active when the platform's `i18n` option is configured.
+ * Only transforms modules loaded for the SSR environment.
+ */
+export function i18nComponentRegistryPlugin(): Plugin {
+  return {
+    name: 'analogjs-i18n-component-registry',
+    enforce: 'post',
+
+    transform(code, id, options): TransformResult | undefined {
+      if (!options?.ssr) return;
+      if (!code.includes('.ɵcmp')) return;
+      if (id.includes('node_modules')) return;
+      if (!id.match(/\.(ts|js)(\?|$)/)) return;
+
+      const ast = this.parse(code) as unknown as AstNode;
+      const classNames = findComponentClassNames(ast);
+
+      if (classNames.size === 0) return;
+
+      const registrations = [...classNames]
+        .map((name) => `__analog_i18n_reg(${name});`)
+        .join('\n');
+
+      // Use MagicString so the source map stays aligned with the original
+      // file — prepended imports and appended registration calls must not
+      // shift line numbers for frames that land inside the user's code.
+      const s = new MagicString(code);
+      s.prepend(
+        `import { ɵregisterI18nComponentDef as __analog_i18n_reg } from '@analogjs/router';\n`,
+      );
+      s.append(`\n${registrations}\n`);
+
+      return {
+        code: s.toString(),
+        map: s.generateMap({ hires: true, source: id, includeContent: true }),
+      };
+    },
+  };
+}
+
+// Minimal ESTree node shape used by the walker.
+interface AstNode {
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Walks the AST to find class names whose definitions include a `ɵcmp`
+ * static property assignment — the marker Angular uses for compiled
+ * component definitions.
+ *
+ * Handles two codegen styles:
+ *
+ * Production (tree-shaken):
+ *   _ClassName.ɵcmp = ɵɵdefineComponent({...})
+ *   → AssignmentExpression  left: MemberExpression(.ɵcmp)  object: Identifier
+ *
+ * Dev mode (class fields):
+ *   class Foo { static { this.ɵcmp = i0.ɵɵdefineComponent({...}) } }
+ *   → ClassDeclaration → StaticBlock → AssignmentExpression  left: MemberExpression(.ɵcmp) object: ThisExpression
+ */
+function findComponentClassNames(ast: AstNode): Set<string> {
+  const names = new Set<string>();
+
+  walk(ast, (node: any) => {
+    // Prod: top-level `Identifier.ɵcmp = ...`
+    if (
+      node.type === 'AssignmentExpression' &&
+      isNode(node.left) &&
+      node.left.type === 'MemberExpression' &&
+      isNode(node.left.property) &&
+      (node.left.property as AstNode & { name?: string }).name === 'ɵcmp' &&
+      isNode(node.left.object) &&
+      node.left.object.type === 'Identifier'
+    ) {
+      const name = (node.left.object as AstNode & { name: string }).name;
+      if (name !== 'this') {
+        names.add(name);
+      }
+    }
+
+    // Dev: ClassDeclaration containing `this.ɵcmp = ...` in a static block
+    if (
+      (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') &&
+      isNode(node.id) &&
+      (node.id as AstNode & { name?: string }).name
+    ) {
+      const className = (node.id as AstNode & { name: string }).name;
+      if (classHasCmpDef(node)) {
+        names.add(className);
+      }
+    }
+  });
+
+  return names;
+}
+
+function classHasCmpDef(classNode: AstNode): boolean {
+  let found = false;
+
+  walk(classNode, (node: any) => {
+    if (found) return;
+
+    // static ɵcmp = ... (PropertyDefinition)
+    if (
+      node.type === 'PropertyDefinition' &&
+      node.static === true &&
+      isNode(node.key) &&
+      (node.key as AstNode & { name?: string }).name === 'ɵcmp'
+    ) {
+      found = true;
+      return;
+    }
+
+    // static { this.ɵcmp = ... }
+    if (
+      node.type === 'AssignmentExpression' &&
+      isNode(node.left) &&
+      node.left.type === 'MemberExpression' &&
+      isNode(node.left.property) &&
+      (node.left.property as AstNode & { name?: string }).name === 'ɵcmp' &&
+      isNode(node.left.object) &&
+      node.left.object.type === 'ThisExpression'
+    ) {
+      found = true;
+    }
+  });
+
+  return found;
+}
+
+function isNode(v: unknown): v is AstNode {
+  return v != null && typeof v === 'object' && 'type' in (v as object);
+}
+
+function walk(node: AstNode, visitor: (n: AstNode) => void): void {
+  visitor(node);
+  for (const key of Object.keys(node)) {
+    const child = node[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (isNode(item)) walk(item, visitor);
+      }
+    } else if (isNode(child)) {
+      walk(child, visitor);
+    }
+  }
+}

--- a/packages/platform/src/lib/i18n-component-registry-plugin.ts
+++ b/packages/platform/src/lib/i18n-component-registry-plugin.ts
@@ -47,7 +47,11 @@ export function i18nComponentRegistryPlugin(): Plugin {
 
       return {
         code: s.toString(),
-        map: s.generateMap({ hires: true, source: id, includeContent: true }),
+        map: s.generateMap({
+          hires: true,
+          source: id,
+          includeContent: true,
+        }) as TransformResult['map'],
       };
     },
   };

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -12,6 +12,7 @@ import { depsPlugin } from './deps-plugin.js';
 import { injectHTMLPlugin } from './ssr/inject-html-plugin.js';
 import { serverModePlugin } from '../server-mode-plugin.js';
 import { i18nExtractPlugin } from './i18n-extract-plugin.js';
+import { i18nComponentRegistryPlugin } from './i18n-component-registry-plugin.js';
 
 export function platformPlugin(opts: Options = {}): Plugin[] {
   const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
@@ -71,6 +72,7 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
     serverModePlugin(),
     ssrXhrBuildPlugin() as Plugin,
     clearClientPageEndpointsPlugin() as Plugin,
+    ...(platformOptions.i18n ? [i18nComponentRegistryPlugin()] : []),
     ...(platformOptions.i18n?.extract
       ? [i18nExtractPlugin(platformOptions.i18n)]
       : []),

--- a/packages/router/server/src/render.ts
+++ b/packages/router/server/src/render.ts
@@ -16,6 +16,7 @@ import {
   serverComponentRequest,
   renderServerComponent,
 } from './server-component-render';
+import { ɵresetI18nComponentDefCache } from '@analogjs/router';
 
 if (import.meta.env.PROD) {
   enableProdMode();
@@ -47,6 +48,12 @@ export function render(
     if (serverComponentRequest(serverContext)) {
       return await renderServerComponent(url, serverContext);
     }
+
+    // Reset any cached tViews on component defs registered by the
+    // i18n-component-registry Vite plugin so that the next render picks
+    // up the locale loaded by `provideI18n()`'s app initializer rather
+    // than the first-rendered locale's strings baked into `tView.consts`.
+    ɵresetI18nComponentDefCache();
 
     const html = await renderApplication(bootstrap, {
       document,

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -21,7 +21,11 @@ export { ServerOnly } from './lib/server.component';
 export {
   provideI18n,
   I18nConfig,
-  I18N_CONFIG,
-  loadTranslationsRuntime,
   injectSwitchLocale,
+  loadTranslationsRuntime,
+  // Framework-internal helpers. `ɵ`-prefixed following the Angular
+  // convention for plumbing that is technically reachable but not part
+  // of the supported API.
+  ɵregisterI18nComponentDef,
+  ɵresetI18nComponentDefCache,
 } from './lib/i18n/provide-i18n';

--- a/packages/router/src/lib/i18n/provide-i18n.spec.ts
+++ b/packages/router/src/lib/i18n/provide-i18n.spec.ts
@@ -7,8 +7,8 @@ import {
   replaceLocaleInPath,
   resolveI18nConfig,
   I18nConfig,
-  ɵɵregisterI18nComponentDef,
-  ɵɵresetI18nComponentDefCache,
+  ɵregisterI18nComponentDef,
+  ɵresetI18nComponentDefCache,
   getI18nComponentDefRegistrySize,
   clearI18nComponentDefRegistry,
 } from './provide-i18n';

--- a/packages/router/src/lib/i18n/provide-i18n.spec.ts
+++ b/packages/router/src/lib/i18n/provide-i18n.spec.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
   loadTranslationsRuntime,
+  clearTranslationsRuntime,
   initI18n,
   detectClientLocale,
   replaceLocaleInPath,
   resolveI18nConfig,
   I18nConfig,
+  ɵɵregisterI18nComponentDef,
+  ɵɵresetI18nComponentDefCache,
+  getI18nComponentDefRegistrySize,
+  clearI18nComponentDefRegistry,
 } from './provide-i18n';
 
 describe('loadTranslationsRuntime', () => {
@@ -19,43 +24,86 @@ describe('loadTranslationsRuntime', () => {
     (globalThis as any).$localize = originalLocalize;
   });
 
-  it('should set translations on $localize.TRANSLATIONS', () => {
+  it('should store translations in the parsed shape $localize.translate expects', async () => {
     (globalThis as any).$localize = {};
 
-    loadTranslationsRuntime({
+    await loadTranslationsRuntime({
       'msg-hello': 'Bonjour',
       'msg-goodbye': 'Au revoir',
     });
 
-    expect((globalThis as any).$localize.TRANSLATIONS).toEqual({
-      'msg-hello': 'Bonjour',
-      'msg-goodbye': 'Au revoir',
+    const translations = (globalThis as any).$localize.TRANSLATIONS;
+    // `@angular/localize`'s `loadTranslations` parses each message into
+    // `{ text, messageParts, placeholderNames }` so that the runtime
+    // `translate()` function can build a translated template object.
+    expect(translations['msg-hello']).toMatchObject({
+      text: 'Bonjour',
+      messageParts: ['Bonjour'],
+      placeholderNames: [],
+    });
+    expect(translations['msg-goodbye']).toMatchObject({
+      text: 'Au revoir',
+      messageParts: ['Au revoir'],
+      placeholderNames: [],
     });
   });
 
-  it('should merge with existing translations', () => {
-    (globalThis as any).$localize = {
-      TRANSLATIONS: { 'msg-existing': 'Existant' },
-    };
+  it('should wire up $localize.translate so lookups actually happen', async () => {
+    (globalThis as any).$localize = {};
 
-    loadTranslationsRuntime({ 'msg-new': 'Nouveau' });
+    await loadTranslationsRuntime({ 'msg-hello': 'Bonjour' });
 
-    expect((globalThis as any).$localize.TRANSLATIONS).toEqual({
-      'msg-existing': 'Existant',
-      'msg-new': 'Nouveau',
-    });
+    expect(typeof (globalThis as any).$localize.translate).toBe('function');
   });
 
-  it('should warn if $localize is not available', () => {
+  it('should merge with existing translations', async () => {
+    (globalThis as any).$localize = {};
+    await loadTranslationsRuntime({ 'msg-existing': 'Existant' });
+    await loadTranslationsRuntime({ 'msg-new': 'Nouveau' });
+
+    const translations = (globalThis as any).$localize.TRANSLATIONS;
+    expect(translations['msg-existing']).toMatchObject({ text: 'Existant' });
+    expect(translations['msg-new']).toMatchObject({ text: 'Nouveau' });
+  });
+
+  it('should warn if $localize is not available', async () => {
     (globalThis as any).$localize = undefined;
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    loadTranslationsRuntime({ 'msg-hello': 'Bonjour' });
+    await loadTranslationsRuntime({ 'msg-hello': 'Bonjour' });
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('$localize is not available'),
     );
     warnSpy.mockRestore();
+  });
+});
+
+describe('clearTranslationsRuntime', () => {
+  let originalLocalize: any;
+
+  beforeEach(() => {
+    originalLocalize = (globalThis as any).$localize;
+  });
+
+  afterEach(() => {
+    (globalThis as any).$localize = originalLocalize;
+  });
+
+  it('should drop $localize.translate and empty TRANSLATIONS', async () => {
+    (globalThis as any).$localize = {};
+    await loadTranslationsRuntime({ 'msg-hello': 'Bonjour' });
+    expect((globalThis as any).$localize.translate).toBeTypeOf('function');
+
+    await clearTranslationsRuntime();
+
+    expect((globalThis as any).$localize.translate).toBeUndefined();
+    expect((globalThis as any).$localize.TRANSLATIONS).toEqual({});
+  });
+
+  it('should no-op when $localize is not available', async () => {
+    (globalThis as any).$localize = undefined;
+    await expect(clearTranslationsRuntime()).resolves.toBeUndefined();
   });
 });
 
@@ -71,7 +119,7 @@ describe('initI18n', () => {
     (globalThis as any).$localize = originalLocalize;
   });
 
-  it('should skip loading when locale matches the first (source) locale', async () => {
+  it('should skip the loader when the locale matches the source locale', async () => {
     const loader = vi.fn();
     const config: I18nConfig = {
       defaultLocale: 'en',
@@ -84,7 +132,27 @@ describe('initI18n', () => {
     expect(loader).not.toHaveBeenCalled();
   });
 
-  it('should load translations for non-source locale', async () => {
+  it('should clear translations even when the source locale is active', async () => {
+    // Simulate a prior render having loaded fr translations.
+    await loadTranslationsRuntime({ 'msg-hello': 'Bonjour' });
+    expect((globalThis as any).$localize.translate).toBeTypeOf('function');
+
+    const config: I18nConfig = {
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      loader: vi.fn(),
+    };
+
+    await initI18n(config, 'en');
+
+    // Previously loaded fr translations must be dropped so that the
+    // source locale's templates fall through to their source strings
+    // rather than silently rendering stale fr values.
+    expect((globalThis as any).$localize.translate).toBeUndefined();
+    expect((globalThis as any).$localize.TRANSLATIONS).toEqual({});
+  });
+
+  it('should load translations for a non-source locale', async () => {
     const config: I18nConfig = {
       defaultLocale: 'fr',
       locales: ['en', 'fr'],
@@ -96,9 +164,31 @@ describe('initI18n', () => {
     await initI18n(config, 'fr');
 
     expect(config.loader).toHaveBeenCalledWith('fr');
-    expect((globalThis as any).$localize.TRANSLATIONS).toEqual({
-      'msg-hello': 'Bonjour',
+    expect(
+      (globalThis as any).$localize.TRANSLATIONS['msg-hello'],
+    ).toMatchObject({
+      text: 'Bonjour',
     });
+  });
+
+  it('should clear previous translations before loading new ones', async () => {
+    // Pretend an earlier request loaded fr.
+    await loadTranslationsRuntime({ 'msg-only-in-fr': 'Seulement' });
+
+    const config: I18nConfig = {
+      defaultLocale: 'en',
+      locales: ['en', 'de'],
+      loader: vi.fn().mockResolvedValue({ 'msg-only-in-de': 'Nur' }),
+    };
+
+    await initI18n(config, 'de');
+
+    const translations = (globalThis as any).$localize.TRANSLATIONS;
+    // The fr-only message must be gone; only the newly loaded de messages
+    // should be present. Without clearing, the two maps would mix and a
+    // /de request would still resolve fr-only messages.
+    expect(translations['msg-only-in-fr']).toBeUndefined();
+    expect(translations['msg-only-in-de']).toMatchObject({ text: 'Nur' });
   });
 
   it('should handle empty translations gracefully', async () => {
@@ -111,8 +201,7 @@ describe('initI18n', () => {
     await initI18n(config, 'fr');
 
     expect(config.loader).toHaveBeenCalledWith('fr');
-    // Should not crash, TRANSLATIONS should not be set
-    expect((globalThis as any).$localize.TRANSLATIONS).toBeUndefined();
+    expect((globalThis as any).$localize.TRANSLATIONS).toEqual({});
   });
 
   it('should support synchronous loaders', async () => {
@@ -124,8 +213,10 @@ describe('initI18n', () => {
 
     await initI18n(config, 'de');
 
-    expect((globalThis as any).$localize.TRANSLATIONS).toEqual({
-      'msg-hello': 'Hallo',
+    expect(
+      (globalThis as any).$localize.TRANSLATIONS['msg-hello'],
+    ).toMatchObject({
+      text: 'Hallo',
     });
   });
 
@@ -162,12 +253,11 @@ describe('detectClientLocale', () => {
   };
 
   it('should return defaultLocale when window is undefined (server)', () => {
-    // In Node test environment, window is typically undefined
     const originalWindow = globalThis.window;
     // @ts-ignore
     delete globalThis.window;
 
-    expect(detectClientLocale(baseConfig)).toBe('en');
+    expect(detectClientLocale(baseConfig as any)).toBe('en');
 
     globalThis.window = originalWindow;
   });
@@ -177,7 +267,7 @@ describe('detectClientLocale', () => {
     // @ts-ignore
     globalThis.window = { location: { pathname: '/fr/about' } };
 
-    expect(detectClientLocale(baseConfig)).toBe('fr');
+    expect(detectClientLocale(baseConfig as any)).toBe('fr');
 
     globalThis.window = originalWindow;
   });
@@ -187,7 +277,7 @@ describe('detectClientLocale', () => {
     // @ts-ignore
     globalThis.window = { location: { pathname: '/about' } };
 
-    expect(detectClientLocale(baseConfig)).toBe('en');
+    expect(detectClientLocale(baseConfig as any)).toBe('en');
 
     globalThis.window = originalWindow;
   });
@@ -197,8 +287,7 @@ describe('detectClientLocale', () => {
     // @ts-ignore
     globalThis.window = { location: { pathname: '/es/about' } };
 
-    // 'es' is not in the locales list
-    expect(detectClientLocale(baseConfig)).toBe('en');
+    expect(detectClientLocale(baseConfig as any)).toBe('en');
 
     globalThis.window = originalWindow;
   });
@@ -208,7 +297,7 @@ describe('detectClientLocale', () => {
     // @ts-ignore
     globalThis.window = { location: { pathname: '/de' } };
 
-    expect(detectClientLocale(baseConfig)).toBe('de');
+    expect(detectClientLocale(baseConfig as any)).toBe('de');
 
     globalThis.window = originalWindow;
   });
@@ -289,5 +378,57 @@ describe('resolveI18nConfig', () => {
     expect(() => resolveI18nConfig({ loader })).toThrow(
       'provideI18n() requires defaultLocale and locales',
     );
+  });
+});
+
+describe('component def registry', () => {
+  beforeEach(() => {
+    clearI18nComponentDefRegistry();
+  });
+
+  it('should null def.tView on registered components when reset', () => {
+    const fakeDef = {
+      template: () => undefined,
+      tView: { someCachedValue: true },
+    };
+    ɵregisterI18nComponentDef(fakeDef);
+    expect(getI18nComponentDefRegistrySize()).toBe(1);
+
+    ɵresetI18nComponentDefCache();
+
+    expect(fakeDef.tView).toBeNull();
+    // The registry itself is intentionally preserved across resets so
+    // that subsequent requests keep clearing the same defs.
+    expect(getI18nComponentDefRegistrySize()).toBe(1);
+  });
+
+  it('should accept a Type with a ɵcmp static and unwrap it', () => {
+    const fakeDef = { template: () => undefined, tView: {} };
+    class FakeComponent {
+      static ɵcmp = fakeDef;
+    }
+
+    ɵregisterI18nComponentDef(FakeComponent);
+    ɵresetI18nComponentDefCache();
+
+    expect(fakeDef.tView).toBeNull();
+  });
+
+  it('should ignore things that are not component defs', () => {
+    ɵregisterI18nComponentDef(null);
+    ɵregisterI18nComponentDef(undefined);
+    ɵregisterI18nComponentDef({ notAComponent: true });
+    ɵregisterI18nComponentDef(class Bare {});
+
+    expect(getI18nComponentDefRegistrySize()).toBe(0);
+  });
+
+  it('should de-duplicate repeated registrations of the same def', () => {
+    const fakeDef = { template: () => undefined, tView: {} };
+    ɵregisterI18nComponentDef(fakeDef);
+    ɵregisterI18nComponentDef(fakeDef);
+    ɵregisterI18nComponentDef(fakeDef);
+
+    expect(getI18nComponentDefRegistrySize()).toBe(1);
   });
 });

--- a/packages/router/src/lib/i18n/provide-i18n.ts
+++ b/packages/router/src/lib/i18n/provide-i18n.ts
@@ -1,12 +1,13 @@
 import {
-  ENVIRONMENT_INITIALIZER,
   EnvironmentProviders,
   InjectionToken,
+  Type,
   assertInInjectionContext,
   inject,
   makeEnvironmentProviders,
+  provideAppInitializer,
 } from '@angular/core';
-import { LOCALE, injectLocale } from '@analogjs/router/tokens';
+import { LOCALE, REQUEST, ServerRequest } from '@analogjs/router/tokens';
 
 declare const ANALOG_I18N_DEFAULT_LOCALE: string;
 declare const ANALOG_I18N_LOCALES: string[];
@@ -47,9 +48,10 @@ export type ResolvedI18nConfig = Required<I18nConfig>;
 
 /**
  * Injection token for the resolved i18n configuration.
- * Provided by `provideI18n()`.
+ * Provided by `provideI18n()` and consumed by `injectSwitchLocale()`.
+ * @internal
  */
-export const I18N_CONFIG = new InjectionToken<ResolvedI18nConfig>(
+const I18N_CONFIG = new InjectionToken<ResolvedI18nConfig>(
   '@analogjs/router I18n Config',
 );
 
@@ -90,7 +92,8 @@ export function resolveI18nConfig(config: I18nConfig): Required<I18nConfig> {
  *
  * Works in both SSR and client-only modes. On the client, locale is detected
  * from `window.location.pathname`. On the server, locale is detected from
- * the request in `provideServerContext()`.
+ * the request in `provideServerContext()` and provided at the platform level;
+ * this function does not shadow it.
  *
  * When the platform plugin is configured with `i18n` in `vite.config.ts`,
  * `defaultLocale` and `locales` are injected automatically — only
@@ -104,21 +107,57 @@ export function resolveI18nConfig(config: I18nConfig): Required<I18nConfig> {
  */
 export function provideI18n(config: I18nConfig): EnvironmentProviders {
   const resolved = resolveI18nConfig(config);
-  const detectedLocale = detectClientLocale(resolved);
+
+  // Only provide LOCALE at the environment level on the client. On the
+  // server, the platform-level LOCALE set by `provideServerContext()` is
+  // authoritative and must not be shadowed by an environment-level provider.
+  const localeProviders =
+    typeof window !== 'undefined'
+      ? [{ provide: LOCALE, useValue: detectClientLocale(resolved) }]
+      : [];
 
   return makeEnvironmentProviders([
     { provide: I18N_CONFIG, useValue: resolved },
-    { provide: LOCALE, useValue: detectedLocale },
-    {
-      provide: ENVIRONMENT_INITIALIZER,
-      multi: true,
-      useFactory: () => {
-        // Re-read LOCALE in case the server context overrode it
-        const locale = injectLocale();
-        return () => initI18n(resolved, locale ?? undefined);
-      },
-    },
+    ...localeProviders,
+    provideAppInitializer(async () => {
+      const locale = resolveActiveLocale(resolved);
+      await initI18n(resolved, locale);
+      // Force component definitions to re-evaluate their `consts()` factories
+      // on the next render so that `$localize` tagged templates pick up the
+      // newly loaded translations. Angular caches the result of `consts()`
+      // on `def.tView`, so without this reset the first rendered locale
+      // would be reused for every subsequent SSR request.
+      ɵresetI18nComponentDefCache();
+    }),
   ]);
+}
+
+/**
+ * Resolves the active locale, preferring the injected `LOCALE` token
+ * (which on the server reads from the platform-level provider set by
+ * `provideServerContext()`) and falling back to the request URL,
+ * `window.location.pathname`, or `defaultLocale`.
+ */
+function resolveActiveLocale(config: ResolvedI18nConfig): string {
+  const injected = inject(LOCALE, { optional: true });
+  if (injected && config.locales.includes(injected)) {
+    return injected;
+  }
+
+  // Fallback: read the path directly from the request on the server or
+  // from the browser URL on the client. This covers cases where a locale
+  // prefix is present in the URL but no token provider set it explicitly.
+  const req = inject(REQUEST, { optional: true }) as ServerRequest | null;
+  const pathname =
+    req?.originalUrl ??
+    req?.url ??
+    (typeof window !== 'undefined' ? window.location.pathname : '/');
+  const first = pathname.split('?')[0].split('/').filter(Boolean)[0];
+  if (first && config.locales.includes(first)) {
+    return first;
+  }
+
+  return config.defaultLocale;
 }
 
 /**
@@ -143,33 +182,45 @@ export function detectClientLocale(config: ResolvedI18nConfig): string {
 
 /**
  * Loads translations for the given locale and registers them with $localize.
+ *
+ * Always clears any previously loaded translations first so that switching
+ * between locales in a single SSR process does not mix translation maps.
  */
 export async function initI18n(
   config: ResolvedI18nConfig,
   locale?: string,
 ): Promise<void> {
   const activeLocale = locale ?? config.defaultLocale;
+  await clearTranslationsRuntime();
 
-  // Skip loading translations for the source locale
-  // (source messages are already in the templates)
+  // The source locale (first entry in `locales`) has its messages baked
+  // directly into the template source, so there is nothing to load.
   if (activeLocale === config.locales[0]) {
     return;
   }
 
   const translations = await config.loader(activeLocale);
-
   if (translations && Object.keys(translations).length > 0) {
-    loadTranslationsRuntime(translations);
+    await loadTranslationsRuntime(translations);
   }
 }
 
 /**
  * Loads translations into the global $localize translation map.
- * Requires @angular/localize/init to be imported in the application entry point.
+ *
+ * Uses `@angular/localize`'s `loadTranslations` when available so that
+ * each translation string is parsed into the `{text, messageParts,
+ * placeholderNames}` shape that `$localize.translate` expects. Falls back
+ * to writing raw strings only as a last resort (in which case lookups
+ * will not succeed — the fallback exists to keep error messages useful
+ * for users who have not installed `@angular/localize`).
+ *
+ * Requires `@angular/localize/init` to be imported in the application
+ * entry point so that `globalThis.$localize` is defined.
  */
-export function loadTranslationsRuntime(
+export async function loadTranslationsRuntime(
   translations: Record<string, string>,
-): void {
+): Promise<void> {
   const $localize = (globalThis as any).$localize;
   if (!$localize) {
     console.warn(
@@ -179,10 +230,106 @@ export function loadTranslationsRuntime(
     return;
   }
 
-  $localize.TRANSLATIONS ??= {};
-  for (const [id, message] of Object.entries(translations)) {
-    $localize.TRANSLATIONS[id] = message;
+  try {
+    const { loadTranslations } = (await import('@angular/localize')) as {
+      loadTranslations: (t: Record<string, string>) => void;
+    };
+    loadTranslations(translations);
+  } catch {
+    console.warn(
+      '[@analogjs/router] Unable to import @angular/localize. ' +
+        'Install it as a dependency to enable runtime translation loading.',
+    );
+    $localize.TRANSLATIONS ??= {};
+    for (const [id, message] of Object.entries(translations)) {
+      $localize.TRANSLATIONS[id] = message;
+    }
   }
+}
+
+/**
+ * Clears any previously loaded translations from `$localize` so that the
+ * next render falls through to the source messages until new translations
+ * are loaded. Uses `@angular/localize`'s `clearTranslations` when present.
+ */
+/** @internal — exported for tests; not re-exported from the package entry. */
+export async function clearTranslationsRuntime(): Promise<void> {
+  const $localize = (globalThis as any).$localize;
+  if (!$localize) {
+    return;
+  }
+  try {
+    const { clearTranslations } = (await import('@angular/localize')) as {
+      clearTranslations: () => void;
+    };
+    clearTranslations();
+  } catch {
+    $localize.translate = undefined;
+    $localize.TRANSLATIONS = {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component definition registry
+// ---------------------------------------------------------------------------
+//
+// Angular caches the result of a component's `consts()` factory on
+// `def.tView` the first time the component is rendered. The factory is
+// where `$localize` tagged templates are evaluated, so once a tView has
+// been created for one locale, subsequent renders in the same process
+// reuse those strings no matter what translations are loaded.
+//
+// To support per-request locale switching in SSR, we keep a process-level
+// registry of component definitions that have been rendered, and null out
+// their cached tViews before each new render so the factory re-runs with
+// the freshly loaded translations.
+
+const componentDefRegistry = new Set<any>();
+
+/**
+ * Framework-internal: registers a component type (or `ɵcmp` definition)
+ * so that its cached tView will be reset before the next SSR render.
+ * Called from code emitted by the `i18nComponentRegistryPlugin` Vite
+ * plugin into user component modules. Not intended for direct use.
+ * @internal
+ */
+export function ɵregisterI18nComponentDef(typeOrDef: Type<any> | any): void {
+  if (!typeOrDef) return;
+  const def = (typeOrDef as any).ɵcmp ?? typeOrDef;
+  if (def && typeof def === 'object' && 'template' in def) {
+    componentDefRegistry.add(def);
+  }
+}
+
+/**
+ * Framework-internal: nulls `def.tView` on every registered component
+ * definition so that Angular's next render re-invokes `consts()` — where
+ * `$localize` tagged templates are evaluated — with whichever
+ * translations are currently loaded. Called by the server renderer
+ * before each request. Not intended for direct use.
+ * @internal
+ */
+export function ɵresetI18nComponentDefCache(): void {
+  for (const def of componentDefRegistry) {
+    def.tView = null;
+  }
+}
+
+/**
+ * Returns the number of component definitions in the registry.
+ * Exposed for testing.
+ * @internal
+ */
+export function getI18nComponentDefRegistrySize(): number {
+  return componentDefRegistry.size;
+}
+
+/**
+ * Clears the component definition registry. Exposed for testing.
+ * @internal
+ */
+export function clearI18nComponentDefRegistry(): void {
+  componentDefRegistry.clear();
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@angular/forms':
         specifier: 21.2.7
         version: 21.2.7(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(rxjs@7.8.2)
+      '@angular/localize':
+        specifier: 21.2.7
+        version: 21.2.7(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)
       '@angular/material':
         specifier: 21.2.5
         version: 21.2.5(121ef31cac834805c9fcde0d0fe835bd)
@@ -62,7 +65,7 @@ importers:
         version: 3.1.1(@types/react@18.3.28)(react@18.3.1)
       '@nx/angular':
         specifier: 22.6.4
-        version: 22.6.4(eed34d03e50aff5588b10950653efca5)
+        version: 22.6.4(d9f36ad57645e720619ab48aa05999af)
       '@nx/devkit':
         specifier: 22.6.4
         version: 22.6.4(nx@22.6.4(@swc-node/register@1.11.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.18(@swc/helpers@0.5.19)))
@@ -150,7 +153,7 @@ importers:
         version: 0.2102.6(chokidar@5.0.0)
       '@angular-devkit/build-angular':
         specifier: 21.2.6
-        version: 21.2.6(fde3fe4dd3bf65dee958578821a22fa2)
+        version: 21.2.6(295054b4e13eb97e0fd26ad4658a4d3f)
       '@angular-devkit/core':
         specifier: 21.2.6
         version: 21.2.6(chokidar@5.0.0)
@@ -168,7 +171,7 @@ importers:
         version: 21.3.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       '@angular/build':
         specifier: 21.2.6
-        version: 21.2.6(d343df650565c00f621247ff5a65382e)
+        version: 21.2.6(a8d343296faaa4a63e023c85c188a1c3)
       '@angular/cli':
         specifier: 21.2.6
         version: 21.2.6(@types/node@22.19.15)(chokidar@5.0.0)
@@ -261,7 +264,7 @@ importers:
         version: 10.2.19(@vitest/browser-playwright@4.0.18)(@vitest/browser@4.0.18(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(stylus@0.64.0)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.17(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.18)
       '@storybook/angular':
         specifier: 10.2.17
-        version: 10.2.17(e7255b1e4a7db4ba02ff25457fb0b800)
+        version: 10.2.17(5e7fa277eaca3285a6755c63f5142c7d)
       '@storybook/builder-vite':
         specifier: ^10.2.17
         version: 10.2.19(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.17(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.98.0)(sass@1.98.0)(stylus@0.64.0)(terser@5.46.0)(yaml@2.8.2))(webpack@5.105.4(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.27.3))
@@ -954,6 +957,14 @@ packages:
   '@angular/language-service@21.2.7':
     resolution: {integrity: sha512-XulGTWSw9S3CbTLmNivZtaqfZC2QJvt0grApV/bPZ1evRmnvO0Ep3EaLN2+zAfBQiD5tg3eTHhsCemL5HD+CWw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@angular/localize@21.2.7':
+    resolution: {integrity: sha512-EcZHeEuEy9Fr4cWOwdJudPVbjfqso82bAXmnAE0f+Rt5LB3Le8O5RDGgV52EuLo8gzTiWzhVUI7Zg1tYkBqnSQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@angular/compiler': 21.2.7
+      '@angular/compiler-cli': 21.2.7
 
   '@angular/material@21.2.5':
     resolution: {integrity: sha512-hSil2QUKObjF73EbhUEA5xAZx0/o9r/AFrkRsxa2z9e11jSjlKJHrYuY1tMIFv3SpzK33EYf58IXOBJVwt0iIw==}
@@ -16030,13 +16041,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@21.2.6(fde3fe4dd3bf65dee958578821a22fa2)':
+  '@angular-devkit/build-angular@21.2.6(295054b4e13eb97e0fd26ad4658a4d3f)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.6(chokidar@5.0.0)
       '@angular-devkit/build-webpack': 0.2102.6(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.27.3)))(webpack@5.105.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.27.3))
       '@angular-devkit/core': 21.2.6(chokidar@5.0.0)
-      '@angular/build': 21.2.6(06b6c4b9478d7df30abbd22070b664ee)
+      '@angular/build': 21.2.6(3148d95c9c72e24f0b86f8a307d57d43)
       '@angular/compiler-cli': 21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3)
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -16090,6 +16101,7 @@ snapshots:
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.6(@rspack/core@1.6.8(@swc/helpers@0.5.19))(webpack@5.105.4(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.27.3)))(webpack@5.105.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.27.3))
     optionalDependencies:
       '@angular/core': 21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)
+      '@angular/localize': 21.2.7(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)
       '@angular/platform-browser': 21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))
       '@angular/platform-server': 21.2.7(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(rxjs@7.8.2)
       '@angular/ssr': 21.2.6(bb34f5a4800f2729c0a819df96d6aed2)
@@ -16233,7 +16245,7 @@ snapshots:
       '@angular/core': 21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)
       tslib: 2.8.1
 
-  '@angular/build@21.2.6(06b6c4b9478d7df30abbd22070b664ee)':
+  '@angular/build@21.2.6(3148d95c9c72e24f0b86f8a307d57d43)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.6(chokidar@5.0.0)
@@ -16268,6 +16280,7 @@ snapshots:
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)
+      '@angular/localize': 21.2.7(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)
       '@angular/platform-browser': 21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))
       '@angular/platform-server': 21.2.7(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(rxjs@7.8.2)
       '@angular/ssr': 21.2.6(bb34f5a4800f2729c0a819df96d6aed2)
@@ -16290,7 +16303,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.6(d343df650565c00f621247ff5a65382e)':
+  '@angular/build@21.2.6(a8d343296faaa4a63e023c85c188a1c3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.6(chokidar@5.0.0)
@@ -16325,6 +16338,7 @@ snapshots:
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)
+      '@angular/localize': 21.2.7(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)
       '@angular/platform-browser': 21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))
       '@angular/platform-server': 21.2.7(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(rxjs@7.8.2)
       '@angular/ssr': 21.2.6(bb34f5a4800f2729c0a819df96d6aed2)
@@ -16426,6 +16440,17 @@ snapshots:
       tslib: 2.8.1
 
   '@angular/language-service@21.2.7': {}
+
+  '@angular/localize@21.2.7(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)':
+    dependencies:
+      '@angular/compiler': 21.2.7
+      '@angular/compiler-cli': 21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3)
+      '@babel/core': 7.29.0
+      '@types/babel__core': 7.20.5
+      tinyglobby: 0.2.15
+      yargs: 18.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@angular/material@21.2.5(121ef31cac834805c9fcde0d0fe835bd)':
     dependencies:
@@ -21086,7 +21111,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nx/angular@22.6.4(eed34d03e50aff5588b10950653efca5)':
+  '@nx/angular@22.6.4(d9f36ad57645e720619ab48aa05999af)':
     dependencies:
       '@angular-devkit/core': 21.2.6(chokidar@5.0.0)
       '@angular-devkit/schematics': 21.2.6(chokidar@5.0.0)
@@ -21110,8 +21135,8 @@ snapshots:
       tslib: 2.8.1
       webpack-merge: 5.10.0
     optionalDependencies:
-      '@angular-devkit/build-angular': 21.2.6(fde3fe4dd3bf65dee958578821a22fa2)
-      '@angular/build': 21.2.6(d343df650565c00f621247ff5a65382e)
+      '@angular-devkit/build-angular': 21.2.6(295054b4e13eb97e0fd26ad4658a4d3f)
+      '@angular/build': 21.2.6(a8d343296faaa4a63e023c85c188a1c3)
       ng-packagr: 21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@3.4.19(yaml@2.8.2))(tslib@2.8.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -22756,10 +22781,10 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/angular@10.2.17(e7255b1e4a7db4ba02ff25457fb0b800)':
+  '@storybook/angular@10.2.17(5e7fa277eaca3285a6755c63f5142c7d)':
     dependencies:
       '@angular-devkit/architect': 0.2102.6(chokidar@5.0.0)
-      '@angular-devkit/build-angular': 21.2.6(fde3fe4dd3bf65dee958578821a22fa2)
+      '@angular-devkit/build-angular': 21.2.6(295054b4e13eb97e0fd26ad4658a4d3f)
       '@angular-devkit/core': 21.2.6(chokidar@5.0.0)
       '@angular/common': 21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2)
       '@angular/compiler': 21.2.7


### PR DESCRIPTION
## PR Checklist

Fixes three issues that prevented `provideI18n()` from switching locales correctly across SSR requests in a single Node process.

Closes #

## Affected scope

- Primary scope: router
- Secondary scopes: platform

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Three related problems were fixed, plus the public API was trimmed:

**1. Server-context `LOCALE` is no longer shadowed.** Previously `provideI18n()` unconditionally provided `LOCALE` at environment level using a value computed at module-load time (`detectClientLocale`), which returned `defaultLocale` on the server because `typeof window === 'undefined'`. That shadowed the platform-level `LOCALE` set by `provideServerContext()`, so `injectLocale()` always returned the default locale during SSR regardless of the URL. The provider is now registered only on the client; on the server, injection falls through to the platform-level value.

**2. `loadTranslationsRuntime` stores parsed translations.** The previous implementation set raw strings on `$localize.TRANSLATIONS`, which `$localize.translate()` cannot consume — it expects the `{ text, messageParts, placeholderNames }` shape produced by `parseTranslation()`. The helper now delegates to `@angular/localize`'s `loadTranslations()` via dynamic import, with a fallback for environments where the package is not installed.

**3. APP_INITIALIZER built into `provideI18n()`.** The old `ENVIRONMENT_INITIALIZER` returned an unawaited Promise, so translations could be in flight while components began rendering. Replaced with `provideAppInitializer` so bootstrap blocks on translation loading. The initializer detects locale via `inject(LOCALE, { optional: true })` (which now correctly reads the server-context value) with fallbacks to `REQUEST.originalUrl` and `window.location.pathname`.

**Per-request tView reset.** Added a process-level registry of component defs plus a reset helper, both `ɵ`-prefixed. The registry is populated at module load time by a new Vite plugin in `@analogjs/platform` (`i18nComponentRegistryPlugin`) that instruments compiled component output under SSR transforms, injecting a `ɵregisterI18nComponentDef(ClassName)` call at module scope. The plugin uses `this.parse()` from the Rollup plugin context rather than regex matching and produces correctly anchored source maps via `magic-string`. The server renderer calls `ɵresetI18nComponentDefCache()` before each `renderApplication()` so the next render re-evaluates `consts()` with the locale that its APP_INITIALIZER just loaded.

**Public API reduction.** The i18n surface is now 4 names (`provideI18n`, `I18nConfig`, `injectSwitchLocale`, `loadTranslationsRuntime`). Framework plumbing is `ɵ`-prefixed following Angular's convention (`ɵregisterI18nComponentDef`, `ɵresetI18nComponentDefCache`). `I18N_CONFIG` and `clearTranslationsRuntime` are no longer exported from the package entry — they have no external consumers.

## Test plan

- [x] Unit: `packages/router/src/lib/i18n/provide-i18n.spec.ts` updated for the new behavior (parsed translation shape, `clearTranslationsRuntime` side effects, component def registry)
- [x] Manual dev server: sequential requests for `/fr`, `/de`, `/en` against a running `vite` dev server each return their own translations with the correct `<html lang>`
- [x] Manual built server: `node dist/analog/server/index.mjs` exercised with the same sequence — every request handled correctly from a single process
- [x] Prerendering: 3 routes × 3 locales produces 9 HTML files, each with locale-appropriate translations and `<html lang>`
- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The runtime i18n API is still in beta. `registerI18nComponentDef` and `resetI18nComponentDefCache` have been renamed to `ɵregisterI18nComponentDef` / `ɵresetI18nComponentDefCache` to mark them as framework plumbing, and `I18N_CONFIG` / `clearTranslationsRuntime` are no longer exported from `@analogjs/router` — all four were internal and unlikely to be called directly.

## Other information

### Why clear `tView` between SSR requests

Angular caches the result of a component def's `consts()` factory on `def.tView` the first time the component renders. The factory is where `$localize` tagged templates are evaluated, so once a `tView` is created under one locale, every later render in the same process reuses those strings regardless of what `$localize.TRANSLATIONS` currently holds. In a single-build multi-locale SSR setup, the first locale to render wins for the lifetime of the process.

Angular's canonical i18n story is build-time `--localize`, which avoids this by producing one bundle per locale — the cache-forever behavior is correct in that model. Runtime `loadTranslations()` was introduced primarily for early-bootstrap test fixtures and for whole-app locale switches where a page reload is acceptable (which is why `injectSwitchLocale()` does a `window.location.href` assignment — the reload resets the process and the tView caches along with it). The missing quadrant is "one build, shared Node process, locale per request," which is the workflow `provideI18n()` invites.

Nulling `def.tView` before each render forces `getOrCreateComponentTView()` to rebuild — running `consts()` again, picking up whichever translations are currently loaded. The reset is safe across requests in this codebase because it runs before `bootstrapApplication()`, by which point the previous request's LViews have been destroyed; there are no in-flight references to the old `tView` to invalidate. Component IDs come from `def.id`, not `tView`, so they remain stable across rebuilds — SSR → client hydration keeps working as long as the same translations are loaded on both sides (they are; the client runs the same APP_INITIALIZER).

The trade-offs worth documenting:

- **Allocation cost.** Each request rebuilds `tView.blueprint`, `tView.data`, `directiveRegistry`, and `pipeRegistry` for every rendered component rather than amortizing those allocations across the process lifetime. At high QPS this is measurable GC pressure. Users serving public traffic should still prefer build-time `--localize` if their deployment model allows per-locale bundles.
- **`firstCreatePass` runs every request.** Directive/pipe registry extraction, host binding setup, content query setup, node-level DI, and component feature callbacks (`ɵɵNgOnChangesFeature`, `ɵɵHostDirectivesFeature`) fire each render instead of once. The contract for these is idempotent population of tView slots, but features with setup side effects outside that contract will fire repeatedly.
- **Incremental hydration is untested.** Deferred blocks (`@defer hydrate on …`) rely on serialized tView identity between server and client. I haven't verified that rebuilding tView keeps the `ssrId` and dehydrated-node layout byte-identical across requests for the same locale. Worth an E2E before relying on this combination.

### Upstream Angular

The `ɵregisterI18nComponentDef` / `ɵresetI18nComponentDefCache` pair is doing work that ideally lives in Angular itself. Angular already maintains a dev-only client-side component registry (`GENERATED_COMP_IDS`), but it's gated off when `ngServerMode === true`, so we can't reuse it on the built Node server. If Angular extended that registry to server mode and exposed `ɵresetAllComponentTViews()`, Analog could drop the Vite plugin and the registry entirely. Filing an RFC against `angular/angular` is the long-term path; this PR is the pragmatic floor.

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?