### PR TITLE
fix(vite-plugin-angular): preserve TS sourcemaps in test pipeline

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -727,9 +727,17 @@ export function angular(options?: PluginOptions): Plugin[] {
             });
           }
 
+          if (typescriptResult.map) {
+            // TS emits `//# sourceMappingURL=foo.js.map` at the end of the
+            // .js content, but the .map file isn't served by Vite — we
+            // return the map object directly. Strip the stale reference so
+            // downstream tools don't see two sourceMappingURL comments.
+            data = data.replace(/\s*\/\/# sourceMappingURL=[^\r\n]*\s*$/, '');
+          }
+
           return {
             code: data,
-            map: null,
+            map: typescriptResult.map ?? null,
           };
         },
       },
@@ -769,7 +777,9 @@ export function angular(options?: PluginOptions): Plugin[] {
     !pluginOptions.fastCompile &&
       pluginOptions.liveReload &&
       liveReloadPlugin({ classNames, fileEmitter }),
-    ...(isTest && !isStackBlitz ? angularVitestPlugins() : []),
+    ...(isTest && !isStackBlitz
+      ? angularVitestPlugins((id) => outputFiles.get(normalizePath(id))?.map)
+      : []),
     (jit &&
       jitPlugin({
         inlineStylesExtension: pluginOptions.inlineStylesExtension,
@@ -1025,8 +1035,8 @@ export function angular(options?: PluginOptions): Plugin[] {
       const read = compilerCli.readConfiguration(resolvedTsConfigPath, {
         suppressOutputPathCheck: true,
         outDir: undefined,
-        sourceMap: false,
-        inlineSourceMap: !isProd,
+        sourceMap: !isProd,
+        inlineSourceMap: false,
         inlineSources: !isProd,
         declaration: false,
         declarationMap: false,
@@ -1217,9 +1227,26 @@ export function angular(options?: PluginOptions): Plugin[] {
         return;
       }
 
+      // TS emits the .js.map file separately — attach it to the entry for
+      // the same source file so the transform hook can return the map and
+      // coverage tools can chain maps back to the original TS. The .map can
+      // arrive before or after the .js, so upsert in either order. Match
+      // only `.js.map` (not `.d.ts.map`) so a future `declarationMap: true`
+      // doesn't clobber the JS source map with the declaration map.
+      if (/\.[cm]?js\.map$/.test(_filename)) {
+        const existing = outputFiles.get(filename);
+        outputFiles.set(filename, {
+          ...(existing ?? { dependencies: [] }),
+          map: content,
+        });
+        return;
+      }
+
       const metadata = watchMode ? fileMetadata(filename) : {};
+      const existing = outputFiles.get(filename);
 
       outputFiles.set(filename, {
+        ...(existing ?? {}),
         content,
         dependencies: [],
         errors: metadata.errors,
@@ -1236,11 +1263,18 @@ export function angular(options?: PluginOptions): Plugin[] {
       }
 
       let content = '';
+      let map: string | undefined;
+      let mapFilename: string | undefined;
       builder.emit(
         sourceFile,
         (filename, data) => {
           if (/\.[cm]?js$/.test(filename)) {
             content = data;
+          }
+
+          if (/\.[cm]?js\.map$/.test(filename)) {
+            map = data;
+            mapFilename = filename;
           }
 
           if (
@@ -1273,6 +1307,11 @@ export function angular(options?: PluginOptions): Plugin[] {
       );
 
       writeFileCallback(id, content, false, undefined, [sourceFile]);
+      if (map !== undefined && mapFilename !== undefined) {
+        // Use the filename TypeScript emitted (handles `.cts`/`.mts` as well
+        // as `.ts`) instead of regex-replacing the source `.ts` extension.
+        writeFileCallback(mapFilename, map, false, undefined, [sourceFile]);
+      }
 
       if (angularCompiler) {
         angularCompiler.incrementalCompilation.recordSuccessfulEmit(sourceFile);

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -79,12 +79,20 @@ export function angularVitestEsbuildPlugin(): Plugin {
 }
 
 /**
- * This plugin does post-processing with esbuild
- * instead of preprocessing to re-align
- * the sourcemaps so breakpoints and coverage reports
- * work correctly.
+ * Post-processing pass that converts any `.ts` files Angular's compilation
+ * skipped (e.g. files without Angular decorators when
+ * `useAngularCompilationAPI` is on) into runnable JS via esbuild/OXC.
+ *
+ * Files Angular already compiled have a sourcemap available via
+ * `getInMap` — we skip those here to avoid breaking the chain Vite is
+ * already wiring up. Re-running OXC over already-compiled JS produces a
+ * map relative to the TS-emitted JS, not the original .ts source, and
+ * OXC's `inMap` parameter does not chain through the way esbuild's inline
+ * `//# sourceMappingURL=` auto-detection does.
  */
-export function angularVitestSourcemapPlugin(): Plugin {
+export function angularVitestSourcemapPlugin(
+  getInMap?: (id: string) => string | undefined,
+): Plugin {
   return {
     name: '@analogjs/vitest-angular-sourcemap-plugin',
     async transform(code: string, id: string) {
@@ -92,33 +100,35 @@ export function angularVitestSourcemapPlugin(): Plugin {
         return;
       }
 
-      const [, query] = id.split('?');
+      const [bareId, query] = id.split('?');
 
       if (query && query.includes('inline')) {
         return;
       }
 
-      if (vite.transformWithOxc) {
-        const result = await vite.transformWithOxc(code, id, {
-          lang: 'js',
-        });
+      if (getInMap?.(bareId)) {
+        return;
+      }
 
+      if (vite.transformWithOxc) {
+        const result = await vite.transformWithOxc(code, id, { lang: 'js' });
         return result as unknown as vite.TransformResult;
       } else {
         const result = await vite.transformWithEsbuild(code, id, {
           loader: 'ts',
         });
-
         return result;
       }
     },
   };
 }
 
-export function angularVitestPlugins() {
+export function angularVitestPlugins(
+  getInMap?: (id: string) => string | undefined,
+) {
   return [
     angularVitestPlugin(),
     angularVitestEsbuildPlugin(),
-    angularVitestSourcemapPlugin(),
+    angularVitestSourcemapPlugin(getInMap),
   ];
 }

--- a/tests/vitest-angular/src/sourcemap/sourcemap.spec.ts
+++ b/tests/vitest-angular/src/sourcemap/sourcemap.spec.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { expect, test } from 'vitest';
+
+// A component decorator above the throw site forces Angular's compilation to
+// insert generated definitions (`ɵfac`, `ɵcmp`) into the emit, which shifts
+// line numbers between the .ts source and the compiled JS. Without a correct
+// sourcemap chain the stack trace below reports the post-compile line number,
+// not the original .ts line.
+@Component({
+  standalone: true,
+  selector: 'lib-padded',
+  template: '',
+})
+export class PaddedComponent {}
+
+// The throw below sits on a known source line. With a working sourcemap
+// chain through the plugin pipeline, `Error.stack` should report a line
+// close to THROW_LINE — Angular's compile-time emit inserts a few lines
+// of generated code (`ɵfac`/`ɵcmp`) that the sourcemap doesn't perfectly
+// attribute, so a small tolerance is allowed. The regression this guards
+// against is a much larger offset (~20+ lines) caused by the OXC
+// post-transform stripping the chain.
+const THROW_LINE = 34;
+const MAX_OFFSET = 6;
+
+function parseSpecLine(stack: string): number | null {
+  const match = /sourcemap\.spec\.ts[^:]*:(\d+)(?::\d+)?/.exec(stack);
+  return match ? Number(match[1]) : null;
+}
+
+test('error stack maps back to the original TypeScript line', () => {
+  let stack = '';
+  try {
+    throw new Error('sourcemap probe');
+  } catch (e) {
+    stack = (e as Error).stack ?? '';
+  }
+  const reportedLine = parseSpecLine(stack);
+  expect(reportedLine, `no spec frame in stack:\n${stack}`).not.toBeNull();
+  expect(
+    Math.abs((reportedLine as number) - THROW_LINE),
+    `reported line ${reportedLine}, expected within ${MAX_OFFSET} of ${THROW_LINE}\n${stack}`,
+  ).toBeLessThanOrEqual(MAX_OFFSET);
+});

--- a/tests/vitest-angular/src/sourcemap/test-setup.ts
+++ b/tests/vitest-angular/src/sourcemap/test-setup.ts
@@ -1,0 +1,3 @@
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+setupTestBed();

--- a/tests/vitest-angular/src/sourcemap/vitest.project.ts
+++ b/tests/vitest-angular/src/sourcemap/vitest.project.ts
@@ -1,0 +1,16 @@
+import angular from '@analogjs/vite-plugin-angular';
+import type { Plugin, TestProjectInlineConfiguration } from 'vitest/config';
+
+import { basename, dirname } from 'path';
+
+const name = basename(dirname(__filename));
+
+export default {
+  extends: true,
+  plugins: [angular({ jit: false }) as unknown as Plugin],
+  test: {
+    name,
+    include: [`src/${name}/**/*.spec.ts`],
+    setupFiles: [`src/${name}/test-setup.ts`],
+  },
+} satisfies TestProjectInlineConfiguration;

--- a/tests/vitest-angular/vitest.config.ts
+++ b/tests/vitest-angular/vitest.config.ts
@@ -6,6 +6,7 @@ import aotProject from './src/aot/vitest.project';
 import snapshotSerializersProject from './src/snapshot-serializers/vitest.project';
 import providersProject from './src/providers/vitest.project';
 import resetTestBedBetweenTestsProject from './src/reset-test-bed-between-tests/vitest.project';
+import sourcemapProject from './src/sourcemap/vitest.project';
 
 export default defineConfig({
   root: __dirname,
@@ -31,6 +32,7 @@ export default defineConfig({
       resetTestBedBetweenTestsProject,
       providersProject,
       snapshotSerializersProject,
+      sourcemapProject,
     ],
   },
 });


### PR DESCRIPTION
## PR Checklist

Closes #2332

Likely also addresses #2296 (coverage variant of the same root cause — coverage maps to TS-emitted JS instead of original `.ts`).

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: vitest-angular (integration test fixture)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Restores accurate sourcemap line numbers for `.ts` test files when running Vitest against `@analogjs/vite-plugin-angular` on Vite 8 / rolldown. Stack frames in `Error.stack`, breakpoints in the Vitest VS Code extension, and coverage reports now point at the original TypeScript line rather than the post-compile JS line.

Three changes in one fix:

1. **Switch TS emit from inline → separate `.map`.** Configure `sourceMap: !isProd, inlineSourceMap: false` so the TypeScript compiler emits a sibling `.js.map` instead of baking a base64 data URI into the `.js`. The angular transform hook captures the map and returns it via `{ code, map }`, and the stale trailing `//# sourceMappingURL=` comment is stripped so downstream tools don't see two references.

2. **Fix order-of-arrival bug in `writeFileCallback`.** TS emits the `.js.map` *before* the `.js`. The original handler only stored the map when an entry already existed in `outputFiles`, so the map was silently dropped on every emit. The handler now upserts in either order.

3. **Skip the post-OXC/esbuild transform when the upstream map exists.** `angularVitestSourcemapPlugin` was a workaround from the esbuild era — esbuild auto-chains inline sourcemaps in its `transform` API, so post-processing produced a fresh map back to the original `.ts` for free. OXC does not auto-chain (`inMap` is documented but ignored in practice), so re-running it over already-compiled JS produces a map relative to the TS-emitted JS instead of the original source, breaking the chain Vite is wiring up. The post-pass now runs only for files Angular's compilation skipped (e.g. non-decorator `.ts` under `useAngularCompilationAPI`), which is what it was originally intended for.

## Test plan

- [x] `nx run tests-vitest-angular:test` — new sub-project under `tests/vitest-angular/src/sourcemap/` asserts `Error.stack` reports a line within 6 of the original throw site (Angular's compile-time `ɵfac`/`ɵcmp` insertions account for a small irreducible offset). Pre-fix this offset is ~21 lines; post-fix it's 0–4.
- [x] Standalone reproduction project (`npm create analog@latest`) with 5 stacked decorators above the throw: pre-fix the stack reports an 11-line offset; post-fix it matches the source line exactly.
- [x] Existing `aot`, `providers`, `reset-test-bed-between-tests`, and `snapshot-serializers` integration projects continue to pass.
- [ ] `nx format:check`
- [ ] `pnpm build`
- [x] `pnpm test` (subset — `tests-vitest-angular`)
- [x] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The `getInMap` callback is plumbed end-to-end so that if `transformWithOxc`'s `inMap` parameter starts honoring chained input maps in a future rolldown release, switching the post-plugin from "skip when map exists" to "chain when map exists" is a single-line change. Filed mentally as a TODO; happy to file an upstream OXC issue separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)