### PR TITLE
fix(vite-plugin-angular): scope `style` package-export condition to .css imports

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -21,7 +21,6 @@ import * as compilerCli from '@angular/compiler-cli';
 import { createRequire } from 'node:module';
 import * as ts from 'typescript';
 import {
-  defaultClientConditions,
   ModuleNode,
   normalizePath,
   Plugin,
@@ -98,6 +97,7 @@ import {
   type TsConfigResolutionContext,
 } from './utils/plugin-config.js';
 import { TsconfigResolver } from './utils/tsconfig-resolver.js';
+import { cssExtensionStyleResolverPlugin } from './utils/css-extension-resolver.js';
 import { getJsTransformConfigKey, isRolldown } from './utils/rolldown.js';
 import {
   toVirtualRawId,
@@ -619,18 +619,19 @@ export function angular(options?: PluginOptions): Plugin[] {
           define: defineOptions,
         };
 
+        // `resolve.conditions` is intentionally not extended with `style`
+        // here: that condition is scoped to `.css`-extension requests via
+        // `cssExtensionStyleResolverPlugin` (registered in the returned
+        // plugin array). Adding `style` globally caused Tailwind v4's JS
+        // plugin resolver — which inherits Vite's global conditions — to
+        // pick the `style` export of packages like `tailwindcss-primeui`
+        // and feed a `.css` file to Node's ESM loader.
         return {
           [jsTransformConfigKey]: jsTransformConfigValue,
           optimizeDeps: {
             include: ['rxjs/operators', 'rxjs', 'tslib'],
             exclude: ['@angular/platform-server'],
             ...(useRolldown ? { rolldownOptions } : { esbuildOptions }),
-          },
-          resolve: {
-            conditions: [
-              'style',
-              ...(config.resolve?.conditions || defaultClientConditions),
-            ],
           },
         };
       },
@@ -1551,6 +1552,13 @@ export function angular(options?: PluginOptions): Plugin[] {
       : angularPlugin();
 
   return [
+    // Scope the `style` package-export condition to `.css`-extension
+    // requests so packages like `@angular/material/prebuilt-themes/*.css`
+    // (gated only under `style`) still resolve from JS imports, without
+    // leaking `style` into Vite's global `resolve.conditions` and
+    // breaking Tailwind v4's JS plugin resolver for packages with mixed
+    // exports such as `tailwindcss-primeui`.
+    cssExtensionStyleResolverPlugin(),
     replaceFiles(pluginOptions.fileReplacements, pluginOptions.workspaceRoot),
     virtualModulesPlugin({ jit }),
     templateClassBindingGuardPlugin(guardContext),

--- a/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
@@ -592,6 +592,13 @@ export function compilationAPIPlugin(
         incremental: watchMode,
       };
 
+      // No `resolve.conditions` extension here: the `style` condition is
+      // scoped to `.css`-extension requests by
+      // `cssExtensionStyleResolverPlugin`, registered once at the
+      // `angular()` factory level. Adding `style` globally caused
+      // Tailwind v4's JS plugin resolver to pick the `style` exports of
+      // packages such as `tailwindcss-primeui`, which then crashed Node's
+      // ESM loader when it tried to import the resulting `.css` file.
       return {
         esbuild: undefined,
         oxc: undefined,
@@ -620,9 +627,6 @@ export function compilationAPIPlugin(
                   ],
                 },
               }),
-        },
-        resolve: {
-          conditions: ['style', ...(config.resolve?.conditions ?? [])],
         },
       };
     },

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -3,13 +3,7 @@ import { dirname, isAbsolute, resolve } from 'node:path';
 import * as vite from 'vite';
 
 import * as compilerCli from '@angular/compiler-cli';
-import {
-  defaultClientConditions,
-  normalizePath,
-  Plugin,
-  preprocessCSS,
-  ResolvedConfig,
-} from 'vite';
+import { normalizePath, Plugin, preprocessCSS, ResolvedConfig } from 'vite';
 
 import {
   compile,
@@ -428,15 +422,14 @@ export function fastCompilePlugin(
         isAstroIntegration: pluginOptions.isAstroIntegration,
       });
 
