### PR TITLE
feat(vite-plugin-angular): external-registry hook + .tsrx regex fix (beta backport)

### DIFF
--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -39,6 +39,21 @@ import {
 } from './utils/virtual-resources.js';
 import { markStylePathSafe } from './utils/safe-module-paths.js';
 
+declare global {
+  /**
+   * Shared convention for out-of-tree compilers (e.g. `@tsrx/analog`) that
+   * produce Angular Ivy definitions from a non-TS source format. Populate
+   * this map with directive/component metadata for any class fastCompile
+   * can't reach through its own tsconfig-driven scan, and the per-compile
+   * registry lookup in `fastCompilePlugin` will merge those entries in —
+   * so TS `@Component({ imports: [X] })` references to such classes
+   * resolve statically instead of hitting the `_unresolved-${className}`
+   * sentinel.
+   */
+  // eslint-disable-next-line no-var
+  var __ANALOG_EXTERNAL_REGISTRY__: ComponentRegistry | undefined;
+}
+
 export interface FastCompilePluginOptions {
   tsconfigGetter: () => string;
   workspaceRoot: string;
@@ -305,8 +320,23 @@ export function fastCompilePlugin(
 
     ensureDtsRegistryForSource(code, id);
 
+    // Merge entries from the shared external-registry global into this
+    // compile's lookup view. Convention: out-of-tree compilers populate
+    // `globalThis.__ANALOG_EXTERNAL_REGISTRY__` with directive metadata
+    // for classes fastCompile can't reach through its tsconfig-driven
+    // scan (e.g. `.tsrx` files compiled by `@tsrx/analog`). Without this
+    // merge, a TS `@Component({ imports: [X] })` that references such a
+    // class hits `_unresolved-${className}` as its selector and the tag
+    // never matches at runtime.
+    let compileRegistry: ComponentRegistry = registry;
+    const externalRegistry = globalThis.__ANALOG_EXTERNAL_REGISTRY__;
+    if (externalRegistry && externalRegistry.size > 0) {
+      compileRegistry = new Map(registry);
+      for (const [k, v] of externalRegistry) compileRegistry.set(k, v);
+    }
+
     const result = compile(code, id, {
-      registry,
+      registry: compileRegistry,
       resolvedStyles,
       resolvedInlineStyles,
       useDefineForClassFields,

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { TS_EXT_REGEX } from './plugin-config.js';
+
+describe('TS_EXT_REGEX', () => {
+  describe('matches genuine TypeScript files', () => {
+    it.each([
+      '/abs/path/file.ts',
+      'file.ts',
+      'file.cts',
+      'file.mts',
+      'file.ts?import',
+      'file.ts?v=123',
+      'file.cts?inline',
+      'file.mts?foo=bar',
+      // Generated .ts.map side-files — the regex shouldn't reject `.ts`
+      // because of a trailing `.map` segment.
+      'file.ts.map',
+    ])('%s', (id) => {
+      expect(TS_EXT_REGEX.test(id)).toBe(true);
+    });
+  });
+
+  describe('rejects .tsx and other .ts<letter>… look-alikes', () => {
+    it.each([
+      'file.tsx',
+      'file.ctsx',
+      'file.mtsx',
+      'file.tsx?import',
+      // Historical bug: the old `/\.[cm]?(ts)[^x]?\??/` admitted these
+      // because `[^x]?` matched any non-x letter (and `?` allowed zero
+      // chars). The fixed form uses a negative lookahead on an ASCII
+      // letter, so any `.ts<letter>…` form is rejected.
+      'file.tsrx',
+      'file.tsrx?import',
+      'file.tsrx?v=abc',
+      'file.tsz',
+      'file.tsd',
+    ])('%s', (id) => {
+      expect(TS_EXT_REGEX.test(id)).toBe(false);
+    });
+  });
+
+  describe('rejects unrelated extensions', () => {
+    it.each([
+      'file.js',
+      'file.jsx',
+      'file.mjs',
+      'file.cjs',
+      'file.json',
+      'file.html',
+      'file.css',
+      'file',
+    ])('%s', (id) => {
+      expect(TS_EXT_REGEX.test(id)).toBe(false);
+    });
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
@@ -10,10 +10,17 @@ import {
 
 /**
  * TypeScript file extension regex
- * Match .(c or m)ts, .ts extensions with an optional ? for query params
- * Ignore .tsx extensions
+ * Match .ts / .cts / .mts extensions with an optional ?query suffix.
+ * Reject .tsx — and any other `.ts<letter>…` extension like .tsrx — via
+ * a negative-lookahead on a following ASCII letter, so only genuine TS
+ * files pass.
+ *
+ * Previous form `/\.[cm]?(ts)[^x]?\??/` was intended to exclude `.tsx`
+ * specifically (`[^x]?` = not-an-x), but the `?` quantifier also allows
+ * zero characters, and any non-`x` letter was admitted — so `.tsrx`
+ * and similar extensions matched by accident.
  */
-export const TS_EXT_REGEX = /\.[cm]?(ts)[^x]?\??/;
+export const TS_EXT_REGEX = /\.[cm]?ts(?![a-z])/;
 
 export interface TsConfigResolutionContext {
   root: string;


### PR DESCRIPTION
## PR Checklist

Backport from [analogjs/analog#2315](https://github.com/analogjs/analog/pull/2315) (alpha) of the parts that apply to beta:

1. `globalThis.__ANALOG_EXTERNAL_REGISTRY__` handoff for fastCompile — lets out-of-tree compilers (e.g. `@tsrx/analog` compiling `.tsrx` files) feed directive metadata into fastCompile's per-compile registry view, so TS `@Component({ imports: [X] })` references to such classes resolve statically instead of hitting the `_unresolved-${className}` sentinel.
2. `.tsrx` regex rejection — tightens `TS_EXT_REGEX` so non-TS extensions like `.tsrx`, `.tsz`, `.tsd` are no longer accidentally matched (the prior `[^x]?` quantifier admitted zero chars or any non-`x` letter).

Closes #

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [ ] Squash merge
- [x] Rebase merge
- [ ] Other

## Commit preservation note [optional]

Two commits that tell distinct stories and document non-obvious root causes worth keeping greppable via `git log`/`git blame`:

- `feat(vite-plugin-angular): add globalThis external-registry hook for fastCompile` — the handoff convention and why the merge has to happen per-compile rather than at registry build time.
- `fix(vite-plugin-angular): stop matching .tsrx in TS extension regex` — the regex pitfall (`[^x]?` admitting `.tsrx`) and the matrix of cases the replacement `/\.[cm]?ts(?![a-z])/` covers.

## What is the new behavior?

### Backported vs. not

Scope differs slightly from the alpha PR ([analogjs/analog#2315](https://github.com/analogjs/analog/pull/2315)) because the plumbing on beta is already different:

- **Backported:** the `fast-compile-plugin.ts` registry merge (applies verbatim — beta has fastCompile and the `ComponentRegistry` plumbing).
- **Backported:** the `.tsrx` regex fix (the buggy pattern `/\.[cm]?(ts)[^x]?\??/` exists on beta verbatim).
- **Not backported:** the `!pluginOptions.fastCompile && angularPlugin()` guard in `angular-vite-plugin.ts`. Beta's plugin array already skips the legacy ngc-driven plugin when fastCompile is on via the `compilationPlugin` ternary — no duplicate registration to guard against.
- **Not backported:** the alpha dedup commit (`don't include angularPlugin twice in plugin array`). Same reason — the duplicate doesn't exist on beta.

### Registry merge (fastCompile)

`fastCompilePlugin` now consults `globalThis.__ANALOG_EXTERNAL_REGISTRY__` on each compile and merges its entries into the per-compile registry view before the `compile()` call. Without the merge, a TS `@Component({ imports: [X] })` that references a class from an out-of-tree compiler hit `_unresolved-${className}` as its selector and the tag never matched at runtime. The global type is declared in `fast-compile-plugin.ts` so callers don't need to cast when reading/writing it.

### Regex tightening

`/\.[cm]?(ts)[^x]?\??/` was intended to accept `.ts` / `.cts` / `.mts` and reject `.tsx`, but `[^x]?` is too permissive — the `?` quantifier allows zero chars, and any non-`x` letter is admitted. So `.tsrx`, `.tsz`, `.tsd` all matched by accident. `.tsrx` in particular caused ngc to try compiling out-of-tree source as if it were TypeScript, stripping the module's exports on the way out.

Replaced with `/\.[cm]?ts(?![a-z])/` — negative lookahead on any ASCII letter after `ts`. Matrix covered by a new `plugin-config.spec.ts`:

- `.ts`, `.ts?query`, `.ts.map` → match
- `.cts`, `.mts` → match
- `.tsx`, `.ctsx`, `.mtsx` → reject
- `.tsrx`, `.tsz`, `.tsd`, any `.ts<letter>…` → reject

## Test plan

- [x] `nx format:check`
- [x] `pnpm nx test vite-plugin-angular` (694 passed, 2 pre-existing skips)
- [x] Verified end-to-end against `@tsrx/analog` on alpha (same code path)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Additive: `globalThis.__ANALOG_EXTERNAL_REGISTRY__` is optional and only consulted when present and non-empty; existing consumers are unaffected. The regex tightening is corrective — files previously matched by accident (`.tsrx` et al.) were never intended to flow through the TS transform.

## Other information

🤖 Generated with [Claude Code](https://claude.com/claude-code)