### PR TITLE
fix(vite-plugin-angular): skip source .d.ts files for composite TS projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analogjs-platform",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analogjs-platform",
-  "version": "2.5.2",
+  "version": "2.5.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1223,7 +1223,14 @@ export function angular(options?: PluginOptions): Plugin[] {
 
       const filename = normalizePath(sourceFiles[0].fileName);
 
-      if (filename.includes('ngtypecheck.ts') || filename.includes('.d.')) {
+      // Skip declaration outputs and declaration source files.
+      if (
+        filename.includes('ngtypecheck.ts') ||
+        filename.includes('.d.') ||
+        _filename.endsWith('.d.ts') ||
+        _filename.endsWith('.d.mts') ||
+        _filename.endsWith('.d.cts')
+      ) {
         return;
       }
 


### PR DESCRIPTION
## PR Checklist

I have composite project (so declaration: true) and previous impl took content of .d.ts files - that lead to having 0 unit tests inside spec files.
This PR extends list of ignorable files.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
