### PR TITLE
feat(content): improve support for hierarchical content 

### DIFF
--- a/apps/docs-app/docs/features/routing/content.md
+++ b/apps/docs-app/docs/features/routing/content.md
@@ -274,6 +274,8 @@ Hello World
 
 To get a list using the list of content files in the `src/content` folder, use the `injectContentFiles<Attributes>(filterFn?: InjectContentFilesFilterFunction<Attributes>)` function from the `@analogjs/content` package in your component. To narrow the files, you can use the `filterFn` predicate function as an argument. You can use the `InjectContentFilesFilterFunction<T>` type to set up your predicate.
 
+> `injectContentFiles` returns metadata only — `filename`, `slug`, and `attributes`. The `content` body is not loaded; reading it from the returned items yields `undefined`. Use `injectContent` to load and render an individual file's body.
+
 ```ts
 import { Component } from '@angular/core';
 import { RouterLink, RouterOutlet } from '@angular/router';
@@ -471,6 +473,55 @@ export default class ProjectComponent {
   });
 }
 ```
+
+### Hierarchical (Nested) Content
+
+When content is organized into category subdirectories under a `subdirectory`, pair `injectContent({ param, subdirectory })` with a catch-all route. The catch-all parameter captures the full path under the subdirectory and resolves to the matching nested file.
+
+```treeview
+src/
+└── app/
+│   └── pages/
+│       └── docs/
+│           └── [...slug].page.ts
+└── content/
+    └── docs/
+        ├── getting-started/
+        │   ├── welcome.md
+        │   └── first-upload.md
+        └── assets/
+            └── upload.md
+```
+
+```ts
+// /src/app/pages/docs/[...slug].page.ts
+import { injectContent, MarkdownComponent } from '@analogjs/content';
+import { AsyncPipe } from '@angular/common';
+import { Component } from '@angular/core';
+
+export interface DocAttributes {
+  title: string;
+}
+
+@Component({
+  standalone: true,
+  imports: [MarkdownComponent, AsyncPipe],
+  template: `
+    @if (doc$ | async; as doc) {
+      <h1>{{ doc.attributes.title }}</h1>
+      <analog-markdown [content]="doc.content"></analog-markdown>
+    }
+  `,
+})
+export default class DocComponent {
+  readonly doc$ = injectContent<DocAttributes>({
+    param: 'slug',
+    subdirectory: 'docs',
+  });
+}
+```
+
+A request for `/docs/getting-started/welcome` resolves to `src/content/docs/getting-started/welcome.md`. Frontmatter `slug` is optional in this layout — when omitted, the file is keyed by its on-disk path. If a file does specify a `slug` containing path separators, that slug is interpreted relative to its top-level subdirectory (e.g. `slug: getting-started/welcome` on a file under `src/content/docs/` resolves to `src/content/docs/getting-started/welcome`).
 
 ## Loading Custom Content
 

