### PR TITLE
fix(storybook-angular): support Storybook 10.4+ object-shaped core preset

### DIFF
--- a/packages/storybook-angular/src/lib/preset.spec.ts
+++ b/packages/storybook-angular/src/lib/preset.spec.ts
@@ -48,14 +48,18 @@ beforeEach(async () => {
  * call. Required when a test needs a fresh module graph (e.g. to change the
  * `@angular/core` VERSION mock).
  */
-const registerDependencyMocks = () => {
-  vi.doMock('@storybook/angular/preset', () => ({
-    core: async () => ({
-      options: {},
-      channelOptions: { wsToken: 'mock-token' },
-    }),
-    addons: [],
-  }));
+const registerDependencyMocks = (presetMock?: Record<string, unknown>) => {
+  vi.doMock(
+    '@storybook/angular/preset',
+    () =>
+      presetMock ?? {
+        core: async () => ({
+          options: {},
+          channelOptions: { wsToken: 'mock-token' },
+        }),
+        addons: [],
+      },
+  );
   vi.doMock('storybook/internal/types', () => ({}));
   vi.doMock('@storybook/angular', () => ({}));
   vi.doMock('@storybook/builder-vite', () => ({}));
@@ -83,6 +87,13 @@ const importWithAngularVersion = async (major: string) => {
   return mod.viteFinal;
 };
 
+const importCoreWithPreset = async (presetMock: Record<string, unknown>) => {
+  vi.resetModules();
+  registerDependencyMocks(presetMock);
+  const mod = await import('./preset');
+  return mod.core;
+};
+
 describe('core', () => {
   it('should await PresetCore and include channelOptions from resolved config', async () => {
     const result = await core({}, {});
@@ -95,6 +106,35 @@ describe('core', () => {
 
     expect(result.builder).toBeDefined();
     expect(result.builder.name).toBeDefined();
+  });
+
+  it('should support Storybook <= 10.3 where core is an async function', async () => {
+    const freshCore = await importCoreWithPreset({
+      core: async (config: Record<string, unknown>) => ({
+        ...config,
+        channelOptions: { wsToken: 'fn-token' },
+      }),
+      addons: [],
+    });
+
+    const result = await freshCore({ tags: ['cli'] }, {});
+
+    expect(result.tags).toEqual(['cli']);
+    expect(result.channelOptions?.wsToken).toBe('fn-token');
+    expect(result.builder.name).toBeDefined();
+  });
+
+  it('should support Storybook >= 10.4 where core is a static object', async () => {
+    const freshCore = await importCoreWithPreset({
+      core: { builder: 'webpack5-builder-path' },
+      addons: [],
+    });
+
+    const result = await freshCore({ tags: ['cli'] }, {});
+
+    expect(result.tags).toEqual(['cli']);
+    expect(result.builder.name).toBeDefined();
+    expect(result.builder.name).not.toBe('webpack5-builder-path');
   });
 });
 

--- a/packages/storybook-angular/src/lib/preset.ts
+++ b/packages/storybook-angular/src/lib/preset.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { core as PresetCore } from '@storybook/angular/preset';
+import * as angularPreset from '@storybook/angular/preset';
 import { fileURLToPath } from 'node:url';
 import * as vite from 'vite';
 
@@ -28,7 +28,10 @@ export const previewAnnotations = async (entries = [], options) => {
 };
 
 export const core = async (config, options) => {
-  const presetCore = await PresetCore(config, options);
+  const presetCore =
+    typeof angularPreset.core === 'function'
+      ? await angularPreset.core(config, options)
+      : { ...config, ...angularPreset.core };
   return {
     ...presetCore,
     builder: {


### PR DESCRIPTION
## PR Checklist

Storybook 10.4 ([storybookjs/storybook@c52ca909](https://github.com/storybookjs/storybook/commit/c52ca909cb9858fc469a83f8286c7f3e7b40aac4)) changed the `core` export of `@storybook/angular/preset` from an async function to a static object. The Analog preset called it as a function, throwing `TypeError: PresetCore is not a function`.

Closes #2336

## Affected scope

- Primary scope: storybook-angular
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

The `core` preset detects the shape of the upstream `@storybook/angular/preset` `core` export and handles both — calling it when it's a function (Storybook <= 10.3) and spreading it when it's an object (Storybook >= 10.4). The Vite builder override is unchanged, so it keeps working across both versions. No peer-dependency bump is needed (`^10.0.0` already covers 10.4).

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [x] `pnpm test` — `nx test storybook-angular --testFile=preset.spec.ts` (23 tests pass, including new cases for both the function-shaped and object-shaped `core` exports)
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

🤖 Generated with [Claude Code](https://claude.com/claude-code)
