### PR TITLE
fix(vite-plugin-angular): use empty string instead of undefined for mapRoot/sourceRoot overrides (beta)

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1034,8 +1034,8 @@ export function angular(options?: PluginOptions): Plugin[] {
         annotationsAs: 'decorators',
         enableResourceInlining: false,
         noEmitOnError: false,
-        mapRoot: undefined,
-        sourceRoot: undefined,
+        mapRoot: '',
+        sourceRoot: '',
         supportTestBed: false,
         supportJitMode: false,
       });


### PR DESCRIPTION
## PR Checklist

Backports the fix from #2320 (merged to `alpha`) onto the `beta` branch. On `beta`, the equivalent `readConfiguration()` call lives in `packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts` rather than `utils/tsconfig-resolver.ts`, so the same two-line override is applied there.

Closes #2319

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

When a project's `tsconfig.json` inherits `mapRoot` from a base config, the `readConfiguration()` override of `mapRoot: undefined` does not effectively clear it. This causes TS5069: 'Option mapRoot cannot be specified without specifying option sourceMap' because the plugin also sets `sourceMap: false`.

Root cause: `readConfiguration()` internally calls `ts.parseJsonConfigFileContent(config, host, basePath, existingOptions)`. The `existingOptions` object contains `mapRoot: undefined`, but TypeScript's `parseJsonConfigFileContent` reads the raw JSON config first (which has the inherited `mapRoot` value), and the `undefined` value in the overrides does not reliably clear the option. TypeScript then sees `mapRoot` as specified (from the JSON) while `sourceMap` is `false` (from the override), triggering TS5069.

The fix changes `mapRoot` and `sourceRoot` from `undefined` to empty string. An empty string is a valid value that TypeScript treats as 'not specified' for path-based options, and unlike `undefined`, it does override the inherited value in `parseJsonConfigFileContent`.

This eliminates the need for users to add `mapRoot` workarounds in their vite-specific tsconfig files.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Backport of #2320 to `beta`.

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

🤖 Generated with [Claude Code](https://claude.com/claude-code)