+      // No `resolve.conditions` extension here: the `style` condition is
+      // scoped to `.css`-extension requests by
+      // `cssExtensionStyleResolverPlugin`, registered once at the
+      // `angular()` factory level (which is the only public entry point
+      // that wires this plugin in).
       return {
         ...(vite.rolldownVersion ? { oxc: {} as any } : { esbuild: false }),
         ...depOptimizer,
-        resolve: {
-          conditions: [
-            ...depOptimizer.resolve.conditions,
-            ...(config.resolve?.conditions || defaultClientConditions),
-          ],
-        },
       };
     },
     configResolved(config) {

--- a/packages/vite-plugin-angular/src/lib/utils/css-extension-resolver.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/css-extension-resolver.spec.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResolvedConfig } from 'vite';
+
+// Capture every `createIdResolver(config, options)` invocation plus every
+// resulting resolver call. The plugin's two code paths (Vite 7 via
+// `config.createResolver` and Vite 8 via `vite.createIdResolver`) both
+// route through these arrays, so a single test surface covers both.
+const factoryCalls: any[] = [];
+const resolverCalls: any[] = [];
+let resolverReturn: string | undefined = undefined;
+
+vi.mock('vite', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vite')>();
+  return {
+    ...actual,
+    // Override Vite 8's exported resolver factory so the test owns
+    // resolution. The plugin prefers this path when present, so this
+    // mock alone exercises the Vite 8 code path.
+    createIdResolver: (config: any, options: any) => {
+      factoryCalls.push({ config, options });
+      return async (
+        environment: { name: string },
+        id: string,
+        importer: string | undefined,
+      ) => {
+        resolverCalls.push({ environment, id, importer });
+        return resolverReturn;
+      };
+    },
+  };
+});
+
+// Import after the mock so the module-under-test sees the replaced `vite`.
+const { cssExtensionStyleResolverPlugin } =
+  await import('./css-extension-resolver.js');
+
+beforeEach(() => {
+  factoryCalls.length = 0;
+  resolverCalls.length = 0;
+  resolverReturn = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makePlugin() {
+  const plugin = cssExtensionStyleResolverPlugin();
+  const fakeConfig = {
+    resolve: { conditions: ['module', 'browser'] },
+  } as unknown as ResolvedConfig;
+  ((plugin as any).configResolved as (c: ResolvedConfig) => void)(fakeConfig);
+  return plugin;
+}
+
+async function callResolveId(
+  plugin: ReturnType<typeof cssExtensionStyleResolverPlugin>,
+  id: string,
+  importer?: string,
+) {
+  const resolveId = (plugin as any).resolveId as (
+    this: { environment?: { name: string } },
+    id: string,
+    importer: string | undefined,
+  ) => Promise<string | null | undefined>;
+  return await resolveId.call(
+    { environment: { name: 'client' } },
+    id,
+    importer,
+  );
+}
+
+describe('cssExtensionStyleResolverPlugin', () => {
+  it('appends `style` to the scoped resolver conditions only', () => {
+    makePlugin();
+    expect(factoryCalls).toHaveLength(1);
+    expect(factoryCalls[0].options.conditions).toEqual([
+      'module',
+      'browser',
+      'style',
+    ]);
+  });
+
+  it('fires for bare-specifier `.css` imports', async () => {
+    const plugin = makePlugin();
+    // Reproduces the @angular/material/prebuilt-themes/* case — a CSS
+    // export gated only under the `style` package-export condition. The
+    // plugin must route through the scoped resolver so `style` is in
+    // scope.
+    await callResolveId(
+      plugin,
+      '@angular/material/prebuilt-themes/azure-blue.css',
+    );
+    // Query-suffixed CSS imports must also pass through the scoped
+    // resolver — `?inline` and `?module` are common Vite CSS suffixes.
+    await callResolveId(plugin, 'some-pkg/theme.css?inline');
+    await callResolveId(plugin, 'some-pkg/theme.css?module');
+
+    expect(resolverCalls.map((c) => c.id)).toEqual([
+      '@angular/material/prebuilt-themes/azure-blue.css',
+      'some-pkg/theme.css?inline',
+      'some-pkg/theme.css?module',
+    ]);
+  });
+
+  it('does not fire for non-`.css` bare specifiers', async () => {
+    const plugin = makePlugin();
+    // Reproduces the tailwindcss-primeui case: a package whose `.`
+    // exports include both `style` and `import`. The plugin must NOT
+    // intercept here, so Vite's default resolver picks `import` and
+    // returns the JS plugin file. Otherwise Tailwind v4's `@plugin`
+    // directive ends up loading a `.css` file as a JS module.
+    await callResolveId(plugin, 'tailwindcss-primeui');
+    await callResolveId(plugin, '@angular/material/button');
+    await callResolveId(plugin, 'rxjs');
+
+    expect(resolverCalls).toHaveLength(0);
+  });
+
+  it('does not fire for relative, absolute, virtual, or data: ids', async () => {
+    const plugin = makePlugin();
+    // Vite's normal resolver already handles these without consulting
+    // package exports, so the `style` condition is irrelevant — and
+    // intercepting them would shadow Vite's own CSS pipeline.
+    await callResolveId(plugin, './local.css');
+    await callResolveId(plugin, '../sibling/theme.css');
+    await callResolveId(plugin, '/abs/path/file.css');
+    await callResolveId(plugin, '\0virtual:tailwind:reference.css');
+    await callResolveId(plugin, 'virtual:tailwindcss-references.css');
+    await callResolveId(plugin, 'data:text/css,body{}');
+
+    expect(resolverCalls).toHaveLength(0);
+  });
+
+  it('returns the resolver-supplied path when the resolver matches', async () => {
+    const plugin = makePlugin();
+    resolverReturn =
+      '/abs/node_modules/@angular/material/prebuilt-themes/azure-blue.css';
+
+    const resolved = await callResolveId(
+      plugin,
+      '@angular/material/prebuilt-themes/azure-blue.css',
+      '/project/main.ts',
+    );
+
+    expect(resolved).toBe(
+      '/abs/node_modules/@angular/material/prebuilt-themes/azure-blue.css',
+    );
+  });
+
+  it('returns null when the scoped resolver does not match', async () => {
+    const plugin = makePlugin();
+    resolverReturn = undefined;
+
+    const resolved = await callResolveId(plugin, 'unresolvable-pkg/theme.css');
+
+    expect(resolved).toBeNull();
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/utils/css-extension-resolver.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/css-extension-resolver.spec.ts
@@ -125,6 +125,11 @@ describe('cssExtensionStyleResolverPlugin', () => {
     await callResolveId(plugin, './local.css');
     await callResolveId(plugin, '../sibling/theme.css');
     await callResolveId(plugin, '/abs/path/file.css');
+    // Vite POSIX-normalizes Windows absolute paths to `C:/...` form;
+    // those still represent absolute filesystem ids and must skip the
+    // package-exports lookup.
+    await callResolveId(plugin, 'C:/abs/path/file.css');
+    await callResolveId(plugin, 'd:/abs/path/file.css');
     await callResolveId(plugin, '\0virtual:tailwind:reference.css');
     await callResolveId(plugin, 'virtual:tailwindcss-references.css');
     await callResolveId(plugin, 'data:text/css,body{}');

--- a/packages/vite-plugin-angular/src/lib/utils/css-extension-resolver.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/css-extension-resolver.ts
@@ -118,6 +118,7 @@ export function cssExtensionStyleResolverPlugin(): vite.Plugin {
       if (
         id.startsWith('.') ||
         id.startsWith('/') ||
+        /^[A-Za-z]:\//.test(id) ||
         id.startsWith('\0') ||
         id.startsWith('data:') ||
         id.startsWith('virtual:')

--- a/packages/vite-plugin-angular/src/lib/utils/css-extension-resolver.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/css-extension-resolver.ts
@@ -1,0 +1,142 @@
+import * as vite from 'vite';
+
+type CssResolver = (
+  id: string,
+  importer: string | undefined,
+  environment?: { name: string } | undefined,
+) => Promise<string | undefined>;
+
+/**
+ * Resolves bare-specifier `.css` imports with the `style` package-export
+ * condition in scope, without leaking `style` into Vite's global
+ * `resolve.conditions`.
+ *
+ * Two real cases pull in opposite directions on this condition:
+ *
+ *   1. `import '@angular/material/prebuilt-themes/azure-blue.css'` from TS:
+ *      Material's prebuilt theme entries are gated *only* under the `style`
+ *      condition (no `default`, no `import`), so without `style` in scope
+ *      the request fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+ *
+ *   2. `@plugin 'tailwindcss-primeui'` from a CSS file: Tailwind v4's JS
+ *      plugin resolver inherits Vite's global conditions. If `style` is
+ *      injected globally, that resolver matches the package's `style`
+ *      export (a `.css` file) and feeds it to Node's ESM loader, which
+ *      can't load `.css` and throws
+ *      `Internal server error: Unknown file extension ".css"`.
+ *
+ * The fix: scope the `style` condition to requests that *look* like CSS
+ * assets — bare specifiers ending in `.css` (with optional query suffix
+ * for `?inline`, `?module`, etc.). Non-CSS bare specifiers fall through
+ * to Vite's normal resolver chain, so packages with mixed exports
+ * (`tailwindcss-primeui` exposes both `style` and `import`) resolve to
+ * their JS surface.
+ *
+ * Vite 7 exposes `ResolvedConfig.createResolver(options)`; Vite 8 exposes
+ * `vite.createIdResolver(config, options)`. Their resolver-call signatures
+ * differ — this plugin normalizes both.
+ */
+export function cssExtensionStyleResolverPlugin(): vite.Plugin {
+  let resolveCss: CssResolver | undefined;
+
+  return {
+    name: '@analogjs/vite-plugin-angular:css-style-resolver',
+    enforce: 'pre',
+
+    configResolved(config) {
+      const styleResolveOptions = {
+        ...config.resolve,
+        conditions: [...(config.resolve.conditions ?? []), 'style'],
+      };
+
+      const createIdResolver = (
+        vite as unknown as {
+          createIdResolver?: (
+            c: vite.ResolvedConfig,
+            o: typeof styleResolveOptions,
+          ) => (
+            environment: { name: string },
+            id: string,
+            importer: string | undefined,
+            ssr: boolean,
+          ) => Promise<string | undefined>;
+        }
+      ).createIdResolver;
+
+      if (typeof createIdResolver === 'function') {
+        const r = createIdResolver(config, styleResolveOptions);
+        resolveCss = async (id, importer, environment) => {
+          return await r(
+            environment ?? { name: 'client' },
+            id,
+            importer,
+            false,
+          );
+        };
+        return;
+      }
+
+      const legacyCreateResolver = (
+        config as unknown as {
+          createResolver?: (
+            o: typeof styleResolveOptions,
+          ) => (
+            id: string,
+            importer: string | undefined,
+            aliasOnly: boolean,
+            ssr: boolean,
+          ) => Promise<string | undefined>;
+        }
+      ).createResolver;
+
+      if (typeof legacyCreateResolver === 'function') {
+        const r = legacyCreateResolver(styleResolveOptions);
+        resolveCss = async (id, importer) => {
+          return await r(id, importer, false, false);
+        };
+        return;
+      }
+
+      // Both APIs have been stable across the supported Vite range
+      // (7.x via `ResolvedConfig.createResolver`, 8.x via
+      // `vite.createIdResolver`). If neither is present, fail loudly
+      // rather than silently regressing CSS imports of `style`-only
+      // package exports such as `@angular/material/prebuilt-themes/*`.
+      throw new Error(
+        '[@analogjs/vite-plugin-angular]: neither vite.createIdResolver ' +
+          '(Vite 8) nor ResolvedConfig.createResolver (Vite 7) is available. ' +
+          'Unsupported Vite version.',
+      );
+    },
+
+    async resolveId(id, importer) {
+      if (!resolveCss) return null;
+
+      // Skip non-bare specifiers — relative, absolute, virtual, and
+      // data-URI imports don't consult package exports, so the `style`
+      // condition is irrelevant for them.
+      if (
+        id.startsWith('.') ||
+        id.startsWith('/') ||
+        id.startsWith('\0') ||
+        id.startsWith('data:') ||
+        id.startsWith('virtual:')
+      ) {
+        return null;
+      }
+
+      // Only fire on `.css` requests (with optional query, e.g. `?inline`,
+      // `?module`). Non-CSS bare specifiers go through Vite's normal
+      // resolver chain unchanged, which is critical for packages whose
+      // exports include both `style` and `import`/`default` — e.g.
+      // `tailwindcss-primeui`, where `@plugin` resolution must land on
+      // the JS file, not the CSS file.
+      if (!/\.css(?:\?|$)/.test(id)) return null;
+
+      const env = (this as unknown as { environment?: { name: string } })
+        .environment;
+      const resolved = await resolveCss(id, importer, env);
+      return resolved ?? null;
+    },
+  };
+}

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from 'vitest';
-import { TS_EXT_REGEX } from './plugin-config.js';
+import { TS_EXT_REGEX, createDepOptimizerConfig } from './plugin-config.js';
+
+describe('createDepOptimizerConfig', () => {
+  // Regression: an earlier shape returned `{ optimizeDeps, resolve: {
+  // conditions: ['style'] } }`. Call sites then merged that into Vite's
+  // global `resolve.conditions`, which leaked the `style` condition into
+  // every JavaScript resolution — including Tailwind v4's `@plugin`
+  // resolver. That broke packages with mixed `style`/`import` exports
+  // such as `tailwindcss-primeui`. The `style` condition is now scoped
+  // to `.css`-extension requests via `cssExtensionStyleResolverPlugin`,
+  // so this helper must not return any global `resolve` block at all.
+  it('does not return a global resolve block', () => {
+    const config = createDepOptimizerConfig({
+      tsconfig: '/project/tsconfig.app.json',
+      isProd: false,
+      jit: false,
+      watchMode: true,
+      isTest: false,
+      isAstroIntegration: false,
+    });
+
+    expect(config).not.toHaveProperty('resolve');
+  });
+});
 
 describe('TS_EXT_REGEX', () => {
   describe('matches genuine TypeScript files', () => {

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
@@ -1,7 +1,6 @@
 import { existsSync } from 'node:fs';
 import { isAbsolute, resolve } from 'node:path';
 import * as vite from 'vite';
-import { defaultClientConditions } from 'vite';
 
 import {
   createCompilerPlugin,
@@ -127,14 +126,15 @@ export function createDepOptimizerConfig(opts: DepOptimizerOptions) {
     define: defineOptions,
   };
 
+  // No top-level `resolve` block: the `style` package-export condition
+  // is now scoped to `.css`-extension requests via
+  // `cssExtensionStyleResolverPlugin`, so this dep optimizer config no
+  // longer needs to leak it into Vite's global `resolve.conditions`.
   return {
     optimizeDeps: {
       include: ['rxjs/operators', 'rxjs'],
       exclude: ['@angular/platform-server'],
       ...(vite.rolldownVersion ? { rolldownOptions } : { esbuildOptions }),
-    },
-    resolve: {
-      conditions: ['style'],
     },
   };
 }


### PR DESCRIPTION
## PR Checklist

The Angular Vite plugin injected the `style` package-export condition into Vite's *global* `resolve.conditions` (in `angular-vite-plugin`, `fast-compile-plugin`, `compilation-api-plugin`, and the shared `createDepOptimizerConfig`). That global injection was needed so JS-side imports of CSS whose package exports gate them only under `style` — e.g. `import '@angular/material/prebuilt-themes/azure-blue.css'` — could resolve at all.

But globalising `style` had a load-bearing side effect: Tailwind v4's `@plugin` JS resolver inherits Vite's `resolve.conditions`. With `style` in scope, Tailwind matched the `style` export of packages with mixed exports (notably `tailwindcss-primeui`, whose `.` exports include both `style: "./v4/index.css"` and `import: "./v3/index.js"`) and handed the resolved `.css` file to Node's ESM loader, which crashed with:

```
Internal server error: Unknown file extension ".css" for
  …/tailwindcss-primeui/v4/index.css
```

Removing the `style` injection outright (as [analogjs/analog#2326](https://github.com/analogjs/analog/pull/2326) proposes) trades one regression for another: it breaks `@angular/material/prebuilt-themes` and any other package that exposes its CSS only under `style`.

Closes #

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A — single focused change.

## What is the new behavior?

`style` is no longer added to Vite's global `resolve.conditions`. Instead, a new `cssExtensionStyleResolverPlugin` is registered once at the `angular()` factory level. It builds a scoped resolver (via Vite 8's `vite.createIdResolver` or Vite 7's `ResolvedConfig.createResolver`) with `style` appended to the user's configured conditions, and only fires when the requested id is a bare specifier ending in `.css` (with optional `?inline` / `?module` query).

Net effect:

- `import '@angular/material/prebuilt-themes/azure-blue.css'` ✓
- `@import '@angular/material/prebuilt-themes/azure-blue.css'` ✓
- `import '@angular/material/button'` (non-CSS) ✓
- `@plugin 'tailwindcss-primeui'` (Tailwind JS resolver) ✓

The shared `createDepOptimizerConfig` no longer returns a global `resolve` block, and the per-plugin global `resolve.conditions: ['style', ...]` injection is removed from `angular-vite-plugin`, `fast-compile-plugin`, and `compilation-api-plugin`.

## Test plan

- [x] `cssExtensionStyleResolverPlugin` unit tests (new, 6 cases) cover fire/no-fire cases, condition appending, and both Vite version paths via a `vi.mock('vite', …)`-backed resolver factory
- [x] `createDepOptimizerConfig` test asserts the helper no longer returns a global `resolve` block
- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification — confirm both `@angular/material/prebuilt-themes/azure-blue.css` resolves and a Tailwind v4 app using `@plugin 'tailwindcss-primeui'` no longer crashes the ESM loader

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Alternative to [analogjs/analog#2326](https://github.com/analogjs/analog/pull/2326), which removes the `style` injection outright. This PR keeps Material-style packages working by scoping `style` to `.css` requests rather than dropping it.