--- a/apps/docs-app/docs/features/server/static-site-generation.md
+++ b/apps/docs-app/docs/features/server/static-site-generation.md
@@ -72,6 +72,37 @@ export default defineConfig(({ mode }) => ({
 }));
 ```
 
+#### Recursing Into Subdirectories
+
+By default, `contentDir` only matches files at the top level of the configured directory. To prerender content organized into category subdirectories, set `recursive: true`. Each discovered file's directory relative to `contentDir` is exposed via `file.relativePath`, which `transform` can use to build the route.
+
+```ts
+import { defineConfig } from 'vite';
+import analog, { type PrerenderContentFile } from '@analogjs/platform';
+
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    analog({
+      prerender: {
+        routes: async () => [
+          '/',
+          {
+            contentDir: 'src/content/docs',
+            recursive: true,
+            transform: (file: PrerenderContentFile) => {
+              const slug = file.attributes.slug || file.name;
+              return file.relativePath
+                ? `/docs/${file.relativePath}/${slug}`
+                : `/docs/${slug}`;
+            },
+          },
+        ],
+      },
+    }),
+  ],
+}));
+```
+
 ### Outputting Source Markdown Files
 
 To make prerendered pages more accessible to LLMs or other tools that prefer raw markdown, you can output the source markdown file alongside each prerendered route. The source file will be accessible at the route path with a `.md` extension (e.g., `/blog/my-post` would also be available at `/blog/my-post.md`).

--- a/packages/content/src/lib/content-files-token.spec.ts
+++ b/packages/content/src/lib/content-files-token.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CONTENT_FILES_LIST_TOKEN } from './content-files-list-token';
+import { CONTENT_FILES_TOKEN } from './content-files-token';
+
+const fileLoaders = {
+  '/src/content/docs/erste-schritte/willkommen.md': () =>
+    Promise.resolve('willkommen body'),
+  '/src/content/docs/intro.md': () => Promise.resolve('intro body'),
+  '/src/content/aliased-root.md': () => Promise.resolve('aliased body'),
+};
+
+vi.mock('./get-content-files', () => ({
+  getContentFiles: () => fileLoaders,
+  getContentFilesList: () => ({}),
+}));
+
+describe('CONTENT_FILES_TOKEN', () => {
+  function setup(
+    contentFilesList: { filename: string; slug: string; attributes: any }[],
+  ) {
+    TestBed.configureTestingModule({});
+    TestBed.overrideProvider(CONTENT_FILES_LIST_TOKEN, {
+      useValue: contentFilesList,
+    });
+    return TestBed.inject(CONTENT_FILES_TOKEN);
+  }
+
+  it('keys nested files under their own subdirectory when the slug includes a separator', () => {
+    const map = setup([
+      {
+        filename: '/src/content/docs/erste-schritte/willkommen.md',
+        slug: 'erste-schritte/willkommen',
+        attributes: {},
+      },
+    ]);
+
+    expect(map['/src/content/docs/erste-schritte/willkommen.md']).toBeDefined();
+    expect(map['/src/content/erste-schritte/willkommen.md']).toBeUndefined();
+  });
+
+  it('still treats slash-containing slugs as root-relative when the file lives directly under /src/content', () => {
+    const map = setup([
+      {
+        filename: '/src/content/aliased-root.md',
+        slug: 'category/aliased',
+        attributes: {},
+      },
+    ]);
+
+    expect(map['/src/content/category/aliased.md']).toBeDefined();
+  });
+
+  it('preserves filename-derived slugs for nested files without a frontmatter slug', () => {
+    const map = setup([
+      {
+        filename: '/src/content/docs/intro.md',
+        slug: 'intro',
+        attributes: {},
+      },
+    ]);
+
+    expect(map['/src/content/docs/intro.md']).toBeDefined();
+  });
+});

--- a/packages/content/src/lib/content-files-token.ts
+++ b/packages/content/src/lib/content-files-token.ts
@@ -27,9 +27,15 @@ export const CONTENT_FILES_TOKEN = new InjectionToken<
       if (slug === '') {
         slug = 'index';
       }
-      // If slug contains path separators, treat it as root-relative to /src/content
+      // Slugs with path separators are scoped to the file's top-level
+      // subdirectory (e.g. `/src/content/docs`) rather than absolute root,
+      // so nested files keep resolving through `subdirectory` lookups.
+      // Files directly under `/src/content` keep the original root-relative
+      // behavior since they have no subdirectory of their own.
+      const subdirRoot =
+        fileParts.length > 4 ? fileParts.slice(0, 4).join('/') : '/src/content';
       const newBase = slug.includes('/')
-        ? `/src/content/${slug}`
+        ? `${subdirRoot}/${slug}`
         : `${filePath}/${slug}`;
       lookup[contentFilename] = `${newBase}.${ext}`.replace(/\/{2,}/g, '/');
     });

--- a/packages/vite-plugin-nitro/src/lib/options.ts
+++ b/packages/vite-plugin-nitro/src/lib/options.ts
@@ -113,6 +113,15 @@ export interface PrerenderContentDir {
    * @returns the markdown content string to output, or `false` to skip outputting for this file
    */
   outputSourceFile?: (file: PrerenderContentFile) => string | false;
+
+  /**
+   * Recurse into subdirectories of `contentDir` when discovering files.
+   * When enabled, the matching file's directory relative to `contentDir`
+   * is exposed via `PrerenderContentFile.relativePath` so transforms can
+   * disambiguate identically-named files across subdirectories.
+   * @default false
+   */
+  recursive?: boolean;
 }
 
 /**
@@ -121,6 +130,7 @@ export interface PrerenderContentDir {
  * @param extension the file extension
  * @param attributes the frontmatter attributes extracted from the frontmatter section of the file
  * @param content the raw file content including frontmatter
+ * @param relativePath when `recursive` is enabled, the directory of the file relative to `contentDir` (empty string for files at the top level)
  * @returns a string with the route should be returned (e. g. `/blog/<slug>`) or the value `false`, when the route should not be prerendered.
  */
 export interface PrerenderContentFile {
@@ -129,6 +139,7 @@ export interface PrerenderContentFile {
   name: string;
   extension: string;
   content: string;
+  relativePath?: string;
 }
 
 export interface PrerenderSitemapConfig {

--- a/packages/vite-plugin-nitro/src/lib/utils/get-content-files.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-content-files.spec.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getMatchingContentFilesWithFrontMatter } from './get-content-files';
+
+describe('getMatchingContentFilesWithFrontMatter', () => {
+  let workspaceRoot: string;
+  const rootDir = '.';
+  const contentDir = '/src/content/docs';
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'analog-content-'));
+    mkdirSync(join(workspaceRoot, 'src/content/docs/erste-schritte'), {
+      recursive: true,
+    });
+    mkdirSync(join(workspaceRoot, 'src/content/docs/assets'), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(workspaceRoot, 'src/content/docs/intro.md'),
+      '---\ntitle: Intro\n---\n# Intro',
+    );
+    writeFileSync(
+      join(workspaceRoot, 'src/content/docs/erste-schritte/willkommen.md'),
+      '---\ntitle: Willkommen\n---\n# Willkommen',
+    );
+    writeFileSync(
+      join(workspaceRoot, 'src/content/docs/assets/hochladen.md'),
+      '---\ntitle: Hochladen\n---\n# Hochladen',
+    );
+  });
+
+  afterEach(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('returns only top-level files by default', () => {
+    const files = getMatchingContentFilesWithFrontMatter(
+      workspaceRoot,
+      rootDir,
+      contentDir,
+    );
+
+    expect(files.map((f) => f.name).sort()).toEqual(['intro']);
+  });
+
+  it('returns nested files when recursive is enabled', () => {
+    const files = getMatchingContentFilesWithFrontMatter(
+      workspaceRoot,
+      rootDir,
+      contentDir,
+      true,
+    );
+
+    expect(files.map((f) => f.name).sort()).toEqual([
+      'hochladen',
+      'intro',
+      'willkommen',
+    ]);
+  });
+
+  it('exposes the directory relative to contentDir as relativePath', () => {
+    const files = getMatchingContentFilesWithFrontMatter(
+      workspaceRoot,
+      rootDir,
+      contentDir,
+      true,
+    );
+
+    const byName = Object.fromEntries(files.map((f) => [f.name, f]));
+    expect(byName['intro'].relativePath).toBe('');
+    expect(byName['willkommen'].relativePath).toBe('erste-schritte');
+    expect(byName['hochladen'].relativePath).toBe('assets');
+  });
+});

--- a/packages/vite-plugin-nitro/src/lib/utils/get-content-files.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-content-files.ts
@@ -66,6 +66,7 @@ export function getMatchingContentFilesWithFrontMatter(
   workspaceRoot: string,
   rootDir: string,
   glob: string,
+  recursive = false,
 ): PrerenderContentFile[] {
   // Dynamically require front-matter library
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -77,12 +78,18 @@ export function getMatchingContentFilesWithFrontMatter(
   // Resolve the content directory path relative to the project root
   const resolvedDir = normalizePath(relative(root, join(root, glob)));
 
-  // Discover all content files in the specified directory
-  // Pattern: looks for any files in the resolved directory
-  const contentFiles: string[] = globSync([`${root}/${resolvedDir}/*`], {
+  // Discover all content files in the specified directory.
+  // Default pattern matches only top-level files; recursive opt-in walks subdirectories.
+  const pattern = recursive
+    ? `${root}/${resolvedDir}/**/*`
+    : `${root}/${resolvedDir}/*`;
+  const contentFiles: string[] = globSync([pattern], {
     dot: true,
     absolute: true,
+    onlyFiles: true,
   });
+
+  const dirPrefix = `${root}/${resolvedDir}`;
 
   // Process each discovered content file to extract metadata and front matter
   const mappedFilesWithFm: PrerenderContentFile[] = contentFiles.map((f) => {
@@ -105,6 +112,15 @@ export function getMatchingContentFilesWithFrontMatter(
       extension = match[3] || ''; // File extension or empty string if no extension
     }
 
+    // Path of the file's directory relative to the configured contentDir.
+    // For top-level files this is an empty string; for nested files it
+    // gives transforms enough context to disambiguate identically-named
+    // files (e.g. docs/a/post.md vs docs/b/post.md).
+    const relativeDir = normalizePath(relative(dirPrefix, f));
+    const lastSlash = relativeDir.lastIndexOf('/');
+    const relativePath =
+      lastSlash === -1 ? '' : relativeDir.slice(0, lastSlash);
+
     // Return structured content file data for prerendering
     return {
       name,
@@ -112,6 +128,7 @@ export function getMatchingContentFilesWithFrontMatter(
       path: resolvedDir,
       attributes: raw.attributes as { attributes: Record<string, any> },
       content: fileContents,
+      relativePath,
     };
   });
 

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -286,6 +286,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                     workspaceRoot,
                     rootDir,
                     current.contentDir,
+                    current.recursive,
                   );
 
                 affectedFiles.forEach((f) => {


### PR DESCRIPTION
## PR Checklist

Closes #2318

## Affected scope

- Primary scope: content
- Secondary scopes: vite-plugin-nitro, docs

## Recommended merge strategy for maintainer [optional]

- [ ] Squash merge
- [x] Rebase merge
- [ ] Other

## Commit preservation note [optional]

Each commit addresses a distinct part of the issue and keeps the runtime, prerender, and docs changes independently revertible.

## What is the new behavior?

- **`injectContentFiles` content body** — documentation only. Adds an explicit note in the content guide that `injectContentFiles` returns metadata (`filename`, `slug`, `attributes`) and that reading `.content` yields `undefined`; users should call `injectContent` to load a file's body. No type change.
- **`subdirectory` + slash-containing slug** — slash-containing frontmatter slugs are scoped to the file's top-level subdirectory (e.g. `/src/content/docs`) rather than the absolute content root, so `injectContent({ subdirectory, param })` resolves nested files. Files directly under `/src/content` keep the original root-relative behavior.
- **Recursive `contentDir` prerender** — `PrerenderContentDir` gains opt-in `recursive: true`, and `PrerenderContentFile` gains `relativePath` so transforms can disambiguate identically-named files across subdirectories. Default behavior unchanged.
- **Hierarchical content docs** — new "Hierarchical (Nested) Content" recipe in the content guide showing the catch-all + `injectContent` pattern, including the slash-slug behavior; new "Recursing Into Subdirectories" example in the SSG guide.

## Test plan

- [x] `nx test content --testPathPattern=content-files-token.spec` (3 new tests)
- [x] `nx test vite-plugin-nitro --testPathPattern=get-content-files.spec` (3 new tests)
- [x] Existing `content.spec.ts` (8 tests) and `vite-plugin-nitro` suite (33 tests) green
- [ ] Manual verification on a docs-style app with nested categories

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`recursive` defaults to `false`, so prerender discovery is unchanged for existing configs.

## Other information

The three commits are independently revertible if any one of them surfaces an issue.