### PR TITLE
fix(vite-plugin-angular): compose fastCompile JIT strip map and cover esbuild fallback

### DIFF
--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
@@ -167,14 +167,76 @@ export class App {
     );
 
     // OXC strip must have been called with the jitTransform output (which
-    // still contains `readonly`) so Rolldown receives valid JS.
+    // still contains `readonly`) so Rolldown receives valid JS. We also
+    // pass the jitTransform map as `inMap` so OXC composes the strip map
+    // with it, keeping debug positions accurate.
     const oxcStripCall = mockTransformWithOxc.mock.calls.find(
       ([, callId]) => callId === '/src/app/app.ts',
     );
     expect(oxcStripCall).toBeDefined();
     expect(oxcStripCall![0]).toContain('readonly');
-    expect(oxcStripCall![2]).toMatchObject({ lang: 'ts' });
+    expect(oxcStripCall![2]).toMatchObject({ lang: 'ts', sourcemap: true });
+    expect(oxcStripCall![3]).toBeDefined(); // inMap from jitTransform
     expect(result.code).not.toContain('readonly');
+  });
+
+  it('JIT path falls back to esbuild when transformWithOxc is unavailable', async () => {
+    // Vite 6-8 compatibility: the same regression coverage as the OXC test
+    // above, but exercising the esbuild branch the plugin takes when
+    // `vite.transformWithOxc` is undefined (Vite 6 / pre-Rolldown).
+    mockTransformWithEsbuild.mockResolvedValue({
+      code: 'export class App { test = ""; }\n',
+      map: { mappings: '' },
+    });
+
+    const viteMod = await import('vite');
+    const realOxc = viteMod.transformWithOxc;
+    Object.defineProperty(viteMod, 'transformWithOxc', {
+      value: undefined,
+      configurable: true,
+    });
+    try {
+      const plugin = fastCompilePlugin({
+        tsconfigGetter: () => 'tsconfig.json',
+        workspaceRoot: '/workspace',
+        inlineStylesExtension: 'css',
+        jit: true,
+        liveReload: false,
+        supportedBrowsers: [],
+        isTest: true,
+        isAstroIntegration: false,
+      });
+      const handler = getTransformHandler(plugin);
+
+      const code = `import { Component } from '@angular/core';
+@Component({ selector: 'app-root', template: '<div></div>' })
+export class App {
+  readonly test = '';
+}
+`;
+      const result = await handler.call(
+        { addWatchFile: () => undefined },
+        code,
+        '/src/app/app.ts',
+      );
+
+      const esbuildStripCall = mockTransformWithEsbuild.mock.calls.find(
+        ([, callId]) => callId === '/src/app/app.ts',
+      );
+      expect(esbuildStripCall).toBeDefined();
+      expect(esbuildStripCall![0]).toContain('readonly');
+      expect(esbuildStripCall![2]).toMatchObject({
+        loader: 'ts',
+        sourcemap: true,
+      });
+      expect(esbuildStripCall![3]).toBeDefined(); // inMap from jitTransform
+      expect(result.code).not.toContain('readonly');
+    } finally {
+      Object.defineProperty(viteMod, 'transformWithOxc', {
+        value: realOxc,
+        configurable: true,
+      });
+    }
   });
 
   it('does not run the bypass strip when the file has @Component', async () => {

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -298,17 +298,33 @@ export function fastCompilePlugin(
       // StackBlitz / WebContainer — and the production build pipeline
       // does not register it either — so the JIT path must self-strip
       // to stay safe across environments.
+      //
+      // Pass the jitTransform map as `inMap` so OXC/esbuild emit a map
+      // composed with the original `.ts` source — without this, debug
+      // stack traces and breakpoints land on the wrong lines once the
+      // strip removes any TS-only token. `jitTransform` returns
+      // `map: null` for files with no Angular class (no edits made);
+      // passing that to OXC/esbuild as `inMap` throws, so coerce to
+      // `undefined` in that case.
+      const inMap = result.map ?? undefined;
       const stripped = vite.transformWithOxc
-        ? await vite.transformWithOxc(result.code, id, {
-            lang: 'ts',
-            sourcemap: false,
-            decorator: { legacy: false, emitDecoratorMetadata: false },
-          })
-        : await vite.transformWithEsbuild(result.code, id, {
-            loader: 'ts',
-            sourcemap: false,
-          });
-      return { code: stripped.code, map: result.map };
+        ? await vite.transformWithOxc(
+            result.code,
+            id,
+            {
+              lang: 'ts',
+              sourcemap: true,
+              decorator: { legacy: false, emitDecoratorMetadata: false },
+            },
+            inMap,
+          )
+        : await vite.transformWithEsbuild(
+            result.code,
+            id,
+            { loader: 'ts', sourcemap: true },
+            inMap,
+          );
+      return { code: stripped.code, map: stripped.map };
     }
 
     // Inline external templateUrl/styleUrl(s) into the source before compilation


### PR DESCRIPTION
## PR Checklist

Follow-up to [#2340](https://github.com/analogjs/analog/pull/2340) addressing CodeRabbit review findings.

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: —

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Two fixes flagged by CodeRabbit on [#2340](https://github.com/analogjs/analog/pull/2340):

1. **Composed sourcemap (major).** The JIT strip used to return `result.map` (the jitTransform map) alongside `stripped.code` — after the first TS-only token was removed, the mappings were shifted and debug positions pointed at the wrong source lines. The strip now passes `result.map` as `inMap` to `transformWithOxc` / `transformWithEsbuild` with `sourcemap: true`, and returns the composed `stripped.map`. `result.map === null` (no Angular class in the file) is coerced to `undefined` so the inMap argument doesn't crash OXC's transform.

2. **Esbuild fallback coverage (minor).** Added a matching regression test that forces `transformWithOxc` undefined to exercise the Vite 6 / pre-Rolldown esbuild branch — the original test only covered OXC, so a break in the esbuild fallback could have slipped through.

## Test plan

- [x] `pnpm nx test vite-plugin-angular` (1101 passed, +1 new test)
- [x] `pnpm nx test analog-app` with a `readonly` field on a component (verified locally)
- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The original PR [#2340](https://github.com/analogjs/analog/pull/2340) (already merged at `44e6334cd`) fixed the parse failure. This follow-up makes the sourcemap correct and broadens the regression coverage to both transform backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)