### PR TITLE
fix(vite-plugin-angular): return empty CSS instead of raw SCSS when test.css is disabled

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -357,8 +357,9 @@ describe('load ?inline style imports', () => {
       const result = await load(virtualId);
 
       expect(result).toBeDefined();
-      expect(result).toContain('export default');
-      expect(result).toContain('color: red');
+      // When test.css is unset, styles are returned as empty strings to match
+      // Vitest's native behavior and avoid raw SCSS crashing jsdom. (#2304)
+      expect(result).toBe('export default ""');
       expect(vi.mocked(preprocessCSS)).not.toHaveBeenCalled();
     } finally {
       realFs.unlinkSync(cssPath);
@@ -373,8 +374,9 @@ describe('load ?inline style imports', () => {
       const load = getLoadHook();
       const result = await load(`${cssPath}?inline`);
       expect(result).toBeDefined();
-      expect(result).toContain('export default');
-      expect(result).toContain('color: red');
+      // When test.css is unset (no resolvedConfig), styles are returned empty
+      // to match Vitest's native behavior. (#2304)
+      expect(result).toBe('export default ""');
     } finally {
       realFs.unlinkSync(cssPath);
     }

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -572,8 +572,9 @@ export function angular(options?: PluginOptions): Plugin[] {
           const code = await fsPromises.readFile(filePath, 'utf-8');
           // In tests, mirror Vitest's `test.css` rules — defaults to no
           // preprocessing (matches Vite's CSS pipeline behavior). (#2297)
+          // Return empty CSS rather than raw preprocessor source. (#2304)
           if (!shouldPreprocessTestCss(resolvedConfig, filePath)) {
-            return `export default ${JSON.stringify(code)}`;
+            return `export default ""`;
           }
           const result = await preprocessCSS(code, filePath, resolvedConfig);
           return `export default ${JSON.stringify(result.code)}`;

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -290,8 +290,9 @@ export function fastCompilePlugin(
             );
             // In tests, mirror Vitest's `test.css` rules — defaults to no
             // preprocessing (matches Vite's CSS pipeline behavior). (#2297)
+            // Return empty rather than raw preprocessor source. (#2304)
             if (!shouldPreprocessTestCss(resolvedConfig, fakePath)) {
-              resolvedInlineStyles.set(i, styleStrings[i]);
+              resolvedInlineStyles.set(i, '');
               continue;
             }
             const processed = await preprocessCSS(
@@ -501,8 +502,9 @@ export function fastCompilePlugin(
         const code = await fsPromises.readFile(filePath, 'utf-8');
         // In tests, mirror Vitest's `test.css` rules — defaults to no
         // preprocessing (matches Vite's CSS pipeline behavior). (#2297)
+        // Return empty CSS rather than raw preprocessor source. (#2304)
         if (!shouldPreprocessTestCss(resolvedConfig, filePath)) {
-          return `export default ${JSON.stringify(code)}`;
+          return `export default ""`;
         }
         const result = await preprocessCSS(code, filePath, resolvedConfig);
         return `export default ${JSON.stringify(result.code)}`;

--- a/packages/vite-plugin-angular/src/lib/utils/virtual-resources.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/virtual-resources.ts
@@ -152,8 +152,10 @@ export async function loadVirtualStyleModule(
   const code = await fsPromises.readFile(filePath, 'utf-8');
   // In tests, mirror Vitest's `test.css` rules — defaults to no preprocessing
   // (matches Vite's CSS pipeline behavior under Vitest). (#2297)
+  // Return empty CSS rather than raw SCSS/Sass/Less source, which would crash
+  // jsdom's CSS parser (css-tree) on preprocessor-specific syntax. (#2304)
   if (!shouldPreprocessTestCss(resolvedConfig, filePath)) {
-    return `export default ${JSON.stringify(code)}`;
+    return `export default ""`;
   }
   const result = await preprocessCSS(code, filePath, resolvedConfig);
   return `export default ${JSON.stringify(result.code)}`;


### PR DESCRIPTION
## PR Checklist

Closes analogjs/analog#2304

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

When `shouldPreprocessTestCss` returns `false` (the default when Vitest's `test.css` is unset), the plugin now returns empty CSS (`export default ""`) instead of the raw preprocessor source. This prevents uncompiled SCSS/Sass/Less from reaching jsdom, where `css-tree` would crash on preprocessor-specific syntax (e.g., `$variables` in `calc()`).

This matches Vitest's native behavior — when `test.css` is disabled or unset, CSS imports resolve to empty strings. Two existing call sites (NgtscProgram stylesheet resolution and JIT inline styles) already returned empty correctly; this PR fixes the remaining three call sites plus the fast-compile inline styles path to be consistent.

**Call sites fixed:**
- `loadVirtualStyleModule()` in `virtual-resources.ts` — component `styleUrls` via virtual IDs
- `?inline` style load path in `angular-vite-plugin.ts`
- `?inline` style load path in `fast-compile-plugin.ts`
- Inline style resolution in `fast-compile-plugin.ts`

## Test plan

- [x] `pnpm nx test vite-plugin-angular` — 677 passed, 2 skipped
- [x] `pnpm nx build vite-plugin-angular` — builds successfully
- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a follow-up to [analogjs/analog#2297](https://github.com/analogjs/analog/issues/2297) which introduced the `shouldPreprocessTestCss` guard. The guard correctly skips expensive SCSS preprocessing in tests, but the fallback returned raw preprocessor source instead of empty CSS. The raw SCSS then crashed jsdom's `css-tree` parser when it encountered SCSS-specific syntax.