### PR TITLE
fix(vite-plugin-angular): emit compilation API diagnostics once with location info

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
@@ -105,6 +105,11 @@ export function compilationAPIPlugin(
   let compilationLock = Promise.resolve();
   let pendingCompilation: Promise<void> | null = null;
   let initialCompilation = false;
+  let compilationDiagnostics: { errors: string[]; warnings: string[] } = {
+    errors: [],
+    warnings: [],
+  };
+  let diagnosticsEmitted = false;
   let viteServer: ViteDevServer | undefined;
 
   const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
@@ -460,8 +465,33 @@ export function compilationAPIPlugin(
         : DiagnosticModes.All,
     );
 
-    const errors = diagnostics.errors?.length ? diagnostics.errors : [];
-    const warnings = diagnostics.warnings?.length ? diagnostics.warnings : [];
+    compilationDiagnostics = {
+      errors: (diagnostics.errors || []).map(
+        (d: {
+          text?: string;
+          location?: { file?: string; line?: number; column?: number } | null;
+        }) => {
+          const loc = d.location;
+          const prefix = loc?.file
+            ? `${loc.file}${loc.line != null ? `:${loc.line}` : ''}${loc.column != null ? `:${loc.column}` : ''} - `
+            : '';
+          return `${prefix}${d.text || ''}`;
+        },
+      ),
+      warnings: (diagnostics.warnings || []).map(
+        (d: {
+          text?: string;
+          location?: { file?: string; line?: number; column?: number } | null;
+        }) => {
+          const loc = d.location;
+          const prefix = loc?.file
+            ? `${loc.file}${loc.line != null ? `:${loc.line}` : ''}${loc.column != null ? `:${loc.column}` : ''} - `
+            : '';
+          return `${prefix}${d.text || ''}`;
+        },
+      ),
+    };
+    diagnosticsEmitted = false;
 
     const templateUpdates = mapTemplateUpdatesToFiles(
       compilationResult.templateUpdates,
@@ -491,10 +521,8 @@ export function compilationAPIPlugin(
       outputFiles.set(normalizedFilename, {
         content: file.contents,
         dependencies: [],
-        errors: errors.map((error: { text?: string }) => error.text || ''),
-        warnings: warnings.map(
-          (warning: { text?: string }) => warning.text || '',
-        ),
+        errors: [],
+        warnings: [],
         hmrUpdateCode: templateUpdate?.code,
         hmrEligible: !!templateUpdate?.code,
       });
@@ -619,6 +647,16 @@ export function compilationAPIPlugin(
         await performCompilation(resolvedConfig);
         pendingCompilation = null;
         initialCompilation = true;
+      }
+
+      if (!diagnosticsEmitted) {
+        for (const warning of compilationDiagnostics.warnings) {
+          this.warn(warning);
+        }
+        if (compilationDiagnostics.errors.length > 0) {
+          this.error(compilationDiagnostics.errors.join('\n'));
+        }
+        diagnosticsEmitted = true;
       }
     },
     async handleHotUpdate(ctx) {
@@ -766,6 +804,16 @@ export function compilationAPIPlugin(
         if (pendingCompilation) {
           await pendingCompilation;
           pendingCompilation = null;
+        }
+
+        if (!diagnosticsEmitted) {
+          for (const warning of compilationDiagnostics.warnings) {
+            this.warn(warning);
+          }
+          if (compilationDiagnostics.errors.length > 0) {
+            this.error(compilationDiagnostics.errors.join('\n'));
+          }
+          diagnosticsEmitted = true;
         }
 
         const typescriptResult = fileEmitter(id);


### PR DESCRIPTION

Previously, performAngularCompilation() attached all global diagnostics to every emitted file in the outputFiles map. The transform hook then emitted each file's warnings via this.warn(), causing an N×M explosion (e.g. 485 warnings × 85 files = 41,087 total warnings).

Additionally, the PartialMessage objects from diagnoseFiles() contain rich location info (file, line, column) but only warning.text was kept, discarding all location context and making it impossible to locate the source of each diagnostic.

This fix:
- Stores diagnostics at the module level instead of per-file
- Emits them once in buildStart (initial build) and once in the transform hook (HMR recompilations) using a diagnosticsEmitted flag
- Includes file:line:column location info in diagnostic messages

## PR Checklist

Closes #2317

## Affected scope

<!-- List the primary scope from CONTRIBUTING.md and any closely related secondary scopes. -->

- Primary scope:
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

<!-- Squash merge is highly preferred. -->
<!-- Recommend a non-squash merge only if you can justify why the PR should bypass focused changes per package. -->

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

<!-- If you recommend a non-squash merge, briefly explain why the commit boundaries matter and why this PR should bypass focused changes per package. -->

## What is the new behavior?

## Test plan

<!-- List the commands you ran and any manual verification you performed. -->

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
