### PR TITLE
fix(vite-plugin-angular): use empty string instead of undefined for mapRoot/sourceRoot overrides

### DIFF
--- a/packages/vite-plugin-angular/src/lib/utils/tsconfig-resolver.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/tsconfig-resolver.ts
@@ -75,8 +75,8 @@ export class TsconfigResolver {
       annotationsAs: 'decorators',
       enableResourceInlining: false,
       noEmitOnError: false,
-      mapRoot: undefined,
-      sourceRoot: undefined,
+      mapRoot: '',
+      sourceRoot: '',
       supportTestBed: false,
       supportJitMode: false,
     });


### PR DESCRIPTION
When a project's tsconfig.json inherits mapRoot from a base config, the readConfiguration() override of mapRoot: undefined does not effectively clear it. This causes TS5069: 'Option mapRoot cannot be specified without specifying option sourceMap' because the plugin also sets sourceMap: false.

Root cause: readConfiguration() internally calls
ts.parseJsonConfigFileContent(config, host, basePath, existingOptions). The existingOptions object contains mapRoot: undefined, but TypeScript's parseJsonConfigFileContent reads the raw JSON config first (which has the inherited mapRoot value), and the undefined value in the overrides does not reliably clear the option. TypeScript then sees mapRoot as specified (from the JSON) while sourceMap is false (from the override), triggering TS5069.

The fix changes mapRoot and sourceRoot from undefined to empty string. An empty string is a valid value that TypeScript treats as 'not specified' for path-based options, and unlike undefined, it does override the inherited value in parseJsonConfigFileContent.

This eliminates the need for users to add mapRoot workarounds in their vite-specific tsconfig files.

## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #2319


## Affected scope

<!-- List the primary scope from CONTRIBUTING.md and any closely related secondary scopes. -->

- Primary scope:
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

<!-- Squash merge is highly preferred. -->
<!-- Recommend a non-squash merge only if you can justify why the PR should bypass focused changes per package. -->

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

<!-- If you recommend a non-squash merge, briefly explain why the commit boundaries matter and why this PR should bypass focused changes per package. -->

## What is the new behavior?

## Test plan

<!-- List the commands you ran and any manual verification you performed. -->

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
