### PR TITLE
fix(vite-plugin-angular): repair CSS and Angular dep resolution regressions

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1223,6 +1223,17 @@ export function angular(options?: PluginOptions): Plugin[] {
         // Map angular external styleUrls to the source file
         if (isComponentStyleSheet(id)) {
           const filename = getFilenameFromPath(id);
+          const search = new URL(id, 'http://localhost').search;
+          const servedSourcePath =
+            stylesheetRegistry?.getServedSourcePath(filename);
+
+          if (servedSourcePath) {
+            debugStylesV('resolveId: mapped served stylesheet to source', {
+              filename,
+              resolvedPath: servedSourcePath,
+            });
+            return servedSourcePath + search;
+          }
 
           if (stylesheetRegistry?.hasServed(filename)) {
             debugStylesV('resolveId: kept preprocessed ID', { filename });
@@ -1286,11 +1297,19 @@ export function angular(options?: PluginOptions): Plugin[] {
                 stylesheetRegistry?.resolveExternalSource(filename) ??
                 stylesheetRegistry?.resolveExternalSource(
                   filename.replace(/^\//, ''),
+                ) ??
+                stylesheetRegistry?.getServedSourcePath(filename) ??
+                stylesheetRegistry?.getServedSourcePath(
+                  filename.replace(/^\//, ''),
                 ),
               trackedRequestIds:
                 stylesheetRegistry?.getRequestIdsForSource(
                   stylesheetRegistry?.resolveExternalSource(filename) ??
                     stylesheetRegistry?.resolveExternalSource(
+                      filename.replace(/^\//, ''),
+                    ) ??
+                    stylesheetRegistry?.getServedSourcePath(filename) ??
+                    stylesheetRegistry?.getServedSourcePath(
                       filename.replace(/^\//, ''),
                     ) ??
                     '',
@@ -2053,7 +2072,9 @@ export function isModuleForChangedResource(
   const requestPath = getFilenameFromPath(mod.id);
   const sourcePath =
     stylesheetRegistry?.resolveExternalSource(requestPath) ??
-    stylesheetRegistry?.resolveExternalSource(requestPath.replace(/^\//, ''));
+    stylesheetRegistry?.resolveExternalSource(requestPath.replace(/^\//, '')) ??
+    stylesheetRegistry?.getServedSourcePath(requestPath) ??
+    stylesheetRegistry?.getServedSourcePath(requestPath.replace(/^\//, ''));
 
   return (
     normalizePath((sourcePath ?? '').split('?')[0]) === normalizedChangedFile
@@ -2101,6 +2122,10 @@ function diagnoseComponentStylesheetPipeline(
   const sourcePath = directRequestPath
     ? (stylesheetRegistry?.resolveExternalSource(directRequestPath) ??
       stylesheetRegistry?.resolveExternalSource(
+        directRequestPath.replace(/^\//, ''),
+      ) ??
+      stylesheetRegistry?.getServedSourcePath(directRequestPath) ??
+      stylesheetRegistry?.getServedSourcePath(
         directRequestPath.replace(/^\//, ''),
       ))
     : normalizedFile;
@@ -2245,7 +2270,11 @@ export async function findComponentStylesheetWrapperModules(
     : undefined;
   const sourcePath = requestPath
     ? (stylesheetRegistry?.resolveExternalSource(requestPath) ??
-      stylesheetRegistry?.resolveExternalSource(requestPath.replace(/^\//, '')))
+      stylesheetRegistry?.resolveExternalSource(
+        requestPath.replace(/^\//, ''),
+      ) ??
+      stylesheetRegistry?.getServedSourcePath(requestPath) ??
+      stylesheetRegistry?.getServedSourcePath(requestPath.replace(/^\//, '')))
     : undefined;
 
   // HMR timing matters here. On a pure CSS edit, the browser often already has

--- a/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.spec.ts
@@ -203,6 +203,81 @@ describe('compilationAPIPlugin', () => {
     expect(emitAffectedFilesMock).toHaveBeenCalledOnce();
   });
 
+  it('resolves hashed component stylesheet ids to their source path', async () => {
+    const containingFile = join(tempRoot, 'src/demo.component.ts');
+    const resourceFile = join(tempRoot, 'src/demo.component.css');
+    let stylesheetId = '';
+
+    const initializeMock = vi
+      .fn()
+      .mockImplementation(async (_tsconfig, host) => {
+        stylesheetId = await host.transformStylesheet(
+          '.demo { @apply sa:flex; }',
+          containingFile,
+          resourceFile,
+          0,
+          'DemoComponent',
+        );
+
+        return {
+          externalStylesheets: new Map(),
+          templateUpdates: new Map(),
+        };
+      });
+    const emitAffectedFilesMock = vi.fn().mockResolvedValue([]);
+
+    createAngularCompilationMock.mockResolvedValue({
+      initialize: initializeMock,
+      update: vi.fn(),
+      diagnoseFiles: vi.fn().mockResolvedValue({ errors: [], warnings: [] }),
+      emitAffectedFiles: emitAffectedFilesMock,
+    });
+
+    const { compilationAPIPlugin } =
+      await import('./compilation-api-plugin.js');
+    const plugin = compilationAPIPlugin({
+      tsconfigGetter: () => join(tempRoot, 'tsconfig.json'),
+      workspaceRoot: tempRoot,
+      inlineStylesExtension: 'css',
+      jit: false,
+      liveReload: false,
+      disableTypeChecking: true,
+      supportedBrowsers: ['safari 15'],
+      fileReplacements: [],
+      hasTailwindCss: true,
+      isTest: false,
+      isAstroIntegration: false,
+      include: [],
+      additionalContentDirs: [],
+    });
+
+    await (plugin.config as any)(
+      { root: tempRoot, mode: 'development' },
+      { command: 'serve', mode: 'development' },
+    );
+    await (plugin.configResolved as any)({
+      cacheDir: join(tempRoot, '.vite'),
+      root: tempRoot,
+      mode: 'development',
+      build: {},
+      server: { hmr: true },
+      plugins: [],
+    });
+    await (plugin.buildStart as any).call({
+      addWatchFile: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    });
+
+    expect(stylesheetId).toMatch(/^[a-f0-9]+\.css$/);
+    expect((plugin.resolveId as any)(`/${stylesheetId}?ngcomp=ng-c1&e=0`)).toBe(
+      `${resourceFile}?ngcomp=ng-c1&e=0`,
+    );
+    await expect(
+      (plugin.load as any)(`${resourceFile}?ngcomp=ng-c1&e=0`),
+    ).resolves.toBe('.demo { @apply sa:flex; }');
+  });
+
   it('maps templateUpdates to HMR metadata', async () => {
     const testFile = join(tempRoot, 'src/app.component.ts');
     const initializeMock = vi.fn().mockResolvedValue({

--- a/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
@@ -25,6 +25,7 @@ import {
   debugHmr,
   debugHmrV,
   debugStyles,
+  debugStylesV,
   type DebugOption,
 } from '../utils/debug.js';
 import {
@@ -737,6 +738,17 @@ export function compilationAPIPlugin(
       // Map angular component stylesheets
       if (isComponentStyleSheet(id)) {
         const filename = getFilenameFromPath(id);
+        const search = new URL(id, 'http://localhost').search;
+        const servedSourcePath =
+          stylesheetRegistry?.getServedSourcePath(filename);
+
+        if (servedSourcePath) {
+          debugStylesV('resolveId: mapped served stylesheet to source', {
+            filename,
+            resolvedPath: servedSourcePath,
+          });
+          return servedSourcePath + search;
+        }
 
         if (stylesheetRegistry?.hasServed(filename)) {
           return id;

--- a/packages/vite-plugin-angular/src/lib/stylesheet-registry.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/stylesheet-registry.spec.ts
@@ -61,6 +61,9 @@ describe('stylesheet-registry', () => {
     });
 
     expect(stylesheetId).toMatch(/^[a-f0-9]+\.css$/);
+    expect(registry.getServedSourcePath(stylesheetId)).toBe(
+      '/project/src/app/demo.component.css',
+    );
     expect(registry.getServedContent(stylesheetId)).toBe(
       '.demo { color: red; }',
     );
@@ -71,6 +74,26 @@ describe('stylesheet-registry', () => {
       registry.getServedContent('project/src/app/demo.component.css'),
     ).toBe('.demo { color: red; }');
     expect(registry.getServedContent('demo.component.css')).toBeUndefined();
+  });
+
+  it('registers inline stylesheet content under a stable synthetic source path', () => {
+    const registry = new AnalogStylesheetRegistry();
+
+    const stylesheetId = registerStylesheetContent(registry, {
+      code: '.demo { color: red; }',
+      containingFile: '/project/src/app/demo.component.ts',
+      className: 'DemoComponent',
+      order: 0,
+      inlineStylesExtension: 'css',
+    });
+
+    expect(stylesheetId).toMatch(/^[a-f0-9]+\.css$/);
+    expect(registry.getServedSourcePath(stylesheetId)).toBe(
+      '/project/src/app/demo.component.css',
+    );
+    expect(
+      registry.getServedContent('/project/src/app/demo.component.css'),
+    ).toBe('.demo { color: red; }');
   });
 
   it('keeps structured transform metadata on the source stylesheet', () => {

--- a/packages/vite-plugin-angular/src/lib/stylesheet-registry.ts
+++ b/packages/vite-plugin-angular/src/lib/stylesheet-registry.ts
@@ -95,6 +95,10 @@ export class AnalogStylesheetRegistry {
     return this.resolveServedRecord(requestId)?.normalizedCode;
   }
 
+  getServedSourcePath(requestId: string): string | undefined {
+    return this.resolveServedRecord(requestId)?.sourcePath;
+  }
+
   resolveExternalSource(requestId: string): string | undefined {
     const normalizedRequestId = this.normalizeRequestId(requestId);
     return this.externalRequestToSource.get(normalizedRequestId);
@@ -136,7 +140,9 @@ export class AnalogStylesheetRegistry {
     const requestPath = normalizedRequestId.split('?')[0];
     const sourcePath =
       this.resolveExternalSource(requestPath) ??
-      this.resolveExternalSource(requestPath.replace(/^\//, ''));
+      this.resolveExternalSource(requestPath.replace(/^\//, '')) ??
+      this.getServedSourcePath(requestPath) ??
+      this.getServedSourcePath(requestPath.replace(/^\//, ''));
     if (!sourcePath) {
       return;
     }
@@ -295,25 +301,23 @@ export function registerStylesheetContent(
     .update(code)
     .digest('hex');
   const stylesheetId = `${id}.${inlineStylesExtension}`;
+  const sourcePath =
+    resourceFile ?? containingFile.replace('.ts', `.${inlineStylesExtension}`);
+  const normalizedSourcePath = normalizePath(normalize(sourcePath));
 
-  const aliases: string[] = [];
-
-  if (resourceFile) {
-    const normalizedResourceFile = normalizePath(normalize(resourceFile));
-    // Avoid basename-only aliases here: shared filenames like `index.css`
-    // can collide across components and break HMR lookups.
-    aliases.push(
-      resourceFile,
-      normalizedResourceFile,
-      resourceFile.replace(/^\//, ''),
-      normalizedResourceFile.replace(/^\//, ''),
-    );
-  }
+  // Avoid basename-only aliases here: shared filenames like `index.css`
+  // can collide across components and break HMR lookups.
+  const aliases = [
+    sourcePath,
+    normalizedSourcePath,
+    sourcePath.replace(/^\//, ''),
+    normalizedSourcePath.replace(/^\//, ''),
+  ];
 
   registry.registerServedStylesheet(
     {
       publicId: stylesheetId,
-      sourcePath: resourceFile,
+      sourcePath: normalizedSourcePath,
       normalizedCode: code,
       dependencies,
       diagnostics,


### PR DESCRIPTION
## Summary

Fixes two Vite resolution regressions in the Angular plugin paths:

- Tailwind CSS `@plugin` imports could resolve package `style` exports as JavaScript modules.
- The Angular Compilation API path skipped Analog's dependency optimizer linker, so Vite could serve partially compiled Angular packages during dev.

Both failures were reproduced from `snyder-apps` using `apps/meritos/edge-gui-portal` with the local Analog packages rebuilt and linked.

## Root Cause

### Tailwind CSS plugin resolution

A consumer stylesheet reproduced the resolver failure:

```css
@import 'tailwindcss' prefix(sa);
@plugin 'tailwindcss-primeui';
```

`tailwindcss-primeui@0.6.1` exposes separate package exports:

- `style` resolves to `v4/index.css`
- `import` resolves to `v3/index.js`

Analog injected `style` into Vite's global `resolve.conditions`, so Tailwind's JavaScript plugin resolver selected the CSS export. Node then attempted to import the CSS file as ESM and failed with:

```text
[plugin:@tailwindcss/vite:generate:build] Unknown file extension ".css" for .../tailwindcss-primeui/v4/index.css
```

### Angular Compilation API dependency linking

`apps/meritos/edge-gui-portal/vite.config.mts` uses `useAngularCompilationAPI: true`. That path disabled Vite's normal app transforms, but it only configured a minimal `optimizeDeps` include/exclude list and did not install Analog's Angular dep optimizer linker plugin.

As a result, Vite's dev optimizer cached Angular packages in their partially compiled declaration form. The runtime then failed when `PlatformLocation` still contained `ɵɵngDeclareFactory(...)` and Angular tried to fall back to JIT without `@angular/compiler` loaded:

```text
The injectable 'PlatformLocation' needs to be compiled using the JIT compiler, but '@angular/compiler' is not available.
```

## What Changed

- Removed global `resolve.conditions: ['style', ...]` from the Angular Vite plugin config paths.
- Kept CSS handling out of global JavaScript package resolution.
- Reused `createDepOptimizerConfig()` in the Angular Compilation API plugin path.
- Included `tslib` in the shared dep optimizer include list.
- Added tests asserting:
  - plugin configs do not add `style` to global resolution;
  - the Compilation API config installs the Angular dep optimizer linker plugin;
  - the shared optimizer include list contains `rxjs/operators`, `rxjs`, and `tslib`.

## Before / After

Before this change, the portal build failed while processing `apps/meritos/edge-gui-portal/src/app/styles/main.css` because `tailwindcss-primeui` resolved to:

```text
.../tailwindcss-primeui/v4/index.css
```

After this change, the consumer Vite config resolves JS plugin imports without the `style` condition:

```json
{
  "conditions": ["module", "browser", "development|production"],
  "primeui": ".../tailwindcss-primeui/v3/index.js"
}
```

Before the Compilation API fix, the Vite dep cache could contain Angular partial declarations such as `ɵɵngDeclareFactory` for `PlatformLocation`.

After this change, forced optimization produces linked Angular deps. The checked cache files for `@angular/common`, `@angular/common/http`, `@angular/platform-browser`, `@angular/router`, and the generated platform-location chunk no longer contain `ngDeclareFactory` / `ɵɵngDeclareFactory`.

## Validation

Passed in the Analog repo:

```bash
pnpm exec vitest run \
  packages/vite-plugin-angular/src/lib/angular-vite-plugin-live-reload.spec.ts \
  packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts \
  packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.spec.ts \
  packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts \
  --config packages/vite-plugin-angular/vite.config.ts
```

Result: `4 files / 131 tests` passed.

Passed through the local Analog debug flow after rebuild/link refresh:

```bash
bun enterpriseOS/tools/debugging/analog-debug-src.ts \
  --scope analog:angular:compilation-api \
  --scope analog:angular:compiler \
  --analog-test-command "cd ../.. && pnpm exec vitest run packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.spec.ts packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts --config packages/vite-plugin-angular/vite.config.ts" \
  --verify-command "node --input-type=module -e \"import { resolveConfig } from 'vite'; const c = await resolveConfig({ configFile: 'apps/meritos/edge-gui-portal/vite.config.mts' }, 'serve', 'development', 'development'); console.log(JSON.stringify({ conditions: c.resolve.conditions, optimizeDeps: c.optimizeDeps }, null, 2));\""
```

Passed consumer optimization/linker sanity check:

```bash
bun x vite optimize apps/meritos/edge-gui-portal \
  --config apps/meritos/edge-gui-portal/vite.config.mts \
  --mode development \
  --force
```

Then verified no Angular partial declaration helpers remained in the relevant optimized Angular cache files.

Passed the original consumer build:

```bash
bun x nx run meritos-edge-gui-portal:build:development --skipNxCache
```

Result: `meritos-edge-gui-portal` and its 34 dependent build tasks completed successfully.

Additional check:

```bash
bun x nx typecheck meritos-edge-gui-portal --skipNxCache --skipSync
```

Result: still fails on existing dependent-library Vite config type overload / excessive stack depth errors, unrelated to these Vite plugin regressions.
