### PR TITLE
fix(vite-plugin-angular): signal-API parity in fast-compile AOT transform

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/aot-parity.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/aot-parity.spec.ts
@@ -1,0 +1,452 @@
+/**
+ * Differential parity tests for the fast-compile AOT path.
+ *
+ * The metadata object Analog hands to `compilePartialCode` is
+ * compared against a reference oracle derived from Angular's upstream
+ * initializer-API transforms (`@angular/compiler-cli/src/ngtsc/annotations/
+ * directive/src/{input,model,output,query}_function.ts`).
+ *
+ * Partial mode is used (not full mode) because its `ɵɵngDeclareComponent`
+ * argument exposes `isRequired`, `transformFunction`, `publicName`, query
+ * descriptors, and the outputs map as structured object literals.
+ * Full-mode `ɵɵdefineComponent` packs inputs into positional arrays that
+ * lose `required` and `transformFunction` (Angular only carries those in
+ * `.d.ts` type metadata or the partial declaration), so partial mode is
+ * the only emit path where every gap fixed by this branch is observable.
+ */
+import { describe, it, expect } from 'vitest';
+import { compilePartialCode } from './test-helpers.js';
+
+type InputMeta = {
+  classPropertyName: string;
+  publicName: string;
+  isSignal: boolean;
+  isRequired: boolean;
+  transformFunction: unknown;
+};
+type QueryMeta = {
+  propertyName: string;
+  first: boolean;
+  predicate: unknown;
+  descendants: boolean;
+  read?: unknown;
+  isSignal?: boolean;
+  static?: boolean;
+  emitDistinctChangesOnly?: boolean;
+};
+type AotMeta = {
+  inputs: Record<string, InputMeta>;
+  outputs: Record<string, string>;
+  queries: QueryMeta[];
+  viewQueries: QueryMeta[];
+};
+
+/** Stub class identities referenced from test fixtures. The fixtures
+ *  use these as predicates or `read` values; the harness identity-checks
+ *  them against the captured metadata. */
+class ElementRefStub {}
+class TemplateRefStub {}
+
+const STUBS: Record<string, any> = {
+  // Stub symbols referenced from fixture sources
+  Component: () => () => undefined,
+  Directive: () => () => undefined,
+  ElementRef: ElementRefStub,
+  TemplateRef: TemplateRefStub,
+  EventEmitter: class EventEmitter {},
+  numberAttribute: (v: unknown) => Number(v),
+  booleanAttribute: (v: unknown) => v != null && v !== 'false',
+  // Signal API factories — return callables so `this.x = input()` succeeds
+  input: Object.assign(() => () => undefined, {
+    required: () => () => undefined,
+  }),
+  model: Object.assign(() => () => undefined, {
+    required: () => () => undefined,
+  }),
+  output: () => ({}),
+  outputFromObservable: () => ({}),
+  viewChild: Object.assign(() => () => undefined, {
+    required: () => () => undefined,
+  }),
+  viewChildren: () => () => [],
+  contentChild: Object.assign(() => () => undefined, {
+    required: () => () => undefined,
+  }),
+  contentChildren: () => () => [],
+  Input: () => () => undefined,
+  Output: () => () => undefined,
+  ViewChild: () => () => undefined,
+  ViewChildren: () => () => [],
+  ContentChild: () => () => undefined,
+  ContentChildren: () => () => [],
+};
+
+/** Build the `i0` namespace stub. ɵɵngDeclareComponent captures the
+ *  metadata; the other declarations are no-ops so eval doesn't crash. */
+function buildI0(captured: { meta?: any }) {
+  const noop = () => undefined;
+  return {
+    ɵɵngDeclareComponent: (m: any) => {
+      captured.meta = m;
+      return undefined;
+    },
+    ɵɵngDeclareDirective: (m: any) => {
+      captured.meta = m;
+      return undefined;
+    },
+    ɵɵngDeclareFactory: noop,
+    ɵɵngDeclareClassMetadata: noop,
+    ɵɵngDeclareInjectable: noop,
+    ɵɵngDeclareInjector: noop,
+    ɵɵngDeclareNgModule: noop,
+    ɵɵngDeclarePipe: noop,
+    ɵɵFactoryTarget: { Component: 0, Directive: 1, Pipe: 2, NgModule: 3 },
+  };
+}
+
+/** Rewrite imports so the eval sandbox sees stubbed @angular/core
+ *  symbols. Drops the `import * as i0` line (the eval scope binds `i0`
+ *  directly via destructure from __stubs__). */
+function rewriteImports(code: string): string {
+  return code
+    .replace(/import\s+\*\s+as\s+i0\s+from\s+['"]@angular\/core['"];?/g, '')
+    .replace(
+      /import\s+\{([^}]+)\}\s+from\s+['"]@angular\/core['"];?/g,
+      (_, specs: string) => {
+        const destructured = specs
+          .split(',')
+          .map((s) => {
+            const m = s.trim().match(/^(\S+)(?:\s+as\s+(\S+))?$/);
+            if (!m) return '';
+            const [, imported, local] = m;
+            return local ? `${imported}: ${local}` : imported;
+          })
+          .filter(Boolean)
+          .join(', ');
+        return `const { ${destructured} } = __stubs__;`;
+      },
+    )
+    .replace(/^\s*import\b[^\n]*\n/gm, '')
+    .replace(/^\s*export\s+(?=(class|const|let|var|function))/gm, '');
+}
+
+function firstClassName(code: string): string {
+  const m = code.match(/(?:export\s+)?class\s+(\w+)/);
+  if (!m) throw new Error('aot parity: no class declaration found');
+  return m[1];
+}
+
+/** Normalize captured metadata into the shape the oracle compares
+ *  against. Strips wrapper expression nodes the Angular compiler emits
+ *  around identifiers (`{forwardRef, expression}`), unwrapping to the
+ *  identity-bearing stub class so deep-equal works. */
+function normalize(meta: any): AotMeta {
+  const inputs: Record<string, InputMeta> = {};
+  for (const [k, v] of Object.entries(meta.inputs ?? {})) {
+    const vv = v as any;
+    inputs[k] = {
+      classPropertyName: vv.classPropertyName,
+      publicName: vv.publicName,
+      isSignal: !!vv.isSignal,
+      isRequired: !!vv.isRequired,
+      transformFunction: vv.transformFunction ?? null,
+    };
+  }
+  const outputs: Record<string, string> = { ...(meta.outputs ?? {}) };
+  const normQ = (q: any): QueryMeta => ({
+    propertyName: q.propertyName,
+    first: q.first,
+    predicate: q.predicate,
+    descendants: q.descendants,
+    read: q.read ?? null,
+    isSignal: !!q.isSignal,
+    static: !!q.static,
+    emitDistinctChangesOnly: !!q.emitDistinctChangesOnly,
+  });
+  return {
+    inputs,
+    outputs,
+    queries: (meta.queries ?? []).map(normQ),
+    viewQueries: (meta.viewQueries ?? []).map(normQ),
+  };
+}
+
+/**
+ * Run a source through compilePartialCode, evaluate the emitted module
+ * in a sandbox with stubbed Angular helpers, capture the metadata
+ * argument handed to ɵɵngDeclareComponent / ɵɵngDeclareDirective, and
+ * return the normalized AOT metadata shape.
+ */
+function reflectAot(source: string): AotMeta {
+  const code = compilePartialCode(source, 'fixture.ts');
+  const rewritten = rewriteImports(code);
+  const className = firstClassName(rewritten);
+  const captured: { meta?: any } = {};
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const fn = new Function(
+    '__stubs__',
+    'i0',
+    `${rewritten}\nreturn ${className};`,
+  );
+  fn(STUBS, buildI0(captured));
+  if (!captured.meta) {
+    throw new Error('aot parity: ɵɵngDeclareComponent was never called');
+  }
+  return normalize(captured.meta);
+}
+
+/**
+ * Reference oracle. Each entry mirrors what Analog's AOT path SHOULD
+ * hand to Angular for a given signal API. Pinned to upstream source
+ * via comments so divergences (Analog or Angular changing emit) are
+ * easy to spot in code review.
+ */
+const ref = {
+  // Mirrors annotations/directive/src/input_function.ts (compiler-cli).
+  input(
+    field: string,
+    opts: { alias?: string; required?: boolean } = {},
+  ): InputMeta {
+    return {
+      classPropertyName: field,
+      publicName: opts.alias ?? field,
+      isSignal: true,
+      isRequired: !!opts.required,
+      // The signal applies the user's transform internally; the
+      // directive metadata must always carry `null` here so the runtime
+      // doesn't re-apply it on every write.
+      transformFunction: null,
+    };
+  },
+
+  // Mirrors annotations/directive/src/model_function.ts (compiler-cli).
+  modelInput(
+    field: string,
+    opts: { alias?: string; required?: boolean } = {},
+  ): InputMeta {
+    return {
+      classPropertyName: field,
+      publicName: opts.alias ?? field,
+      isSignal: true,
+      isRequired: !!opts.required,
+      transformFunction: null,
+    };
+  },
+};
+
+describe('AOT partial-mode metadata parity with Angular reference', () => {
+  describe('input()', () => {
+    it('plain input()', () => {
+      const meta = reflectAot(`
+        import { Component, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { name = input(); }
+      `);
+      expect(meta.inputs).toEqual({ name: ref.input('name') });
+    });
+
+    it('input.required()', () => {
+      const meta = reflectAot(`
+        import { Component, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { id = input.required(); }
+      `);
+      expect(meta.inputs).toEqual({ id: ref.input('id', { required: true }) });
+    });
+
+    it('input() with alias', () => {
+      const meta = reflectAot(`
+        import { Component, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { id = input(0, { alias: 'publicId' }); }
+      `);
+      expect(meta.inputs).toEqual({
+        id: ref.input('id', { alias: 'publicId' }),
+      });
+    });
+
+    // Would have caught: AOT input transform double-application.
+    it('drops user transform from emitted transformFunction', () => {
+      const meta = reflectAot(`
+        import { Component, input, numberAttribute } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { size = input(0, { transform: numberAttribute }); }
+      `);
+      expect(meta.inputs.size.transformFunction).toBeNull();
+      expect(meta.inputs.size.isSignal).toBe(true);
+    });
+  });
+
+  describe('model()', () => {
+    it('plain model — Input on field, Output as <field>Change', () => {
+      const meta = reflectAot(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model(0); }
+      `);
+      expect(meta.inputs).toEqual({ value: ref.modelInput('value') });
+      expect(meta.outputs).toEqual({ value: 'valueChange' });
+    });
+
+    // Would have caught: AOT model.required dropping required.
+    it('model.required() emits isRequired: true', () => {
+      const meta = reflectAot(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model.required(); }
+      `);
+      expect(meta.inputs).toEqual({
+        value: ref.modelInput('value', { required: true }),
+      });
+      expect(meta.outputs).toEqual({ value: 'valueChange' });
+    });
+
+    it('model({alias}) threads alias through Input and Change output', () => {
+      const meta = reflectAot(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model(0, { alias: 'pub' }); }
+      `);
+      expect(meta.inputs).toEqual({
+        value: ref.modelInput('value', { alias: 'pub' }),
+      });
+      expect(meta.outputs).toEqual({ value: 'pubChange' });
+    });
+
+    it('model.required({alias}) — alias on both sides + required', () => {
+      const meta = reflectAot(`
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { value = model.required({ alias: 'pub' }); }
+      `);
+      expect(meta.inputs).toEqual({
+        value: ref.modelInput('value', { alias: 'pub', required: true }),
+      });
+      expect(meta.outputs).toEqual({ value: 'pubChange' });
+    });
+  });
+
+  describe('output() / outputFromObservable()', () => {
+    it('plain output()', () => {
+      const meta = reflectAot(`
+        import { Component, output } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { ready = output(); }
+      `);
+      expect(meta.outputs).toEqual({ ready: 'ready' });
+    });
+
+    it('output({alias})', () => {
+      const meta = reflectAot(`
+        import { Component, output } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { ready = output({ alias: 'readyPub' }); }
+      `);
+      expect(meta.outputs).toEqual({ ready: 'readyPub' });
+    });
+
+    // Would have caught: AOT outputFromObservable reading wrong args.
+    it('outputFromObservable({alias}) — options live in args[1]', () => {
+      const meta = reflectAot(`
+        import { Component, outputFromObservable } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { ready = outputFromObservable(null, { alias: 'readyPub' }); }
+      `);
+      expect(meta.outputs).toEqual({ ready: 'readyPub' });
+    });
+  });
+
+  describe('queries', () => {
+    it('viewChild emits isSignal and the predicate', () => {
+      const meta = reflectAot(`
+        import { Component, viewChild } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #r></div>' })
+        export class X { r = viewChild('r'); }
+      `);
+      expect(meta.viewQueries).toHaveLength(1);
+      expect(meta.viewQueries[0]).toMatchObject({
+        propertyName: 'r',
+        first: true,
+        isSignal: true,
+      });
+    });
+
+    it('viewChild.required emits isSignal — required-ness lives on the signal itself', () => {
+      const meta = reflectAot(`
+        import { Component, viewChild } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #r></div>' })
+        export class X { r = viewChild.required('r'); }
+      `);
+      expect(meta.viewQueries).toHaveLength(1);
+      expect(meta.viewQueries[0].isSignal).toBe(true);
+    });
+
+    it('viewChild preserves the `read` option', () => {
+      const meta = reflectAot(`
+        import { Component, viewChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #r></div>' })
+        export class X { r = viewChild('r', { read: ElementRef }); }
+      `);
+      expect(meta.viewQueries[0].read).toBe(ElementRefStub);
+    });
+
+    it('contentChildren defaults descendants to false; contentChild to true', () => {
+      // Angular's partial-mode emitter omits default-valued fields, so
+      // contentChildren shows up without `descendants` (defaulting to
+      // false at the runtime read side). Treat absent as the type's
+      // default.
+      const meta = reflectAot(`
+        import { Component, contentChild, contentChildren } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X {
+          one = contentChild('a');
+          many = contentChildren('b');
+        }
+      `);
+      expect(meta.queries).toHaveLength(2);
+      const byName = Object.fromEntries(
+        meta.queries.map((q) => [q.propertyName, q]),
+      );
+      expect(byName.one.descendants).toBe(true);
+      expect(byName.many.descendants ?? false).toBe(false);
+    });
+  });
+
+  describe('decorator + signal coexistence', () => {
+    // Would have caught: AOT duplicate query registration.
+    it('@ViewChild on a field with viewChild() — only one query entry', () => {
+      const meta = reflectAot(`
+        import { Component, ViewChild, viewChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #r></div>' })
+        export class X { @ViewChild('r') r = viewChild('r'); }
+      `);
+      expect(meta.viewQueries).toHaveLength(1);
+      // The explicit @ViewChild wins → no isSignal flag from the
+      // signal-derived path.
+      expect(meta.viewQueries[0].isSignal).toBe(false);
+    });
+
+    // Would have caught: AOT decorator metadata being silently overwritten.
+    it('@Input on a field with input() — only the decorator entry, not signal', () => {
+      const meta = reflectAot(`
+        import { Component, Input, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { @Input() name = input(); }
+      `);
+      // The decorator path produces a non-signal input descriptor.
+      expect(meta.inputs.name.isSignal).toBe(false);
+    });
+
+    it('@Input on a field with model() — Input wins, no synthetic Output', () => {
+      const meta = reflectAot(`
+        import { Component, Input, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { @Input() value = model(0); }
+      `);
+      expect(meta.inputs.value.isSignal).toBe(false);
+      // No model-derived Change output — the decorator path doesn't
+      // synthesize one, and the signal branch was skipped.
+      expect(meta.outputs).toEqual({});
+    });
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
@@ -255,6 +255,39 @@ describe('@Component', () => {
       expect(result).toContain('ɵɵlistener');
     });
 
+    it('honors alias on output()', () => {
+      const result = compile(
+        `
+        import { Component, output } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { ready = output({ alias: 'readyPub' }); }
+      `,
+        'output-alias.ts',
+      );
+
+      expectCompiles(result);
+      expect(result).toContain('ready: "readyPub"');
+    });
+
+    it('honors alias on outputFromObservable() — options live in args[1]', () => {
+      // Without selecting args[1] for outputFromObservable, the alias is
+      // silently dropped because args[0] is the source observable.
+      const result = compile(
+        `
+        import { Component, outputFromObservable } from '@angular/core';
+        import { of } from 'rxjs';
+        @Component({ selector: 'x', template: '' })
+        export class X {
+          ready = outputFromObservable(of(1), { alias: 'readyPub' });
+        }
+      `,
+        'output-obs-alias.ts',
+      );
+
+      expectCompiles(result);
+      expect(result).toContain('ready: "readyPub"');
+    });
+
     it('detects model() and model.required()', () => {
       const result = compile(
         `

--- a/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
@@ -269,6 +269,49 @@ describe('@Component', () => {
       expect(result).toContain('ready: "readyPub"');
     });
 
+    it('skips signal-query synthesis when @ViewChild already decorates the field', () => {
+      // Without the skip, the same field is registered as both a
+      // decorator-derived query and a signal-derived query, so the
+      // template's viewQuery instructions fire twice for the same ref
+      // and `this.r` gets clobbered in registration order.
+      const result = compile(
+        `
+        import { Component, ViewChild, viewChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'x', template: '<div #r></div>' })
+        export class X {
+          @ViewChild('r') r = viewChild<ElementRef>('r');
+        }
+      `,
+        'view-coexist.ts',
+      );
+
+      expectCompiles(result);
+      // One ɵɵviewQuery call per registered query. Without the skip, the
+      // same field is registered twice and the call count doubles.
+      const queryCalls = (result.match(/ɵɵviewQuery/g) || []).length;
+      expect(queryCalls).toBe(1);
+    });
+
+    it('skips signal input synthesis when @Input already decorates the field', () => {
+      const result = compile(
+        `
+        import { Component, Input, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X {
+          @Input() name = input<string>();
+        }
+      `,
+        'input-coexist.ts',
+      );
+
+      expectCompiles(result);
+      // The explicit @Input wins → the input descriptor stays in the
+      // non-signal short form (just the public name string), not the
+      // signal-flag array.
+      expect(result).toMatch(/inputs:\s*\{[^}]*name:\s*"name"/);
+      expect(result).not.toMatch(/inputs:\s*\{[^}]*name:\s*\[/);
+    });
+
     it('honors alias on outputFromObservable() — options live in args[1]', () => {
       // Without selecting args[1] for outputFromObservable, the alias is
       // silently dropped because args[0] is the source observable.

--- a/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
@@ -1,6 +1,6 @@
 import * as o from '@angular/compiler';
 import { unwrapForwardRefOxc } from './utils.js';
-import { SIGNAL_APIS } from './constants.js';
+import { FIELD_DECORATORS, SIGNAL_APIS } from './constants.js';
 
 function getCallApi(call: any): { api: string; required: boolean } | null {
   const callee = call.callee;
@@ -446,6 +446,39 @@ export function detectSignals(classNode: any, sourceCode: string) {
 
     const { api, required } = signalCall;
     if (!SIGNAL_APIS.has(api)) continue;
+
+    // Skip signal synthesis when an explicit Angular decorator already
+    // covers the same field. Mirrors Angular's transform behavior
+    // (input_function.ts:42-48 et al.) and the JIT fix in
+    // jit-metadata.ts. Without this, the downstream merge in compile.ts
+    // overwrites decorator-derived metadata or, worse, concats duplicate
+    // query entries that fire twice.
+    const explicit = new Set<string>();
+    for (const dec of m.decorators || []) {
+      const decName: string | undefined = dec.expression?.callee?.name;
+      if (decName && FIELD_DECORATORS.has(decName)) explicit.add(decName);
+    }
+    const hasInput = explicit.has('Input');
+    const hasOutput = explicit.has('Output');
+    const hasQuery =
+      explicit.has('ViewChild') ||
+      explicit.has('ViewChildren') ||
+      explicit.has('ContentChild') ||
+      explicit.has('ContentChildren');
+    if (api === 'input' && hasInput) continue;
+    if (api === 'model' && (hasInput || hasOutput)) continue;
+    if ((api === 'output' || api === 'outputFromObservable') && hasOutput) {
+      continue;
+    }
+    if (
+      (api === 'viewChild' ||
+        api === 'viewChildren' ||
+        api === 'contentChild' ||
+        api === 'contentChildren') &&
+      hasQuery
+    ) {
+      continue;
+    }
 
     const args: any[] = m.value.arguments || [];
 

--- a/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
@@ -595,7 +595,10 @@ export function detectSignals(classNode: any, sourceCode: string) {
     // 4. STANDARD OUTPUTS (output() and outputFromObservable())
     else if (api === 'output' || api === 'outputFromObservable') {
       let alias = name;
-      const optArg = args[0];
+      // outputFromObservable(observable, options) — options is args[1].
+      // output(options) — options is args[0]. Mirrors upstream
+      // output_function.ts:81.
+      const optArg = api === 'outputFromObservable' ? args[1] : args[0];
       if (optArg?.type === 'ObjectExpression') {
         for (const prop of optArg.properties || []) {
           if (

--- a/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
@@ -451,17 +451,13 @@ export function detectSignals(classNode: any, sourceCode: string) {
 
     // 1. SIGNAL INPUTS (Standard & Required)
     if (api === 'input') {
-      let transform: any = null;
       let alias: string | null = null;
       const optionsArg = required ? args[0] : args[1];
       if (optionsArg?.type === 'ObjectExpression') {
         for (const prop of optionsArg.properties || []) {
           if (prop.type !== 'ObjectProperty' && prop.type !== 'Property')
             continue;
-          const k = propKeyName(prop);
-          if (k === 'transform') {
-            transform = new o.WrappedNodeExpr(prop.value);
-          } else if (k === 'alias') {
+          if (propKeyName(prop) === 'alias') {
             const sv = stringValue(prop.value);
             if (sv !== null) alias = sv;
           }
@@ -477,7 +473,13 @@ export function detectSignals(classNode: any, sourceCode: string) {
         bindingPropertyName: alias ?? name,
         isSignal: true,
         required,
-        transform,
+        // Always null for signal inputs. The input() factory already
+        // applies the user's transform internally; forwarding it to the
+        // directive metadata would make Angular's emitter set the
+        // HasDecoratorInputTransform flag, causing the transform to run
+        // again via the runtime input setter. Mirrors upstream
+        // input_function.ts:74.
+        transform: null,
       };
     }
 

--- a/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
@@ -501,6 +501,10 @@ export function detectSignals(classNode: any, sourceCode: string) {
         classPropertyName: name,
         bindingPropertyName: alias ?? name,
         isSignal: true,
+        // Propagate `.required` so the runtime enforces the unbound-required
+        // check. Without this, `model.required(...)` accepts an unbound parent
+        // and the model signal stays at its undefined initial value silently.
+        required,
       };
       // The compiled `outputs` field is `{ classPropertyName: bindingName }`.
       // Angular inverts this at runtime via

--- a/packages/vite-plugin-angular/src/lib/compiler/partial.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/partial.spec.ts
@@ -155,6 +155,46 @@ describe('Partial Compilation (Library Mode)', () => {
     });
   });
 
+  describe('signal API metadata', () => {
+    it('emits isRequired: true for input.required() and false for input()', () => {
+      const result = compilePartial(
+        `
+        import { Component, input } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X {
+          a = input<string>();
+          b = input.required<number>();
+        }
+      `,
+        'inputs.ts',
+      );
+
+      expect(result).toMatch(/a:\s*\{[^}]*isRequired:\s*false/);
+      expect(result).toMatch(/b:\s*\{[^}]*isRequired:\s*true/);
+    });
+
+    it('emits isRequired: true for model.required() and false for model()', () => {
+      // Without propagating required through the model branch, the
+      // template type-checker silently accepts unbound required models —
+      // the consumer only discovers the bug at runtime when the signal
+      // is first read.
+      const result = compilePartial(
+        `
+        import { Component, model } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X {
+          c = model<string>();
+          d = model.required<number>();
+        }
+      `,
+        'models.ts',
+      );
+
+      expect(result).toMatch(/c:\s*\{[^}]*isRequired:\s*false/);
+      expect(result).toMatch(/d:\s*\{[^}]*isRequired:\s*true/);
+    });
+  });
+
   describe('full mode unchanged', () => {
     it('still emits ɵɵdefineComponent in full mode', () => {
       // Verify that full mode (default) is unaffected

--- a/packages/vite-plugin-angular/src/lib/compiler/partial.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/partial.spec.ts
@@ -173,6 +173,25 @@ describe('Partial Compilation (Library Mode)', () => {
       expect(result).toMatch(/b:\s*\{[^}]*isRequired:\s*true/);
     });
 
+    it('emits transformFunction: null for input() — signal applies it internally', () => {
+      // Forwarding the user's transform to the directive metadata makes
+      // Angular's runtime apply it a second time on top of the signal's
+      // own internal application.
+      const result = compilePartial(
+        `
+        import { Component, input, numberAttribute } from '@angular/core';
+        @Component({ selector: 'x', template: '' })
+        export class X { size = input(0, { transform: numberAttribute }); }
+      `,
+        'transform.ts',
+      );
+
+      expect(result).toMatch(/size:\s*\{[^}]*transformFunction:\s*null/);
+      expect(result).not.toMatch(
+        /size:\s*\{[^}]*transformFunction:\s*numberAttribute/,
+      );
+    });
+
     it('emits isRequired: true for model.required() and false for model()', () => {
       // Without propagating required through the model branch, the
       // template type-checker silently accepts unbound required models —


### PR DESCRIPTION
## PR Checklist

Follow-up to [signal-API parity in fast-compile JIT transform analogjs/analog#2345](https://github.com/analogjs/analog/pull/2345). The post-merge audit on that PR identified four parallel gaps in the fast-compile AOT path (`metadata.ts` + `compile.ts`) plus the differential-test infrastructure missing from the AOT side. This PR closes them with the same per-gap commit structure and adds an AOT parity harness alongside the JIT one.

Closes #

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [ ] Squash merge
- [x] Rebase merge
- [ ] Other

## Commit preservation note [optional]

Five focused commits — four fixes plus the parity harness — each independently reviewable and bisectable. Same rationale as analogjs/analog#2345: each commit documents one specific gap and stands alone. Happy to switch to squash if maintainers prefer.

## What is the new behavior?

The fast-compile AOT path's `detectSignals` (in `packages/vite-plugin-angular/src/lib/compiler/metadata.ts`) and the downstream merge in `compile.ts` now match Angular's official initializer-API transforms (`@angular/compiler-cli/src/ngtsc/annotations/directive/src/{input,model,output,query}_function.ts`) for every signal API. The five commits, in order:

1. **`propagate required through aot model metadata`** — the model branch built the input descriptor with `{classPropertyName, bindingPropertyName, isSignal: true}` only, dropping the `required` flag returned by `getCallApi`. `compile.ts:684` then read `sigDesc.required || false` and registered `model.required()` as a non-required input.

   **Important nuance**: this is *less* severe than a naive reading of the audit would suggest. The model signal itself enforces required-ness at runtime — `model.required()` constructs a signal that throws on uninitialized read, so an unbound required model still throws *eventually*. The actual user-facing breakage is **template type-checker silence at compile time**: without `isRequired: true` in the partial-mode declaration metadata, the template type-checker doesn't flag parent templates that omit the binding, and the consumer only discovers the bug at runtime when the signal is first read. The fix restores the compile-time gate — which is what makes required inputs useful in the first place.

2. **`drop transform from aot input metadata`** — `detectSignals` captured the user's `transform: fn` as a `WrappedNodeExpr` and placed it on the input descriptor. `compile.ts` forwarded it as `transformFunction` on the `R3DirectiveMetadata`. Angular's emitter then set `HasDecoratorInputTransform` on the input flags and pushed the expression into the directive definition's input array, so the runtime input setter applied the transform a second time on every write — on top of the transform the input signal already runs internally. Idempotent transforms (`numberAttribute`, `booleanAttribute`) rarely surfaced this; user-defined transforms like `v => v + 1` produced wrong results on the second pass.

3. **`read outputFromObservable options from args[1] in aot`** — `detectSignals` read options from `args[0]` for both `output` and `outputFromObservable`. The first positional argument of `outputFromObservable` is the source observable, not the options object, so aliases on `outputFromObservable(stream, { alias: 'foo' })` silently vanished and the output registered under the class property name. Templates binding `(foo)="..."` silently failed to match.

4. **`skip aot signal synthesis when a matching decorator is on the field`** — `detectSignals` ran independently of `detectFieldDecorators` and `compile.ts` merged the two with last-wins for inputs/outputs (line 670-687) and *array-concat* for queries (line 721-722). When a field carried both an explicit `@Input`/`@Output`/`@ViewChild` and a signal initializer:
   - Inputs/outputs: the signal entry silently overwrote the decorator's `alias`/`required`/`transform`.
   - Queries: the same query was registered twice; the runtime collected both and clobbered `this.field` in registration order, and the template's `ɵɵviewQuery`/`ɵɵcontentQuery` instructions fired duplicated.

5. **`differential parity harness for aot signal-API metadata`** — companion to `jit-parity.spec.ts` introduced in analogjs/analog#2345. Catches the same five gap classes by capturing the `R3DirectiveMetadata` object Analog hands to Angular's compiler and deep-equaling against a reference oracle derived from the upstream initializer-API transforms.

   Partial mode is used (not full mode) because its `ɵɵngDeclareComponent` argument exposes `isRequired`, `transformFunction`, query descriptors, and the outputs map as structured object literals. Full-mode `ɵɵdefineComponent` packs inputs into positional arrays that lose `required` and `transformFunction` (Angular only carries those in `.d.ts` type metadata or the partial declaration), so partial mode is the only emit path where every AOT gap is observable.

   18 cases cover input/model/output/outputFromObservable/queries and decorator-coexistence — each AOT gap fixed earlier in the branch maps to a focused `toEqual` assertion.

## Test plan

- [x] `nx format:check` — all touched files pass; repo-wide check still fails only on pre-existing unformatted files inside `packages/**/dist/` (untracked build output).
- [x] `nx build vite-plugin-angular` — clean build, no type errors.
- [x] `nx test vite-plugin-angular` — **1152 passed | 23 skipped (1175 total)**. Each fix commit adds focused unit tests in `partial.spec.ts` (fixes 1 and 2) or `component.spec.ts` (fixes 3 and 4); the harness commit adds 18 differential parity assertions.
- [ ] Did not run full `pnpm build` or `pnpm test` — changes are scoped to `vite-plugin-angular`.
- [ ] Did not manually exercise a real Angular project with the AOT path through TestBed/devserver. The parity harness exercises the exact metadata object handed to `compilePartialCode`, which is what produces `.d.ts` declarations and what the template type-checker reads.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`fastCompile` is opt-in (defaults to `false`), and every fix moves the emitted AOT metadata strictly toward Angular's official transform shape. Code that worked before continues to work; code that was silently broken now functions correctly (or, in the `model.required` case, fails fast at template-typecheck time rather than late at runtime, which is the desired behavior).

## Other information

See the inline discussion on analogjs/analog#2345 for the post-merge audit that motivated this PR. With this branch landed, both fast-compile codepaths (JIT for tests, AOT for application/library builds) emit Angular-equivalent metadata for every signal initializer API, and both have differential parity harnesses preventing regression.

One ancillary finding from the audit that's **not** addressed by this PR: `metadata.ts:581` hardcodes `emitFlags: 0` on signal queries, but Angular's `R3QueryMetadata` reads `emitDistinctChangesOnly` from there and signal queries should default to `true` (matching upstream). This causes multi-result signal queries to re-emit on every change even when the result list hasn't changed — a minor performance issue, not a correctness bug. Tracked as a separate concern.

## [optional] What gif best describes this PR or how it makes you feel?

That cleaning-the-bathroom-corners-with-a-toothbrush gif where each tile gets the same systematic attention — except both bathrooms now have parity tests guarding the grout lines.
