### PR TITLE
fix(vite-plugin-angular): strip TS in fastCompile bypass for non-Angular files

### DIFF
--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
@@ -1,0 +1,159 @@
+// Mocked at module level so the plugin sees our stubs for the OXC/esbuild
+// strip pass on the bypass path. Kept in a separate file from compile.spec.ts
+// because that suite uses real `vite.transformWithOxc` for end-to-end checks.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockRolldownVersion: string | undefined;
+const mockTransformWithOxc = vi.fn();
+const mockTransformWithEsbuild = vi.fn();
+
+vi.mock('vite', async () => {
+  const actual = await vi.importActual<typeof import('vite')>('vite');
+  return {
+    ...actual,
+    get rolldownVersion() {
+      return mockRolldownVersion;
+    },
+    transformWithOxc: (...args: unknown[]) => mockTransformWithOxc(...args),
+    transformWithEsbuild: (...args: unknown[]) =>
+      mockTransformWithEsbuild(...args),
+  };
+});
+
+import { fastCompilePlugin } from './fast-compile-plugin';
+
+function buildPlugin() {
+  return fastCompilePlugin({
+    tsconfigGetter: () => 'tsconfig.json',
+    workspaceRoot: '/workspace',
+    inlineStylesExtension: 'css',
+    jit: false,
+    liveReload: false,
+    supportedBrowsers: [],
+    isTest: false,
+    isAstroIntegration: false,
+  });
+}
+
+function getTransformHandler(plugin: ReturnType<typeof buildPlugin>) {
+  const transform = plugin.transform as any;
+  return transform.handler ?? transform;
+}
+
+describe('fastCompilePlugin bypass strips TS', () => {
+  beforeEach(() => {
+    mockRolldownVersion = undefined;
+    vi.clearAllMocks();
+    mockTransformWithOxc.mockResolvedValue({
+      code: 'export { SomeClass } from "./lib/some-file";\n',
+      map: { mappings: '' },
+    });
+    mockTransformWithEsbuild.mockResolvedValue({
+      code: 'export { SomeClass } from "./lib/some-file";\n',
+      map: { mappings: '' },
+    });
+  });
+
+  it('runs OXC strip on barrel file with mixed value/type re-export (rolldown)', async () => {
+    mockRolldownVersion = '1.0.0';
+    const plugin = buildPlugin();
+    const handler = getTransformHandler(plugin);
+
+    const code = `export { SomeClass, type SomeInterface } from './lib/some-file';\n`;
+    const result = await handler.call(
+      { addWatchFile: () => undefined },
+      code,
+      '/src/lib/barrel.ts',
+    );
+
+    expect(mockTransformWithOxc).toHaveBeenCalledWith(
+      code,
+      '/src/lib/barrel.ts',
+      expect.objectContaining({ lang: 'ts', sourcemap: true }),
+    );
+    expect(result.code).toBe('export { SomeClass } from "./lib/some-file";\n');
+  });
+
+  it('runs esbuild strip on barrel file when transformWithOxc is unavailable', async () => {
+    mockRolldownVersion = undefined;
+    // Force the OXC branch to be skipped by making the function falsy.
+    (
+      mockTransformWithOxc as unknown as { mockImplementationOnce: any }
+    ).mockImplementationOnce(undefined);
+    const plugin = buildPlugin();
+    const handler = getTransformHandler(plugin);
+
+    // Temporarily remove OXC entry so the falsy branch is taken.
+    const viteMod = await import('vite');
+    const realOxc = viteMod.transformWithOxc;
+    Object.defineProperty(viteMod, 'transformWithOxc', {
+      value: undefined,
+      configurable: true,
+    });
+    try {
+      const code = `export { SomeClass, type SomeInterface } from './lib/some-file';\n`;
+      const result = await handler.call(
+        { addWatchFile: () => undefined },
+        code,
+        '/src/lib/barrel.ts',
+      );
+      expect(mockTransformWithEsbuild).toHaveBeenCalledWith(
+        code,
+        '/src/lib/barrel.ts',
+        expect.objectContaining({ loader: 'ts', sourcemap: true }),
+      );
+      expect(result.code).toBe(
+        'export { SomeClass } from "./lib/some-file";\n',
+      );
+    } finally {
+      Object.defineProperty(viteMod, 'transformWithOxc', {
+        value: realOxc,
+        configurable: true,
+      });
+    }
+  });
+
+  it('strips a plain TS file with no Angular decorator (router config)', async () => {
+    const plugin = buildPlugin();
+    const handler = getTransformHandler(plugin);
+
+    const code = `import type { Route } from '@angular/router';\nexport const ROUTES: Route[] = [];\n`;
+    await handler.call(
+      { addWatchFile: () => undefined },
+      code,
+      '/src/app/app.routes.ts',
+    );
+
+    expect(mockTransformWithOxc).toHaveBeenCalled();
+  });
+
+  it('does not run the bypass strip when the file has @Component', async () => {
+    const plugin = buildPlugin();
+    const handler = getTransformHandler(plugin);
+
+    // A component file goes through the full compile path which calls
+    // transformWithOxc internally too, but with `sourcemap: false`. The
+    // bypass uses `sourcemap: true` — assert no `sourcemap: true` call to
+    // confirm we did not enter the bypass branch.
+    const code = `
+import { Component } from '@angular/core';
+@Component({ selector: 'x', template: '' })
+export class XComponent {}
+`;
+    try {
+      await handler.call(
+        { addWatchFile: () => undefined },
+        code,
+        '/src/app/x.component.ts',
+      );
+    } catch {
+      // The full compile path may throw under the mocked OXC return value;
+      // we only care that the bypass branch was not taken.
+    }
+
+    const sawBypassCall = mockTransformWithOxc.mock.calls.some(
+      ([, , opts]: any[]) => opts?.sourcemap === true,
+    );
+    expect(sawBypassCall).toBe(false);
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -267,9 +267,25 @@ export function fastCompilePlugin(
     id: string,
   ): Promise<{ code: string; map: any } | undefined> {
     if (!/(Component|Directive|Pipe|Injectable|NgModule)\(/.test(code)) {
-      // Non-Angular file — leave it alone so a downstream plugin (or
-      // Vite's built-in TS handler) can process it.
-      return undefined;
+      // Non-Angular file — strip TS-only syntax ourselves so barrels
+      // like `export { Foo, type Bar } from './x'` and other TS-only
+      // forms don't leak unstripped to Rolldown. In rolldown-vite the
+      // built-in `vite:oxc` strip is registered as a Rust-side native
+      // plugin (`viteTransformPlugin` from `rolldown/experimental`); if
+      // its hook-filter treats files our `transform.filter.id.include`
+      // claimed as already-handled, no JS-side fallback runs and raw
+      // TS reaches the parser → `SyntaxError: Unexpected identifier`.
+      const stripped = vite.transformWithOxc
+        ? await vite.transformWithOxc(code, id, {
+            lang: 'ts',
+            sourcemap: true,
+            decorator: { legacy: false, emitDecoratorMetadata: false },
+          })
+        : await vite.transformWithEsbuild(code, id, {
+            loader: 'ts',
+            sourcemap: true,
+          });
+      return { code: stripped.code, map: stripped.map };
     }
 
     // JIT mode


### PR DESCRIPTION
## PR Checklist

Closes #

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: —

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

`fastCompile` previously returned `undefined` from its `transform` hook for any `.ts` file without an Angular decorator (`Component`/`Directive`/`Pipe`/`Injectable`/`NgModule`), assuming Vite's built-in TS strip would run afterwards.

In rolldown-vite the strip is registered as a Rust-side native plugin (`viteTransformPlugin` from `rolldown/experimental`), and its hook-filter treats files our `transform.filter.id.include` claimed as already handled. No JS-side fallback runs in `isBundled` mode either (`vite:oxc` only registers a native sub-plugin), so files like:

```ts
export { SomeClass, type SomeInterface } from './lib/some-file';
```

reach the parser unstripped and crash with `SyntaxError: Unexpected identifier 'SomeInterface'`.

The bypass now strips TS itself via `transformWithOxc` (or `transformWithEsbuild` fallback) before returning, so the result is always valid JS regardless of downstream plugin ordering. This matches what the Angular-component path already does after `compile()`.

## Test plan

- [x] `nx format:check`
- [x] `pnpm test` for `@analogjs/vite-plugin-angular` (698 passed, 2 skipped)
- [x] New `src/lib/fast-compile-plugin.spec.ts` covers:
  - Barrel with mixed value/type re-export → OXC strip is invoked (rolldown path)
  - Same case via esbuild fallback when `transformWithOxc` is unavailable
  - Plain `.ts` file with `import type` → bypass strips
  - `@Component` file → bypass branch is *not* taken (regression guard)
- [ ] Manual verification in a rolldown-vite app with a barrel re-exporting a mix of values and types

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The Angular-decorated path is unchanged. Only the previously-bypassed branch is affected, and it now produces JS rather than raw TS — which is what every downstream plugin/bundler already expected.