### PR TITLE
fix(storybook-angular): use oxc config instead of esbuild for Vite 8

### DIFF
--- a/packages/storybook-angular/src/lib/preset.spec.ts
+++ b/packages/storybook-angular/src/lib/preset.spec.ts
@@ -24,6 +24,7 @@ vi.mock('@storybook/builder-vite', () => ({}));
 vi.mock('vite', () => ({
   mergeConfig: (_base: unknown, override: unknown) => override,
   normalizePath: (p: string) => p,
+  rolldownVersion: undefined,
 }));
 
 vi.mock('@analogjs/vite-plugin-angular', () => ({
@@ -61,6 +62,7 @@ const registerDependencyMocks = () => {
   vi.doMock('vite', () => ({
     mergeConfig: (_base: unknown, override: unknown) => override,
     normalizePath: (p: string) => p,
+    rolldownVersion: undefined,
   }));
   vi.doMock('@analogjs/vite-plugin-angular', () => ({
     default: () => ({ name: 'angular-mock' }),

--- a/packages/storybook-angular/src/lib/preset.ts
+++ b/packages/storybook-angular/src/lib/preset.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import { core as PresetCore } from '@storybook/angular/preset';
 import { fileURLToPath } from 'node:url';
+import * as vite from 'vite';
 
 export const previewAnnotations = async (entries = [], options) => {
   const config = fileURLToPath(
@@ -108,7 +109,7 @@ export const viteFinal = async (config, options) => {
             : 'css',
       }),
       angularOptionsPlugin(options, { normalizePath, experimentalZoneless }),
-      storybookEsbuildPlugin(),
+      storybookTransformConfigPlugin(),
     ],
     define: {
       STORYBOOK_ANGULAR_OPTIONS: JSON.stringify({
@@ -202,13 +203,15 @@ function angularOptionsPlugin(
   };
 }
 
-function storybookEsbuildPlugin() {
+function storybookTransformConfigPlugin() {
+  const configKey = vite.rolldownVersion ? 'oxc' : 'esbuild';
+
   return {
-    name: 'analogjs-storybook-esbuild-config',
+    name: 'analogjs-storybook-transform-config',
     apply: 'build',
     config() {
       return {
-        esbuild: {
+        [configKey]: {
           // Don't mangle class names during the build
           // This fixes display of compodoc argtypes
           keepNames: true,


### PR DESCRIPTION
## PR Checklist

Closes #2312

## Affected scope

- Primary scope: storybook-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Backports the esbuild-to-oxc detection from `alpha` to `beta`. Vite 8 deprecated the `esbuild` config option in favor of `oxc`, causing deprecation warnings when running Storybook builds.

The plugin now checks `vite.rolldownVersion` (present in Vite 8+) to decide whether to set `oxc: { keepNames: true }` or `esbuild: { keepNames: true }`, matching the pattern already used across the rest of the codebase. Also renames the plugin from `analogjs-storybook-esbuild-config` to `analogjs-storybook-transform-config` to reflect the change.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a minimal backport of the relevant changes from [analogjs/analog#2121](https://github.com/analogjs/analog/pull/2121) (already on `alpha`). The full alpha diff includes unrelated type annotations, debug logging, and SCSS resolution changes that are not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)