### PR TITLE
fix(vite-plugin-angular): wire linker plugin into compilation-API deps optimizer

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
@@ -34,6 +34,11 @@ import {
 } from '../utils/plugin-config.js';
 import { TsconfigResolver } from '../utils/tsconfig-resolver.js';
 import { isTailwindReferenceError } from '../utils/tailwind-reference.js';
+import { isRolldown } from '../utils/rolldown.js';
+import {
+  createCompilerPlugin,
+  createRolldownCompilerPlugin,
+} from '../compiler-plugin.js';
 import {
   AnalogStylesheetRegistry,
   preprocessStylesheetResult,
@@ -570,12 +575,51 @@ export function compilationAPIPlugin(
       // esbuild/oxc so they don't compete.
       debugCompilationApi('esbuild/oxc disabled, Angular handles transforms');
 
+      // The compilation API owns user-source transforms, but deps
+      // optimization still bundles partial-compiled Angular libs from
+      // node_modules (`ɵɵngDeclareInjectable/Factory`). Without the
+      // linker plugin, those declarations reach the browser unprocessed
+      // and Angular tries to JIT-compile them at runtime. Mirror the
+      // deps-optimizer wiring from `angular-vite-plugin.ts` so the
+      // linker runs on `.[cm]?js` deps under both rolldown and esbuild.
+      const useRolldown = isRolldown();
+      const preliminaryTsConfigPath = resolveTsConfigPath();
+      const compilerPluginOptions = {
+        tsconfig: preliminaryTsConfigPath,
+        sourcemap: !isProd,
+        advancedOptimizations: isProd,
+        jit: pluginOptions.jit,
+        incremental: watchMode,
+      };
+
       return {
         esbuild: undefined,
         oxc: undefined,
         optimizeDeps: {
           include: ['rxjs/operators', 'rxjs', 'tslib'],
           exclude: ['@angular/platform-server'],
+          ...(useRolldown
+            ? {
+                rolldownOptions: {
+                  plugins: [
+                    createRolldownCompilerPlugin(
+                      compilerPluginOptions,
+                      !pluginOptions.isAstroIntegration,
+                    ),
+                  ],
+                },
+              }
+            : {
+                esbuildOptions: {
+                  plugins: [
+                    createCompilerPlugin(
+                      compilerPluginOptions,
+                      isTest,
+                      !pluginOptions.isAstroIntegration,
+                    ),
+                  ],
+                },
+              }),
         },
         resolve: {
           conditions: ['style', ...(config.resolve?.conditions ?? [])],


### PR DESCRIPTION
## PR Checklist

When the Angular Compilation API is enabled, Vite's deps optimizer was bundling partial-compiled Angular libs from `node_modules` (`ɵɵngDeclareInjectable/Factory`) without running the linker. Those declarations reached the browser unprocessed and Angular tried to JIT-compile them at runtime.

Closes #

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A — single focused change.

## What is the new behavior?

`compilationAPIPlugin` now mirrors the deps-optimizer wiring from `angular-vite-plugin.ts`: it constructs `compilerPluginOptions` once and registers either `createRolldownCompilerPlugin` (under rolldown) or `createCompilerPlugin` (under esbuild) so the Angular linker runs on `.[cm]?js` deps. Behavior under the legacy plugin path is unchanged.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification — confirm a partial-compiled lib (e.g. one shipping `ɵɵngDeclareInjectable`) loads without runtime JIT compilation under both rolldown and esbuild deps optimizers

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Branched off `alpha`. The same wiring already exists in `angular-vite-plugin.ts`; this PR brings parity to the compilation-API code path.