### PR TITLE
fix(vite-plugin-angular): honor Vitest test.css semantics to skip CSS preprocessing

### DIFF
--- a/packages/vite-plugin-angular/src/lib/analog-compiler-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/analog-compiler-plugin.ts
@@ -43,6 +43,7 @@ import {
   loadVirtualStyleModule,
   rewriteHtmlRawImport,
   rewriteInlineStyleImport,
+  shouldPreprocessTestCss,
 } from './utils/virtual-resources.js';
 
 export interface AnalogCompilerPluginOptions {
@@ -287,6 +288,12 @@ export function analogCompilerPlugin(
               /\.ts$/,
               `.inline-${i}.${pluginOptions.inlineStylesExtension}`,
             );
+            // In tests, mirror Vitest's `test.css` rules — defaults to no
+            // preprocessing (matches Vite's CSS pipeline behavior). (#2297)
+            if (!shouldPreprocessTestCss(resolvedConfig, fakePath)) {
+              resolvedInlineStyles.set(i, styleStrings[i]);
+              continue;
+            }
             const processed = await preprocessCSS(
               styleStrings[i],
               fakePath,
@@ -492,6 +499,11 @@ export function analogCompilerPlugin(
       if (/\.(css|scss|sass|less)\?inline$/.test(id)) {
         const filePath = id.split('?')[0];
         const code = await fsPromises.readFile(filePath, 'utf-8');
+        // In tests, mirror Vitest's `test.css` rules — defaults to no
+        // preprocessing (matches Vite's CSS pipeline behavior). (#2297)
+        if (!shouldPreprocessTestCss(resolvedConfig, filePath)) {
+          return `export default ${JSON.stringify(code)}`;
+        }
         const result = await preprocessCSS(code, filePath, resolvedConfig);
         return `export default ${JSON.stringify(result.code)}`;
       }

--- a/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto';
 import { Plugin, ResolvedConfig, preprocessCSS } from 'vite';
 
+import { shouldPreprocessTestCss } from './utils/virtual-resources.js';
+
 export function jitPlugin({
   inlineStylesExtension,
 }: {
@@ -35,6 +37,15 @@ export function jitPlugin({
         ).toString();
 
         let styles: string | undefined = '';
+
+        // In tests, mirror Vitest's `test.css` rules — defaults to no
+        // preprocessing (matches Vite's CSS pipeline behavior). Inline
+        // component styles have no real file path to match include/exclude
+        // patterns against, so only `test.css: true` opts them in. (#2297)
+        const inlineStyleId = `${styleIdHash}.${inlineStylesExtension}`;
+        if (!shouldPreprocessTestCss(config, inlineStyleId)) {
+          return `export default \`\``;
+        }
 
         try {
           const compiled = await preprocessCSS(

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -300,6 +300,14 @@ describe('load ?inline style imports', () => {
         (p) => p.name === '@analogjs/vite-plugin-angular',
       );
 
+      // Opt into CSS preprocessing under Vitest so this test exercises the
+      // preprocessCSS path. The plugin defaults to skipping it under Vitest
+      // unless `test.css` is enabled (see #2297).
+      (mainPlugin as any).configResolved({
+        server: { watch: {} },
+        test: { css: true },
+      });
+
       const resolveId = (mainPlugin as any).resolveId;
       const addWatchFile = vi.fn();
       const load = (mainPlugin as any).load.bind({ addWatchFile });
@@ -316,6 +324,42 @@ describe('load ?inline style imports', () => {
 
       const calls = vi.mocked(preprocessCSS).mock.calls;
       expect(calls[calls.length - 1][1]).toBe(normalizePath(cssPath));
+    } finally {
+      realFs.unlinkSync(cssPath);
+    }
+  });
+
+  it('skips preprocessCSS for virtual style imports when test.css is disabled', async () => {
+    const cssPath = path.join(tmpDir, `analog-virtual-skip-${Date.now()}.scss`);
+    realFs.writeFileSync(cssPath, '.foo { color: red; }', 'utf-8');
+
+    try {
+      const plugins = angular({ jit: true });
+      const mainPlugin = plugins.find(
+        (p) => p.name === '@analogjs/vite-plugin-angular',
+      );
+
+      // Default Vitest config: `test.css` is unset, which Vitest treats as
+      // an empty-include (no preprocessing). The plugin must mirror that.
+      (mainPlugin as any).configResolved({
+        server: { watch: {} },
+        test: {},
+      });
+
+      const resolveId = (mainPlugin as any).resolveId;
+      const load = (mainPlugin as any).load.bind({ addWatchFile: vi.fn() });
+      const virtualId = resolveId(
+        `angular:jit:style:file;./${path.basename(cssPath)}`,
+        path.join(tmpDir, 'host.component.ts'),
+      );
+
+      vi.mocked(preprocessCSS).mockClear();
+      const result = await load(virtualId);
+
+      expect(result).toBeDefined();
+      expect(result).toContain('export default');
+      expect(result).toContain('color: red');
+      expect(vi.mocked(preprocessCSS)).not.toHaveBeenCalled();
     } finally {
       realFs.unlinkSync(cssPath);
     }

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -81,6 +81,7 @@ import {
   loadVirtualStyleModule,
   rewriteHtmlRawImport,
   rewriteInlineStyleImport,
+  shouldPreprocessTestCss,
 } from './utils/virtual-resources.js';
 
 export enum DiagnosticModes {
@@ -565,6 +566,11 @@ export function angular(options?: PluginOptions): Plugin[] {
         if (/\.(css|scss|sass|less)\?inline$/.test(id)) {
           const filePath = id.split('?')[0];
           const code = await fsPromises.readFile(filePath, 'utf-8');
+          // In tests, mirror Vitest's `test.css` rules — defaults to no
+          // preprocessing (matches Vite's CSS pipeline behavior). (#2297)
+          if (!shouldPreprocessTestCss(resolvedConfig, filePath)) {
+            return `export default ${JSON.stringify(code)}`;
+          }
           const result = await preprocessCSS(code, filePath, resolvedConfig);
           return `export default ${JSON.stringify(result.code)}`;
         }
@@ -912,6 +918,12 @@ export function angular(options?: PluginOptions): Plugin[] {
           const filename =
             resourceFile ??
             containingFile.replace('.ts', `.${options?.inlineStylesExtension}`);
+
+          // In tests, mirror Vitest's `test.css` rules — defaults to no
+          // preprocessing (matches Vite's CSS pipeline behavior). (#2297)
+          if (!shouldPreprocessTestCss(resolvedConfig, filename)) {
+            return '';
+          }
 
           let stylesheetResult;
 

--- a/packages/vite-plugin-angular/src/lib/utils/virtual-resources.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/virtual-resources.spec.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ResolvedConfig } from 'vite';
+
+import { shouldPreprocessTestCss } from './virtual-resources.js';
+
+const cfg = (css: unknown): ResolvedConfig =>
+  ({ test: { css } }) as unknown as ResolvedConfig;
+
+describe('shouldPreprocessTestCss', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Force the helper into its test-mode branch.
+    process.env['VITEST'] = 'true';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns true when not in test mode (no NODE_ENV/VITEST)', () => {
+    delete process.env['VITEST'];
+    delete process.env['NODE_ENV'];
+    expect(shouldPreprocessTestCss(cfg(false), '/x.scss')).toBe(true);
+  });
+
+  it('returns true when test.css is true', () => {
+    expect(shouldPreprocessTestCss(cfg(true), '/x.scss')).toBe(true);
+  });
+
+  it('returns false when test.css is false', () => {
+    expect(shouldPreprocessTestCss(cfg(false), '/x.scss')).toBe(false);
+  });
+
+  it('returns false when test.css is unset (Vitest default)', () => {
+    expect(shouldPreprocessTestCss(cfg(undefined), '/x.scss')).toBe(false);
+    expect(shouldPreprocessTestCss({} as ResolvedConfig, '/x.scss')).toBe(
+      false,
+    );
+  });
+
+  it('matches a single RegExp include (not just arrays)', () => {
+    // Vitest's API accepts `RegExp | RegExp[]`, not only arrays. (#2298)
+    expect(
+      shouldPreprocessTestCss(cfg({ include: /\.scss$/ }), '/foo.scss'),
+    ).toBe(true);
+    expect(
+      shouldPreprocessTestCss(cfg({ include: /\.scss$/ }), '/foo.css'),
+    ).toBe(false);
+  });
+
+  it('matches a RegExp[] include and respects exclude', () => {
+    expect(
+      shouldPreprocessTestCss(
+        cfg({ include: [/\.scss$/], exclude: [/skip/] }),
+        '/foo.scss',
+      ),
+    ).toBe(true);
+    expect(
+      shouldPreprocessTestCss(
+        cfg({ include: [/\.scss$/], exclude: [/skip/] }),
+        '/skip.scss',
+      ),
+    ).toBe(false);
+  });
+
+  it('matches a single string exclude', () => {
+    expect(
+      shouldPreprocessTestCss(
+        cfg({ include: [/.+/], exclude: 'node_modules' }),
+        '/proj/node_modules/foo.scss',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false with object form when filePath is missing', () => {
+    expect(shouldPreprocessTestCss(cfg({ include: [/.+/] }))).toBe(false);
+  });
+
+  it('returns false with object form when include is empty', () => {
+    expect(shouldPreprocessTestCss(cfg({}), '/x.scss')).toBe(false);
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/utils/virtual-resources.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/virtual-resources.ts
@@ -22,6 +22,62 @@ interface PluginContextLike {
   addWatchFile(path: string): void;
 }
 
+type CssPattern = string | RegExp;
+
+type VitestCssOption =
+  | boolean
+  | undefined
+  | {
+      // Vitest accepts both single patterns and arrays for include/exclude.
+      include?: CssPattern | CssPattern[];
+      exclude?: CssPattern | CssPattern[];
+    };
+
+/**
+ * True when the given stylesheet should be run through Vite's `preprocessCSS`,
+ * given Vitest's `test.css` semantics:
+ *
+ *   - non-test contexts        → always preprocess
+ *   - `test.css: true`         → always preprocess
+ *   - `test.css: false`        → never preprocess
+ *   - `test.css: { include }`  → preprocess only when `filePath` matches an
+ *                                 include pattern and isn't excluded
+ *   - `test.css` unset         → Vitest defaults to `include: []`, so nothing
+ *                                 matches and we don't preprocess
+ *
+ * Used to gate `preprocessCSS` calls in test mode so we don't surface SCSS
+ * deprecation noise or pay preprocessing cost the user didn't ask for. (#2297)
+ */
+export function shouldPreprocessTestCss(
+  config: ResolvedConfig | undefined,
+  filePath?: string,
+): boolean {
+  const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
+  if (!isTest) return true;
+
+  const cssOpt = (
+    config as
+      | (ResolvedConfig & { test?: { css?: VitestCssOption } })
+      | undefined
+  )?.test?.css;
+
+  if (cssOpt === true) return true;
+  if (cssOpt === false || cssOpt == null) return false;
+
+  const toArray = <T>(value: T | T[] | undefined): T[] =>
+    value == null ? [] : Array.isArray(value) ? value : [value];
+  const include = toArray(cssOpt.include);
+  const exclude = toArray(cssOpt.exclude);
+  if (!filePath || include.length === 0) return false;
+
+  const matches = (patterns: CssPattern[]) =>
+    patterns.some((p) =>
+      typeof p === 'string' ? filePath.includes(p) : p.test(filePath),
+    );
+
+  return matches(include) && !matches(exclude);
+}
+
 function resolveImportPath(
   id: string,
   importer: string | undefined,
@@ -94,6 +150,11 @@ export async function loadVirtualStyleModule(
   const filePath = fromVirtualStyleId(id);
   ctx.addWatchFile(filePath);
   const code = await fsPromises.readFile(filePath, 'utf-8');
+  // In tests, mirror Vitest's `test.css` rules — defaults to no preprocessing
+  // (matches Vite's CSS pipeline behavior under Vitest). (#2297)
+  if (!shouldPreprocessTestCss(resolvedConfig, filePath)) {
+    return `export default ${JSON.stringify(code)}`;
+  }
   const result = await preprocessCSS(code, filePath, resolvedConfig);
   return `export default ${JSON.stringify(result.code)}`;
 }


### PR DESCRIPTION
## PR Checklist

`@analogjs/vite-plugin-angular` was calling `preprocessCSS` on every component style — inline `styles`, `styleUrl` external sheets, virtual style modules, and JIT inline styles — regardless of the user's Vitest `test.css` setting. In tests this surfaced SCSS deprecation warnings (e.g. `@import`, color-functions) and dominated runtime (one user reported transform time going from ~9s → ~35s).

Vite's own CSS pipeline already honors `test.css` and skips preprocessing for files outside the configured include patterns. The Analog plugin now mirrors that.

Closes #2297

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

A new shared helper `shouldPreprocessTestCss(config, filePath?)` mirrors Vitest's full `test.css` semantics:

| `test.css` value | Behavior |
|---|---|
| `true` | preprocess |
| `false` | skip |
| `{ include, exclude }` | preprocess only when path matches `include` and not `exclude` |
| unset (default) | skip — Vitest defaults to `include: []` |
| non-test context | always preprocess (unchanged) |

Routed through the helper:

- `utils/virtual-resources.ts` — `loadVirtualStyleModule` (the actual hit path for `styleUrl`-based external SCSS, rewritten to a virtual id)
- `angular-vite-plugin.ts` — the `?inline` CSS load fallback (added in #2271, the original regression site) and `transformStylesheet` for the Angular Compilation API
- `angular-jit-plugin.ts` — JIT inline-style virtual loader

When the helper says "skip", external-style loaders return the raw source as a default export (matching Vite's own pipeline) and inline style transforms return `''`.

## Test plan

- [x] `nx format:check`
- [x] `nx test vite-plugin-angular` — 66 tests pass (added one new spec covering the default-skip behavior; updated the existing virtual-style test to opt into preprocessing via `configResolved`)
- [x] Manual verification against the issue's StackBlitz repro: SCSS deprecation warnings gone, fatal `Can't find stylesheet to import` gone, transform time recovered. Confirmed working with both explicit `test.css: false` and the Vitest default.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Note: behavior **does** change for users who never set `test.css` and were relying on inline SCSS being preprocessed in tests — the plugin now skips, matching Vitest's documented default. Users who want preprocessing in tests must opt in with `test.css: true` or an `include` pattern. This restores the pre-2.4.4 behavior for the `?inline` external-style path and aligns the other paths with Vitest's defaults.

## Other information

`test.css` isn't on Vite's `ResolvedConfig` type, so the helper casts locally. The helper falls back to "always preprocess" outside test mode (detected via `NODE_ENV=test` / `VITEST` env), so dev/build paths are untouched.