### PR TITLE
fix(vite-plugin-angular): cross-compiler AOT registry handoff + regex/plugin-dedup fixes

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1556,7 +1556,14 @@ export function angular(options?: PluginOptions): Plugin[] {
     templateClassBindingGuardPlugin(guardContext),
     pluginOptions.hasTailwindCss &&
       tailwindReferencePlugin({ tailwindCss: pluginOptions.tailwindCss }),
-    angularPlugin(),
+    // Skip the legacy ngc-driven plugin when fastCompile owns the transform.
+    // Its `transform` hook has no `enforce: 'pre'` and runs AFTER fastCompile's,
+    // overwriting the AOT output with ngc's `fileEmitter` result. For
+    // cross-compiler imports (e.g. a TS `@Component` referencing a class
+    // compiled by an out-of-tree compiler like `@tsrx/analog`), ngc can't
+    // resolve the import and emits a legacy `__decorate` form that triggers
+    // a JIT fallback at runtime.
+    !pluginOptions.fastCompile && angularPlugin(),
     pluginOptions.liveReload && liveReloadPlugin({ classNames, fileEmitter }),
     compilationPlugin,
     !pluginOptions.fastCompile &&

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1556,15 +1556,13 @@ export function angular(options?: PluginOptions): Plugin[] {
     templateClassBindingGuardPlugin(guardContext),
     pluginOptions.hasTailwindCss &&
       tailwindReferencePlugin({ tailwindCss: pluginOptions.tailwindCss }),
-    // Skip the legacy ngc-driven plugin when fastCompile owns the transform.
-    // Its `transform` hook has no `enforce: 'pre'` and runs AFTER fastCompile's,
-    // overwriting the AOT output with ngc's `fileEmitter` result. For
-    // cross-compiler imports (e.g. a TS `@Component` referencing a class
-    // compiled by an out-of-tree compiler like `@tsrx/analog`), ngc can't
-    // resolve the import and emits a legacy `__decorate` form that triggers
-    // a JIT fallback at runtime.
-    !pluginOptions.fastCompile && angularPlugin(),
     pluginOptions.liveReload && liveReloadPlugin({ classNames, fileEmitter }),
+    // `compilationPlugin` is either `angularPlugin()` or `fastCompilePlugin()`
+    // depending on `pluginOptions.fastCompile`. When fastCompile is off the
+    // array used to also include an unconditional `angularPlugin()` right
+    // before this line — invoking the same plugin twice and double-
+    // registering its hooks. Removed: `compilationPlugin` already covers both
+    // branches.
     compilationPlugin,
     !pluginOptions.fastCompile &&
       pluginOptions.liveReload &&

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -39,6 +39,21 @@ import {
 } from './utils/virtual-resources.js';
 import { markStylePathSafe } from './utils/safe-module-paths.js';
 
+declare global {
+  /**
+   * Shared convention for out-of-tree compilers (e.g. `@tsrx/analog`) that
+   * produce Angular Ivy definitions from a non-TS source format. Populate
+   * this map with directive/component metadata for any class fastCompile
+   * can't reach through its own tsconfig-driven scan, and the per-compile
+   * registry lookup in `fastCompilePlugin` will merge those entries in —
+   * so TS `@Component({ imports: [X] })` references to such classes
+   * resolve statically instead of hitting the `_unresolved-${className}`
+   * sentinel.
+   */
+  // eslint-disable-next-line no-var
+  var __ANALOG_EXTERNAL_REGISTRY__: ComponentRegistry | undefined;
+}
+
 export interface FastCompilePluginOptions {
   tsconfigGetter: () => string;
   workspaceRoot: string;
@@ -305,8 +320,23 @@ export function fastCompilePlugin(
 
     ensureDtsRegistryForSource(code, id);
 
+    // Merge entries from the shared external-registry global into this
+    // compile's lookup view. Convention: out-of-tree compilers populate
+    // `globalThis.__ANALOG_EXTERNAL_REGISTRY__` with directive metadata
+    // for classes fastCompile can't reach through its tsconfig-driven
+    // scan (e.g. `.tsrx` files compiled by `@tsrx/analog`). Without this
+    // merge, a TS `@Component({ imports: [X] })` that references such a
+    // class hits `_unresolved-${className}` as its selector and the tag
+    // never matches at runtime.
+    let compileRegistry: ComponentRegistry = registry;
+    const externalRegistry = globalThis.__ANALOG_EXTERNAL_REGISTRY__;
+    if (externalRegistry && externalRegistry.size > 0) {
+      compileRegistry = new Map(registry);
+      for (const [k, v] of externalRegistry) compileRegistry.set(k, v);
+    }
+
     const result = compile(code, id, {
-      registry,
+      registry: compileRegistry,
       resolvedStyles,
       resolvedInlineStyles,
       useDefineForClassFields,

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { TS_EXT_REGEX } from './plugin-config.js';
+
+describe('TS_EXT_REGEX', () => {
+  describe('matches genuine TypeScript files', () => {
+    it.each([
+      '/abs/path/file.ts',
+      'file.ts',
+      'file.cts',
+      'file.mts',
+      'file.ts?import',
+      'file.ts?v=123',
+      'file.cts?inline',
+      'file.mts?foo=bar',
+      // Generated .ts.map side-files — the regex shouldn't reject `.ts`
+      // because of a trailing `.map` segment.
+      'file.ts.map',
+    ])('%s', (id) => {
+      expect(TS_EXT_REGEX.test(id)).toBe(true);
+    });
+  });
+
+  describe('rejects .tsx and other .ts<letter>… look-alikes', () => {
+    it.each([
+      'file.tsx',
+      'file.ctsx',
+      'file.mtsx',
+      'file.tsx?import',
+      // Historical bug: the old `/\.[cm]?(ts)[^x]?\??/` admitted these
+      // because `[^x]?` matched any non-x letter (and `?` allowed zero
+      // chars). The fixed form uses a negative lookahead on an ASCII
+      // letter, so any `.ts<letter>…` form is rejected.
+      'file.tsrx',
+      'file.tsrx?import',
+      'file.tsrx?v=abc',
+      'file.tsz',
+      'file.tsd',
+    ])('%s', (id) => {
+      expect(TS_EXT_REGEX.test(id)).toBe(false);
+    });
+  });
+
+  describe('rejects unrelated extensions', () => {
+    it.each([
+      'file.js',
+      'file.jsx',
+      'file.mjs',
+      'file.cjs',
+      'file.json',
+      'file.html',
+      'file.css',
+      'file',
+    ])('%s', (id) => {
+      expect(TS_EXT_REGEX.test(id)).toBe(false);
+    });
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
@@ -10,10 +10,17 @@ import {
 
 /**
  * TypeScript file extension regex
- * Match .(c or m)ts, .ts extensions with an optional ? for query params
- * Ignore .tsx extensions
+ * Match .ts / .cts / .mts extensions with an optional ?query suffix.
+ * Reject .tsx — and any other `.ts<letter>…` extension like .tsrx — via
+ * a negative-lookahead on a following ASCII letter, so only genuine TS
+ * files pass.
+ *
+ * Previous form `/\.[cm]?(ts)[^x]?\??/` was intended to exclude `.tsx`
+ * specifically (`[^x]?` = not-an-x), but the `?` quantifier also allows
+ * zero characters, and any non-`x` letter was admitted — so `.tsrx`
+ * and similar extensions matched by accident.
  */
-export const TS_EXT_REGEX = /\.[cm]?(ts)[^x]?\??/;
+export const TS_EXT_REGEX = /\.[cm]?ts(?![a-z])/;
 
 export interface TsConfigResolutionContext {
   root: string;


### PR DESCRIPTION
## PR Checklist

Enables TypeScript `@Component({ imports: [X] })` to resolve at AOT time when `X` comes from an out-of-tree compiler that emits its own Angular Ivy definitions from a non-TS source format (e.g. `@tsrx/analog` compiling `.tsrx` files). Fixes two bugs in `vite-plugin-angular` uncovered while validating the handoff end-to-end.

Closes #

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [ ] Squash merge
- [x] Rebase merge
- [ ] Other

## Commit preservation note [optional]

Each commit stands on its own with a substantive message documenting a non-obvious root cause — the regex pitfall (`[^x]?` admitting `.tsrx`) and the duplicate `angularPlugin()` registration that silently overwrote fastCompile's AOT output. Preserving the boundaries keeps those explanations greppable via `git log`/`git blame` for future debugging.

## What is the new behavior?

1. **`globalThis.__ANALOG_EXTERNAL_REGISTRY__` handoff (feat)** — fastCompile merges an external registry populated by out-of-tree compilers (className → directive metadata: selector, kind, inputs, outputs) into its per-compile view. Without the merge, `imports: [X]` from a cross-compiler class resolved to the `_unresolved-${className}` sentinel and the tag never matched at runtime. The type is declared globally so callers don't need to cast. Also skips the legacy unconditional `angularPlugin()` entry when `fastCompile: true`, since its non-`enforce: 'pre'` `transform` ran AFTER fastCompile and overwrote its AOT output with ngc's `fileEmitter` result (triggering a runtime JIT fallback — *\"needs @angular/compiler\"*).

2. **`.tsrx` regex rejection (fix)** — the prior TS-extension pattern `/\.[cm]?(ts)[^x]?\??/` was too permissive; `[^x]?` admits zero chars or any non-`x` letter, so `.tsrx`, `.tsz`, `.tsd` all matched by accident. Replaced with `/\.[cm]?ts(?![a-z])/` — negative lookahead on any ASCII letter after `ts`. Matrix test added in `plugin-config.spec.ts`.

3. **Deduplicate `angularPlugin()` in plugin array (fix)** — the plugin array had `angularPlugin()` called unconditionally *and* `compilationPlugin` (which already selects the right plugin for both fastCompile branches), so every `.ts` transform ran through the full ngc pipeline twice. Removed the unconditional entry.

Verified end-to-end against `@tsrx/analog`: a TS `@Component` hosts a `.tsrx` component via `imports: [Counter]`, renders AOT-only with no `@angular/compiler` in the bundle, through fine-grained signal-based change detection.

## Test plan

- [x] `nx format:check`
- [x] `pnpm nx test vite-plugin-angular`
- [x] Manual verification against `@tsrx/analog` (AOT render, no `@angular/compiler` in bundle)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Additive: `globalThis.__ANALOG_EXTERNAL_REGISTRY__` is optional and only consulted when present; existing consumers are unaffected. The regex tightening and plugin-dedup are corrective.

## Other information

🤖 Generated with [Claude Code](https://claude.com/claude-code)