### PR TITLE
fix(vite-plugin-angular): signal-API parity in fast-compile JIT transform

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/jit-metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-metadata.ts
@@ -185,15 +185,28 @@ export function buildPropDecorators(
 
       if (api === 'input') {
         if (!props[memberName]) props[memberName] = [];
-        // Preserve all original options from the input() call and overlay isSignal/required
+        // Preserve original options from the input() call and overlay
+        // isSignal/required. `transform` is dropped: the input signal
+        // already applies it internally, so forwarding it to the
+        // decorator would make Angular's runtime JIT wrap it a second
+        // time via the directive metadata's transformFunction slot.
+        // Shorthand props ({alias}) are skipped — the identifier
+        // wouldn't be in scope when the propDecorators block runs at
+        // class top level.
         const optArg = required ? args[0] : args[1];
         const optParts: string[] = [];
         if (optArg?.type === 'ObjectExpression') {
           for (const p of optArg.properties || []) {
             if (p.type !== 'ObjectProperty' && p.type !== 'Property') continue;
+            if (p.shorthand) continue;
             const pKey = p.key?.name || p.key?.value;
-            // Skip isSignal/required — we override them below
-            if (pKey === 'isSignal' || pKey === 'required') continue;
+            if (
+              pKey === 'isSignal' ||
+              pKey === 'required' ||
+              pKey === 'transform'
+            ) {
+              continue;
+            }
             optParts.push(sourceCode.slice(p.start, p.end));
           }
         }

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-metadata.ts
@@ -234,27 +234,14 @@ export function buildPropDecorators(
         );
       } else if (api === 'output' || api === 'outputFromObservable') {
         if (!props[memberName]) props[memberName] = [];
-        // Extract alias
-        let alias: string | null = null;
-        const optArg = args[0];
-        if (optArg?.type === 'ObjectExpression') {
-          for (const p of optArg.properties || []) {
-            if (
-              (p.type === 'ObjectProperty' || p.type === 'Property') &&
-              (p.key?.name || p.key?.value) === 'alias'
-            ) {
-              if (
-                p.value?.type === 'StringLiteral' ||
-                (p.value?.type === 'Literal' &&
-                  typeof p.value.value === 'string')
-              ) {
-                alias = p.value.value;
-              }
-            }
-          }
-        }
-        if (alias) {
-          props[memberName].push(`{type: Output, args: ['${alias}']}`);
+        // outputFromObservable(observable, options) — options is args[1].
+        // output(options) — options is args[0].
+        const optArg = api === 'outputFromObservable' ? args[1] : args[0];
+        const alias = extractAlias(optArg);
+        if (alias !== null) {
+          props[memberName].push(
+            `{type: Output, args: ['${escapeStringLiteral(alias)}']}`,
+          );
         } else {
           props[memberName].push(`{type: Output}`);
         }

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-metadata.ts
@@ -29,6 +29,31 @@ function getCallApi(call: any): { api: string; required: boolean } | null {
 }
 
 /**
+ * Read a string-literal `alias` value out of an OXC ObjectExpression.
+ * Returns null when the arg isn't an object literal, has no alias, or
+ * the alias value isn't a static string. Shorthand `{alias}` is skipped
+ * because the identifier wouldn't be in scope when the propDecorators
+ * static block is evaluated at class top level.
+ */
+function extractAlias(optArg: any): string | null {
+  if (!optArg || optArg.type !== 'ObjectExpression') return null;
+  for (const p of optArg.properties || []) {
+    if (p.type !== 'ObjectProperty' && p.type !== 'Property') continue;
+    if (p.shorthand) continue;
+    const pKey = p.key?.name || p.key?.value;
+    if (pKey !== 'alias') continue;
+    const v = p.value;
+    if (v?.type === 'StringLiteral') return v.value;
+    if (v?.type === 'Literal' && typeof v.value === 'string') return v.value;
+  }
+  return null;
+}
+
+function escapeStringLiteral(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+/**
  * Build ctorParameters for constructor DI in JIT format:
  * [{ type: ServiceA }, { type: ServiceB, decorators: [{type: Optional}] }]
  *
@@ -177,12 +202,23 @@ export function buildPropDecorators(
           `{type: Input, args: [{${optParts.join(', ')}}]}`,
         );
       } else if (api === 'model') {
+        // Both Input and Output must live on the SAME propDecorators key
+        // (the class field name). Angular's JIT facade indexes outputs by
+        // classPropertyName and reads `instance[classPropertyName]` for
+        // the EventEmitter — for a model that's the signal itself, which
+        // exposes the emitter via [SIGNAL]. Splitting Output onto a
+        // synthetic `<name>Change` key would point at a field that does
+        // not exist on the class, breaking two-way bindings.
         if (!props[memberName]) props[memberName] = [];
-        props[memberName].push(`{type: Input, args: [{isSignal: true}]}`);
-        // Model also generates a Change output
-        const changeName = memberName + 'Change';
-        if (!props[changeName]) props[changeName] = [];
-        props[changeName].push(`{type: Output, args: ['${changeName}']}`);
+        const optArg = required ? args[0] : args[1];
+        const alias = extractAlias(optArg);
+        const bindingName = alias ?? memberName;
+        props[memberName].push(
+          `{type: Input, args: [{isSignal: true, alias: '${escapeStringLiteral(bindingName)}', required: ${required}}]}`,
+        );
+        props[memberName].push(
+          `{type: Output, args: ['${escapeStringLiteral(bindingName + 'Change')}']}`,
+        );
       } else if (api === 'output' || api === 'outputFromObservable') {
         if (!props[memberName]) props[memberName] = [];
         // Extract alias

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-metadata.ts
@@ -154,6 +154,7 @@ export function buildPropDecorators(
     if (!memberName) continue;
 
     // Check for field decorators (@Input, @Output, @ViewChild, etc.)
+    const explicitDecoratorNames = new Set<string>();
     const decorators: any[] = member.decorators || [];
     for (const dec of decorators) {
       const expr = dec.expression;
@@ -161,6 +162,7 @@ export function buildPropDecorators(
       const decName: string | undefined = expr.callee?.name;
       if (!decName || !FIELD_DECORATORS.has(decName)) continue;
 
+      explicitDecoratorNames.add(decName);
       if (!props[memberName]) props[memberName] = [];
       const args: any[] = expr.arguments || [];
       if (args.length > 0) {
@@ -172,7 +174,10 @@ export function buildPropDecorators(
       }
     }
 
-    // Signal API downleveling
+    // Signal API downleveling. Skip when a matching explicit decorator
+    // is already on the field — Angular's transform bails in that case
+    // (input_function.ts, model_function.ts, output_function.ts,
+    // query_functions.ts) to avoid duplicate metadata entries.
     if (
       member.type === 'PropertyDefinition' &&
       member.value?.type === 'CallExpression'
@@ -182,6 +187,29 @@ export function buildPropDecorators(
 
       const { api, required } = signalCall;
       const args: any[] = member.value.arguments || [];
+
+      const hasInput = explicitDecoratorNames.has('Input');
+      const hasOutput = explicitDecoratorNames.has('Output');
+      const hasQuery =
+        explicitDecoratorNames.has('ViewChild') ||
+        explicitDecoratorNames.has('ViewChildren') ||
+        explicitDecoratorNames.has('ContentChild') ||
+        explicitDecoratorNames.has('ContentChildren');
+
+      if (api === 'input' && hasInput) continue;
+      if (api === 'model' && (hasInput || hasOutput)) continue;
+      if ((api === 'output' || api === 'outputFromObservable') && hasOutput) {
+        continue;
+      }
+      if (
+        (api === 'viewChild' ||
+          api === 'viewChildren' ||
+          api === 'contentChild' ||
+          api === 'contentChildren') &&
+        hasQuery
+      ) {
+        continue;
+      }
 
       if (api === 'input') {
         if (!props[memberName]) props[memberName] = [];

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-metadata.ts
@@ -209,26 +209,38 @@ export function buildPropDecorators(
         } else {
           props[memberName].push(`{type: Output}`);
         }
-      } else if (api === 'viewChild' || api === 'viewChildren') {
-        if (!props[memberName]) props[memberName] = [];
-        const queryType = api === 'viewChildren' ? 'ViewChildren' : 'ViewChild';
-        if (args.length > 0) {
-          props[memberName].push(
-            `{type: ${queryType}, args: [${sourceCode.slice(args[0].start, args[0].end)}]}`,
-          );
-        } else {
-          props[memberName].push(`{type: ${queryType}}`);
-        }
-      } else if (api === 'contentChild' || api === 'contentChildren') {
+      } else if (
+        api === 'viewChild' ||
+        api === 'viewChildren' ||
+        api === 'contentChild' ||
+        api === 'contentChildren'
+      ) {
         if (!props[memberName]) props[memberName] = [];
         const queryType =
-          api === 'contentChildren' ? 'ContentChildren' : 'ContentChild';
+          api === 'viewChildren'
+            ? 'ViewChildren'
+            : api === 'viewChild'
+              ? 'ViewChild'
+              : api === 'contentChildren'
+                ? 'ContentChildren'
+                : 'ContentChild';
+        // Signal queries need `isSignal: true` so the runtime JIT compiler
+        // wires them through the signal query infrastructure rather than
+        // treating them as plain @ViewChild/@ContentChild assignments.
+        // Mirrors Angular's own JIT transform in
+        // compiler-cli/.../initializer_api_transforms/query_functions.ts.
         if (args.length > 0) {
+          const opts =
+            args.length > 1
+              ? `{...${sourceCode.slice(args[1].start, args[1].end)}, isSignal: true}`
+              : `{isSignal: true}`;
           props[memberName].push(
-            `{type: ${queryType}, args: [${sourceCode.slice(args[0].start, args[0].end)}]}`,
+            `{type: ${queryType}, args: [${sourceCode.slice(args[0].start, args[0].end)}, ${opts}]}`,
           );
         } else {
-          props[memberName].push(`{type: ${queryType}}`);
+          props[memberName].push(
+            `{type: ${queryType}, args: [undefined, {isSignal: true}]}`,
+          );
         }
       }
     }

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-parity.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-parity.spec.ts
@@ -1,0 +1,469 @@
+/**
+ * Differential parity tests. The propDecorators object emitted by
+ * Analog's JIT transform is normalized and compared against a reference
+ * oracle derived from Angular's upstream initializer-API transforms at
+ * `@angular/compiler-cli/.../jit/src/initializer_api_transforms/`.
+ *
+ * Why evaluate instead of string-diff? The emit shape differs (Analog
+ * writes static class fields; Angular writes `__decorate` calls), so
+ * the comparable surface is what `ReflectionCapabilities.propMetadata`
+ * sees at runtime.
+ */
+import { describe, it, expect } from 'vitest';
+import { jitTransform } from './jit-transform.js';
+
+type Annotation = { ngMetadataName: string; args: unknown[] };
+type PropMeta = Record<string, Annotation[]>;
+
+/** Make each Angular decorator capture its args verbatim when invoked. */
+function decoratorStub(name: string): any {
+  const fn: any = (...args: unknown[]) => ({ ngMetadataName: name, args });
+  fn.ngMetadataName = name;
+  return fn;
+}
+
+/** Initializer API: returns a callable signal so class-field eval succeeds.
+ *  The returned value is irrelevant — we only inspect propDecorators. */
+function signalStub(): any {
+  const fn: any = () => () => undefined;
+  fn.required = () => () => undefined;
+  return fn;
+}
+
+const STUBS: Record<string, any> = {
+  Component: decoratorStub('Component'),
+  Directive: decoratorStub('Directive'),
+  Injectable: decoratorStub('Injectable'),
+  Pipe: decoratorStub('Pipe'),
+  NgModule: decoratorStub('NgModule'),
+  Input: decoratorStub('Input'),
+  Output: decoratorStub('Output'),
+  ViewChild: decoratorStub('ViewChild'),
+  ViewChildren: decoratorStub('ViewChildren'),
+  ContentChild: decoratorStub('ContentChild'),
+  ContentChildren: decoratorStub('ContentChildren'),
+  HostBinding: decoratorStub('HostBinding'),
+  HostListener: decoratorStub('HostListener'),
+  ElementRef: class ElementRef {},
+  EventEmitter: class EventEmitter {},
+  input: signalStub(),
+  model: signalStub(),
+  output: () => ({}),
+  outputFromObservable: () => ({}),
+  viewChild: signalStub(),
+  viewChildren: () => () => [],
+  contentChild: signalStub(),
+  contentChildren: () => () => [],
+  numberAttribute: (v: unknown) => Number(v),
+  booleanAttribute: (v: unknown) => v != null && v !== 'false',
+  // The JIT-compile entry points the transform appends after each
+  // class. No-op stubs so eval doesn't crash.
+  ɵcompileComponent: () => undefined,
+  ɵcompileDirective: () => undefined,
+  ɵcompilePipe: () => undefined,
+  ɵcompileNgModule: () => undefined,
+};
+
+/** Rewrite `import { ... } from '@angular/core'` into a destructure from
+ *  the stubs argument. Handles `as` renames. Drops all other imports.
+ *  Also strips `export` so the body is valid inside `new Function`. */
+function rewriteImports(code: string): string {
+  return code
+    .replace(
+      /import\s+\{([^}]+)\}\s+from\s+['"]@angular\/core['"];?/g,
+      (_, specs: string) => {
+        const destructured = specs
+          .split(',')
+          .map((s) => {
+            const m = s.trim().match(/^(\S+)(?:\s+as\s+(\S+))?$/);
+            if (!m) return '';
+            const [, imported, local] = m;
+            return local ? `${imported}: ${local}` : imported;
+          })
+          .filter(Boolean)
+          .join(', ');
+        return `const { ${destructured} } = __stubs__;`;
+      },
+    )
+    .replace(/^\s*import\b[^\n]*\n/gm, '')
+    .replace(/^\s*export\s+(?=(class|const|let|var|function))/gm, '');
+}
+
+/** Find the first top-level class name in the emitted JS. */
+function firstClassName(code: string): string {
+  const m = code.match(/(?:export\s+)?class\s+(\w+)/);
+  if (!m) throw new Error('parity harness: no class declaration found');
+  return m[1];
+}
+
+/** Normalize the emitted `propDecorators` from `{type: <stub>, args: [...]}`
+ *  shape to the `{ngMetadataName, args}` shape produced by Angular's
+ *  `__decorate` runtime so deep-equal works against the oracle. */
+function normalize(propDecs: any): PropMeta {
+  const out: PropMeta = {};
+  if (!propDecs) return out;
+  for (const [field, entries] of Object.entries(propDecs)) {
+    out[field] = (entries as any[]).map((e) => ({
+      ngMetadataName: e.type?.ngMetadataName ?? String(e.type),
+      args: e.args ?? [],
+    }));
+  }
+  return out;
+}
+
+/**
+ * Run a source string through jitTransform, evaluate the result with
+ * stubs, and return the runtime-visible propDecorators object.
+ */
+function reflect(source: string): PropMeta {
+  // The fixtures below avoid TS-only syntax (no `: type` annotations,
+  // no `<T>` generics), so the jitTransform output is already valid JS
+  // once decorators are stripped — no TS-to-JS pass needed.
+  const emitted = jitTransform(source, 'fixture.ts').code;
+  const rewritten = rewriteImports(emitted);
+  const className = firstClassName(rewritten);
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const fn = new Function('__stubs__', `${rewritten}\nreturn ${className};`);
+  const Cls = fn(STUBS);
+  return normalize(Cls.propDecorators);
+}
+
+/**
+ * Reference oracle. Each entry mirrors the corresponding upstream
+ * transform's emit shape. Pinned to file references so divergences
+ * (e.g. when Angular changes its emit) are easy to spot in review.
+ */
+const ref = {
+  // Mirrors compiler-cli/.../initializer_api_transforms/input_function.ts
+  // (spec: initializer_api_transforms_spec.ts lines 113-117, 270-273).
+  // Note: Angular's transform always emits an explicit `alias` (defaulting
+  // to the class field name) and `transform: undefined`. Analog emits the
+  // minimal object — alias only when user-supplied, no transform key at
+  // all. Both shapes are runtime-equivalent: jit_compiler_facade.ts:524
+  // falls back to `ann.alias || field`, and absent vs undefined transform
+  // are treated identically at line 531. The oracle below reflects what
+  // the runtime actually needs, which is what Analog emits.
+  input(
+    field: string,
+    opts: { alias?: string; required?: boolean } = {},
+  ): PropMeta {
+    const args: Record<string, unknown> = {
+      isSignal: true,
+      required: !!opts.required,
+    };
+    if (opts.alias !== undefined) args.alias = opts.alias;
+    return {
+      [field]: [
+        {
+          ngMetadataName: 'Input',
+          args: [args],
+        },
+      ],
+    };
+  },
+
+  // Mirrors compiler-cli/.../initializer_api_transforms/model_function.ts
+  // (spec lines 378-403).
+  model(
+    field: string,
+    opts: { alias?: string; required?: boolean } = {},
+  ): PropMeta {
+    const binding = opts.alias ?? field;
+    return {
+      [field]: [
+        {
+          ngMetadataName: 'Input',
+          args: [{ isSignal: true, alias: binding, required: !!opts.required }],
+        },
+        { ngMetadataName: 'Output', args: [binding + 'Change'] },
+      ],
+    };
+  },
+
+  // Mirrors compiler-cli/.../initializer_api_transforms/output_function.ts.
+  // Note: Angular emits the resolved bindingPropertyName as a string
+  // positional arg even when no alias is given. Analog relies on the
+  // runtime fallback (jit_compiler_facade.ts:534 — `ann.alias || field`)
+  // and emits no arg in the no-alias case. Both are runtime-equivalent;
+  // the harness handles this asymmetry below via `expectOutput`.
+  output(field: string, opts: { alias?: string } = {}): PropMeta {
+    return {
+      [field]: [
+        {
+          ngMetadataName: 'Output',
+          args: opts.alias ? [opts.alias] : [],
+        },
+      ],
+    };
+  },
+
+  // Mirrors compiler-cli/.../initializer_api_transforms/query_functions.ts.
+  query(
+    kind: 'ViewChild' | 'ViewChildren' | 'ContentChild' | 'ContentChildren',
+    field: string,
+    predicate: unknown,
+    opts: object = {},
+  ): PropMeta {
+    return {
+      [field]: [
+        {
+          ngMetadataName: kind,
+          args: [predicate, { ...opts, isSignal: true }],
+        },
+      ],
+    };
+  },
+};
+
+/** Relaxed assertion for outputs without an alias — accept either the
+ *  empty-args (Analog) or property-name-as-arg (Angular) form. */
+function expectOutputNoAlias(meta: PropMeta, field: string) {
+  expect(meta[field]).toHaveLength(1);
+  expect(meta[field][0].ngMetadataName).toBe('Output');
+  const arg0 = meta[field][0].args[0];
+  expect(arg0 === undefined || arg0 === field).toBe(true);
+}
+
+describe('JIT propDecorators parity with Angular reference', () => {
+  describe('input()', () => {
+    it('plain input()', () => {
+      const meta = reflect(`
+        import { Component, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { name = input(); }
+      `);
+      expect(meta).toEqual(ref.input('name'));
+    });
+
+    it('input.required()', () => {
+      const meta = reflect(`
+        import { Component, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { id = input.required(); }
+      `);
+      expect(meta).toEqual(ref.input('id', { required: true }));
+    });
+
+    it('input() with alias', () => {
+      const meta = reflect(`
+        import { Component, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { id = input(0, { alias: 'publicId' }); }
+      `);
+      expect(meta).toEqual(ref.input('id', { alias: 'publicId' }));
+    });
+
+    it('input.required() with alias', () => {
+      const meta = reflect(`
+        import { Component, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { id = input.required({ alias: 'publicId' }); }
+      `);
+      expect(meta).toEqual(
+        ref.input('id', { alias: 'publicId', required: true }),
+      );
+    });
+
+    // Would have caught: input transform double-application.
+    it('drops transform from the decorator config', () => {
+      const meta = reflect(`
+        import { Component, input, numberAttribute } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { size = input(0, { transform: numberAttribute }); }
+      `);
+      const opts = meta.size[0].args[0] as Record<string, unknown>;
+      expect(opts.transform).toBeUndefined();
+      expect(opts.isSignal).toBe(true);
+      expect(opts.required).toBe(false);
+    });
+
+    it('drops transform from input.required() config', () => {
+      const meta = reflect(`
+        import { Component, input, booleanAttribute } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { open = input.required({ transform: booleanAttribute }); }
+      `);
+      const opts = meta.open[0].args[0] as Record<string, unknown>;
+      expect(opts.transform).toBeUndefined();
+      expect(opts.required).toBe(true);
+    });
+  });
+
+  describe('model()', () => {
+    // Would have caught: Output on the wrong field key.
+    it('places Input and Output on the same field', () => {
+      const meta = reflect(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model(0); }
+      `);
+      expect(meta).toEqual(ref.model('value'));
+      expect(meta.valueChange).toBeUndefined();
+    });
+
+    // Would have caught: model.required() silently non-required.
+    it('honors .required', () => {
+      const meta = reflect(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model.required(); }
+      `);
+      expect(meta).toEqual(ref.model('value', { required: true }));
+    });
+
+    // Would have caught: alias ignored, Change suffix on property name.
+    it('threads alias through Input and Change output', () => {
+      const meta = reflect(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model(0, { alias: 'pub' }); }
+      `);
+      expect(meta).toEqual(ref.model('value', { alias: 'pub' }));
+    });
+
+    it('model.required() with alias', () => {
+      const meta = reflect(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model.required({ alias: 'pub' }); }
+      `);
+      expect(meta).toEqual(
+        ref.model('value', { alias: 'pub', required: true }),
+      );
+    });
+  });
+
+  describe('output() / outputFromObservable()', () => {
+    it('plain output() — no alias', () => {
+      const meta = reflect(`
+        import { Component, output } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { ready = output(); }
+      `);
+      expectOutputNoAlias(meta, 'ready');
+    });
+
+    it('output() with alias', () => {
+      const meta = reflect(`
+        import { Component, output } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { ready = output({ alias: 'readyPub' }); }
+      `);
+      expect(meta).toEqual(ref.output('ready', { alias: 'readyPub' }));
+    });
+
+    it('outputFromObservable — no alias', () => {
+      const meta = reflect(`
+        import { Component, outputFromObservable } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { ready = outputFromObservable(null); }
+      `);
+      expectOutputNoAlias(meta, 'ready');
+    });
+
+    // Would have caught: outputFromObservable reading wrong args index.
+    it('outputFromObservable threads alias from args[1]', () => {
+      const meta = reflect(`
+        import { Component, outputFromObservable } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X {
+          ready = outputFromObservable(null, { alias: 'readyPub' });
+        }
+      `);
+      expect(meta).toEqual(ref.output('ready', { alias: 'readyPub' }));
+    });
+  });
+
+  describe('queries', () => {
+    // Would have caught: missing isSignal (analogjs/analog#2344).
+    it('viewChild emits isSignal: true', () => {
+      const meta = reflect(`
+        import { Component, viewChild } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #r></div>' })
+        export class X { r = viewChild('r'); }
+      `);
+      expect(meta).toEqual(ref.query('ViewChild', 'r', 'r'));
+    });
+
+    it('viewChild.required emits isSignal: true', () => {
+      const meta = reflect(`
+        import { Component, viewChild } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #r></div>' })
+        export class X { r = viewChild.required('r'); }
+      `);
+      expect(meta).toEqual(ref.query('ViewChild', 'r', 'r'));
+    });
+
+    // Would have caught: dropped second positional argument.
+    it('viewChild preserves the read option alongside isSignal', () => {
+      const meta = reflect(`
+        import { Component, viewChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #r></div>' })
+        export class X { r = viewChild('r', { read: ElementRef }); }
+      `);
+      expect(meta).toEqual({
+        r: [
+          {
+            ngMetadataName: 'ViewChild',
+            args: ['r', { read: STUBS.ElementRef, isSignal: true }],
+          },
+        ],
+      });
+    });
+
+    it('viewChildren / contentChild / contentChildren all carry isSignal', () => {
+      const meta = reflect(`
+        import { Component, viewChildren, contentChild, contentChildren } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X {
+          vs = viewChildren('v');
+          c = contentChild('c');
+          cs = contentChildren('cs');
+        }
+      `);
+      expect(meta).toEqual({
+        ...ref.query('ViewChildren', 'vs', 'v'),
+        ...ref.query('ContentChild', 'c', 'c'),
+        ...ref.query('ContentChildren', 'cs', 'cs'),
+      });
+    });
+  });
+
+  describe('decorator + signal coexistence', () => {
+    // Would have caught: duplicate metadata entries.
+    it('@Input on a field with input() — only the explicit decorator', () => {
+      const meta = reflect(`
+        import { Component, Input, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { @Input() name = input(); }
+      `);
+      expect(meta.name).toHaveLength(1);
+      expect(meta.name[0].ngMetadataName).toBe('Input');
+      const arg0 = meta.name[0].args[0] as any;
+      expect(arg0?.isSignal).toBeUndefined();
+    });
+
+    it('@Input on a field with model() — only the explicit decorator, no synthetic Change', () => {
+      const meta = reflect(`
+        import { Component, Input, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { @Input() value = model(0); }
+      `);
+      expect(meta.value).toHaveLength(1);
+      expect(meta.value[0].ngMetadataName).toBe('Input');
+      expect(meta.valueChange).toBeUndefined();
+    });
+
+    it('@ViewChild on a field with viewChild() — only the explicit decorator', () => {
+      const meta = reflect(`
+        import { Component, ViewChild, viewChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #r></div>' })
+        export class X { @ViewChild('r') r = viewChild('r'); }
+      `);
+      expect(meta.r).toHaveLength(1);
+      expect(meta.r[0].ngMetadataName).toBe('ViewChild');
+      const arg1 = meta.r[0].args[1] as any;
+      expect(arg1?.isSignal).toBeUndefined();
+    });
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
@@ -383,6 +383,49 @@ describe('JIT Transform', () => {
       expect(result).toContain('type: ContentChildren');
       expect(result).toContain('isSignal: true');
     });
+
+    it('skips signal downleveling when @Input already decorates the field', () => {
+      const result = transform(`
+        import { Component, Input, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X {
+          @Input() name = input<string>();
+        }
+      `);
+
+      const propDecorators = result.slice(result.indexOf('X.propDecorators'));
+      // Only one Input entry — the explicit decorator wins.
+      expect(propDecorators.match(/type:\s*Input/g)?.length).toBe(1);
+      expect(propDecorators).not.toContain('isSignal: true');
+    });
+
+    it('skips model downleveling when @Input or @Output already decorates the field', () => {
+      const result = transform(`
+        import { Component, Input, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X {
+          @Input() value = model(0);
+        }
+      `);
+
+      const propDecorators = result.slice(result.indexOf('X.propDecorators'));
+      expect(propDecorators.match(/type:\s*Input/g)?.length).toBe(1);
+      expect(propDecorators).not.toContain('type: Output');
+    });
+
+    it('skips signal-query downleveling when @ViewChild already decorates the field', () => {
+      const result = transform(`
+        import { Component, ViewChild, viewChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #ref></div>' })
+        export class X {
+          @ViewChild('ref') ref = viewChild<ElementRef>('ref');
+        }
+      `);
+
+      const propDecorators = result.slice(result.indexOf('X.propDecorators'));
+      expect(propDecorators.match(/type:\s*ViewChild/g)?.length).toBe(1);
+      expect(propDecorators).not.toContain('isSignal: true');
+    });
   });
 
   describe('External Resources', () => {

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
@@ -247,6 +247,32 @@ describe('JIT Transform', () => {
 
       expect(result).toContain('X.propDecorators');
       expect(result).toContain('type: ViewChild');
+      // Signal queries must carry `isSignal: true` so the JIT compiler
+      // wires them through the signal query infrastructure (NG0951).
+      expect(result).toContain('isSignal: true');
+    });
+
+    it('downlevels viewChild.required() with isSignal so the signal resolves', () => {
+      const result = transform(`
+        import { Component, viewChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #ref></div>' })
+        export class X { trigger = viewChild.required<ElementRef>('ref'); }
+      `);
+
+      expect(result).toContain('type: ViewChild');
+      expect(result).toMatch(/args: \['ref', \{isSignal: true\}\]/);
+    });
+
+    it('downlevels viewChild() with read option, spreading existing options', () => {
+      const result = transform(`
+        import { Component, viewChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #ref></div>' })
+        export class X { ref = viewChild('ref', { read: ElementRef }); }
+      `);
+
+      expect(result).toContain('type: ViewChild');
+      expect(result).toContain('{ read: ElementRef }');
+      expect(result).toContain('isSignal: true');
     });
 
     it('downlevels contentChildren() to propDecorators', () => {
@@ -257,6 +283,7 @@ describe('JIT Transform', () => {
       `);
 
       expect(result).toContain('type: ContentChildren');
+      expect(result).toContain('isSignal: true');
     });
   });
 

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
@@ -307,7 +307,33 @@ describe('JIT Transform', () => {
         export class X { c = output({alias: 'cPublic'}); }
       `);
 
-      expect(result).toContain('cPublic');
+      expect(result).toContain(`'cPublic'`);
+    });
+
+    it('downlevels outputFromObservable() reading options from args[1]', () => {
+      const result = transform(`
+        import { Component, outputFromObservable } from '@angular/core';
+        import { of } from 'rxjs';
+        @Component({ selector: 'x', template: '' })
+        export class X {
+          ready = outputFromObservable(of(1), { alias: 'readyPublic' });
+        }
+      `);
+
+      const propDecorators = result.slice(result.indexOf('X.propDecorators'));
+      expect(propDecorators).toContain('type: Output');
+      expect(propDecorators).toContain(`'readyPublic'`);
+    });
+
+    it('escapes single quotes in output alias strings', () => {
+      const result = transform(`
+        import { Component, output } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { c = output({alias: "tricky'name"}); }
+      `);
+
+      const propDecorators = result.slice(result.indexOf('X.propDecorators'));
+      expect(propDecorators).toContain(`'tricky\\'name'`);
     });
 
     it('downlevels viewChild() to propDecorators', () => {

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
@@ -204,7 +204,7 @@ describe('JIT Transform', () => {
       expect(result).toContain('required: true');
     });
 
-    it('downlevels model() to Input + Output', () => {
+    it('downlevels model() to Input + Output on the same field', () => {
       const result = transform(`
         import { Component, model } from '@angular/core';
         @Component({ selector: 'x', template: '' })
@@ -214,7 +214,52 @@ describe('JIT Transform', () => {
       expect(result).toContain('X.propDecorators');
       expect(result).toContain('type: Input');
       expect(result).toContain('type: Output');
-      expect(result).toContain('valueChange');
+      // Both decorators must be under the class field name, not a synthetic
+      // `valueChange` key — the runtime reads `instance[field]` for the
+      // emitter on the model signal.
+      expect(result).toMatch(
+        /value:\s*\[[\s\S]*?type:\s*Input[\s\S]*?type:\s*Output/,
+      );
+      expect(result).toContain(`'valueChange'`);
+      expect(result).toContain(`alias: 'value'`);
+      expect(result).toContain('required: false');
+    });
+
+    it('downlevels model.required() with required: true', () => {
+      const result = transform(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model.required<number>(); }
+      `);
+
+      expect(result).toContain('type: Input');
+      expect(result).toContain('required: true');
+      expect(result).toContain(`'valueChange'`);
+    });
+
+    it('downlevels model() with alias on both Input and Change', () => {
+      const result = transform(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model('seed', { alias: 'publicName' }); }
+      `);
+
+      expect(result).toContain(`alias: 'publicName'`);
+      expect(result).toContain(`'publicNameChange'`);
+      // Should not leak the property name when an alias is given.
+      expect(result).not.toContain(`'valueChange'`);
+    });
+
+    it('downlevels model.required() with alias', () => {
+      const result = transform(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model.required<number>({ alias: 'publicName' }); }
+      `);
+
+      expect(result).toContain(`alias: 'publicName'`);
+      expect(result).toContain(`'publicNameChange'`);
+      expect(result).toContain('required: true');
     });
 
     it('downlevels output() to propDecorators', () => {

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
@@ -204,6 +204,33 @@ describe('JIT Transform', () => {
       expect(result).toContain('required: true');
     });
 
+    it('drops transform from input() metadata so it does not run twice', () => {
+      const result = transform(`
+        import { Component, input, numberAttribute } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { size = input(0, { transform: numberAttribute }); }
+      `);
+
+      // The signal already applies the transform; forwarding it to the
+      // @Input decorator would make Angular's runtime call it a second time.
+      const propDecorators = result.slice(result.indexOf('X.propDecorators'));
+      expect(propDecorators).not.toContain('transform');
+      expect(propDecorators).toContain('isSignal: true');
+      expect(propDecorators).toContain('required: false');
+    });
+
+    it('drops transform from input.required() metadata', () => {
+      const result = transform(`
+        import { Component, input, booleanAttribute } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { open = input.required({ transform: booleanAttribute }); }
+      `);
+
+      const propDecorators = result.slice(result.indexOf('X.propDecorators'));
+      expect(propDecorators).not.toContain('transform');
+      expect(propDecorators).toContain('required: true');
+    });
+
     it('downlevels model() to Input + Output on the same field', () => {
       const result = transform(`
         import { Component, model } from '@angular/core';


### PR DESCRIPTION
## PR Checklist

Reported in [FastCompile throws NG0951 for viewChild.required analogjs/analog#2344](https://github.com/analogjs/analog/issues/2344). The investigation surfaced four additional gaps in the fast-compile JIT downleveling path that share the same root cause (the existing tests assert string-substring patterns on emitted code rather than evaluating it), so the PR fixes the reported bug plus the rest and adds a differential parity harness so future divergences are caught structurally.

Closes [analogjs/analog#2344](https://github.com/analogjs/analog/issues/2344)

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [ ] Squash merge
- [x] Rebase merge
- [ ] Other

## Commit preservation note [optional]

The six commits are each focused on one specific gap or one piece of test infrastructure, with the parity harness landing last so it exercises the fixed transform rather than the buggy one. Each commit message stands on its own as a description of one bug and one fix. Rebase merge preserves that history for `git bisect` and future audits; happy to switch to squash if maintainers prefer.

## What is the new behavior?

Fast-compile's JIT downleveling now matches Angular's official initializer-API transform (`@angular/compiler-cli/src/ngtsc/transform/jit/src/initializer_api_transforms/`) for every signal API. The six commits, in order:

1. **`emit isSignal on jit signal-query decorators`** — fixes [analogjs/analog#2344](https://github.com/analogjs/analog/issues/2344). `viewChild`/`viewChildren`/`contentChild`/`contentChildren` now emit `{ ...userOpts, isSignal: true }` as the second decorator argument, so the runtime JIT compiler wires them through the signal-query infrastructure rather than treating them as plain `@ViewChild`/`@ContentChild` assignments. Also preserves the second positional options argument (`{ read: ElementRef }`, `{ descendants: true }`) which was being silently dropped.

2. **`preserve model() alias, required, and field`** — `model()` now parses its options, honors `.required`, and places both `@Input` and `@Output` under the same propDecorators key (the class field name) so Angular's runtime — which indexes outputs by `classPropertyName` and reads `instance[classPropertyName]` for the emitter — actually finds the model signal's `[SIGNAL]`-exposed emitter. The Change binding name derives from the alias when one is given.

3. **`drop transform from input() jit metadata`** — stops forwarding the user's `transform: fn` option to the `@Input` decorator config. The input signal already runs the transform internally; forwarding it caused Angular's runtime JIT facade to re-wrap it into the directive metadata's `transformFunction` slot, applying the transform twice. Most transforms are idempotent so this rarely surfaced as a visible bug.

4. **`read outputFromObservable options from args[1]`** — `outputFromObservable(stream, opts)`'s options live at `args[1]` because `args[0]` is the source observable. The transform was reading `args[0]` for both `output` and `outputFromObservable`, so aliases on `outputFromObservable(stream, { alias: 'foo' })` were silently dropped. Shared alias extraction now goes through a single helper that also handles shorthand-property skip and quote escaping.

5. **`skip signal downleveling when a matching decorator is on the field`** — when a field has both an explicit `@Input`/`@Output`/`@ViewChild` and a signal initializer, the signal-downleveling branch is now skipped. The explicit decorator wins, matching Angular's transform behavior (`input_function.ts:42-48`, `model_function.ts:31-37`, `output_function.ts:34-40`, `query_functions.ts:54-58`).

6. **`differential parity harness for jit signal-API downleveling`** — adds `jit-parity.spec.ts`. The earlier bugs all shared a root cause: existing JIT-emit tests assert `expect(result).toContain('isSignal: true')` and similar string-substring patterns, which passed even when the emit was structurally wrong (wrong field key, dropped argument, double-applied transform). The new harness:
   - runs source through `jitTransform`
   - evaluates the emitted JS in a sandbox with stubbed Angular decorator factories that capture their args
   - normalizes the resulting `X.propDecorators` to the `ReflectionCapabilities`-visible shape
   - deep-equals against a reference oracle whose entries are pinned to the upstream Angular transform files

Each gap fixed in this PR maps to a one-line `toEqual` assertion in the parity suite.

## Test plan

- [x] `nx format:check` — all touched files pass; repo-wide check fails only on pre-existing unformatted files inside `packages/**/dist/` (untracked build output).
- [x] `nx build vite-plugin-angular` — clean build, no type errors.
- [x] `nx test vite-plugin-angular` — **1134 passed | 23 skipped (1157 total)**. The five fix commits add 8 targeted tests across `jit-transform.spec.ts`; the harness commit adds 21 parity assertions across all signal APIs.
- [ ] Did not run full `pnpm build` or `pnpm test` — changes are scoped to `vite-plugin-angular` and the rest of the workspace doesn't depend on the touched files. Happy to run the full suite if maintainers prefer.
- [ ] Did not manually exercise the `#2344` repro in a live `TestBed` — the parity harness exercises the same metadata-shape `ReflectionCapabilities` reads at runtime, but a maintainer-side repro confirmation would be a useful additional signal.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`fastCompile` is opt-in (defaults to `false`), and every fix moves emitted metadata strictly toward Angular's official transform shape — code that worked before continues to work, code that was silently broken now functions correctly.

## Other information

The investigation behind this PR includes a write-up of why the bugs weren't caught earlier and a separate audit confirming the AOT path (`metadata.ts`) is unaffected — it emits `isSignal: true` correctly at lines 478, 503, 582 because that path goes through the real `@angular/compiler-cli`. The gaps were JIT-only.

## [optional] What gif best describes this PR or how it makes you feel?

A duck calmly swimming on the surface while its feet paddle furiously underneath the propDecorators block.
