### PR TITLE
fix(vite-plugin-angular): strip TS in fastCompile JIT path for StackBlitz

### DIFF
--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
@@ -127,6 +127,56 @@ describe('fastCompilePlugin bypass strips TS', () => {
     expect(mockTransformWithOxc).toHaveBeenCalled();
   });
 
+  it('strips TS-only syntax in the JIT path so `readonly` etc. never reach Rolldown', async () => {
+    // Regression for analogjs/analog#2339: fastCompile's JIT path returned
+    // the jitTransform output as-is, leaving TS-only modifiers like
+    // `readonly` in place. On StackBlitz / WebContainer (and any other
+    // environment without `angularVitestSourcemapPlugin`), Rolldown's parser
+    // chokes on the unstripped TS:
+    //   `Parse failure: Unexpected token \`ident\`. Expected * for generator, …`
+    // The JIT path must self-strip so the output is valid JS regardless of
+    // which downstream plugins are registered.
+    mockRolldownVersion = '1.0.0';
+    mockTransformWithOxc.mockResolvedValue({
+      code: 'export class App { test = ""; }\n',
+      map: { mappings: '' },
+    });
+
+    const plugin = fastCompilePlugin({
+      tsconfigGetter: () => 'tsconfig.json',
+      workspaceRoot: '/workspace',
+      inlineStylesExtension: 'css',
+      jit: true,
+      liveReload: false,
+      supportedBrowsers: [],
+      isTest: true,
+      isAstroIntegration: false,
+    });
+    const handler = getTransformHandler(plugin);
+
+    const code = `import { Component } from '@angular/core';
+@Component({ selector: 'app-root', template: '<div></div>' })
+export class App {
+  readonly test = '';
+}
+`;
+    const result = await handler.call(
+      { addWatchFile: () => undefined },
+      code,
+      '/src/app/app.ts',
+    );
+
+    // OXC strip must have been called with the jitTransform output (which
+    // still contains `readonly`) so Rolldown receives valid JS.
+    const oxcStripCall = mockTransformWithOxc.mock.calls.find(
+      ([, callId]) => callId === '/src/app/app.ts',
+    );
+    expect(oxcStripCall).toBeDefined();
+    expect(oxcStripCall![0]).toContain('readonly');
+    expect(oxcStripCall![2]).toMatchObject({ lang: 'ts' });
+    expect(result.code).not.toContain('readonly');
+  });
+
   it('does not run the bypass strip when the file has @Component', async () => {
     const plugin = buildPlugin();
     const handler = getTransformHandler(plugin);

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -291,7 +291,24 @@ export function fastCompilePlugin(
     // JIT mode
     if (pluginOptions.jit) {
       const result = jitTransform(code, id);
-      return { code: result.code, map: result.map };
+      // Strip TypeScript-only syntax (e.g. `readonly`, parameter property
+      // modifiers, type annotations on fields) so the output is valid JS
+      // for Rolldown. `angularVitestSourcemapPlugin` normally runs this
+      // strip downstream in tests, but it is intentionally skipped on
+      // StackBlitz / WebContainer — and the production build pipeline
+      // does not register it either — so the JIT path must self-strip
+      // to stay safe across environments.
+      const stripped = vite.transformWithOxc
+        ? await vite.transformWithOxc(result.code, id, {
+            lang: 'ts',
+            sourcemap: false,
+            decorator: { legacy: false, emitDecoratorMetadata: false },
+          })
+        : await vite.transformWithEsbuild(result.code, id, {
+            loader: 'ts',
+            sourcemap: false,
+          });
+      return { code: stripped.code, map: result.map };
     }
 
     // Inline external templateUrl/styleUrl(s) into the source before compilation


### PR DESCRIPTION
## PR Checklist

Closes [Fast compiled test fail when readonly keyword is used in component analogjs/analog#2339](https://github.com/analogjs/analog/issues/2339)

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: —

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

`fastCompile`'s JIT path now strips TypeScript-only syntax (e.g. `readonly`, parameter property modifiers, type annotations on fields) before returning, so its output is valid JS regardless of which downstream plugins are registered.

**Root cause.** `fastCompile` defaults to JIT mode for tests (`jit ??= isTest`). The JIT path in `fast-compile-plugin.ts` returned `jitTransform`'s output as-is, leaving TS-only modifiers like `readonly` in place. `angularVitestSourcemapPlugin` normally strips TS for tests downstream, but `angular-vite-plugin.ts` intentionally skips it on StackBlitz / WebContainer (`isTest && !isStackBlitz`). So on StackBlitz the raw TS reached Rolldown's parser:

```
RollupError: Parse failure: Unexpected token `ident`. Expected * for generator, private key, identifier or async
At file: /src/app/app.ts:6:11
  6  |    readonly test = '';
     |             ^
```

The JIT path now mirrors the strip already done at the end of the full-compile path.

## Test plan

- [x] `pnpm nx test vite-plugin-angular` (1100 passed)
- [x] `pnpm nx test analog-app` with a `readonly` field on a component (verified locally)
- [x] New regression test in `fast-compile-plugin.spec.ts` confirms the JIT path now calls OXC strip with the unstripped TS code and returns stripped JS
- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The fix mirrors the strip already done at the end of the full-compile path in the same file. The double-strip (here + `angularVitestSourcemapPlugin` when it is registered) is idempotent on plain JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)