### PR TITLE
docs(storybook-angular): document code coverage and the monorepo dependency pitfall

### DIFF
--- a/apps/docs-app/docs/integrations/storybook/index.md
+++ b/apps/docs-app/docs/integrations/storybook/index.md
@@ -491,3 +491,52 @@ npm run test-storybook
 ```
 
 You can also run tests directly in the Storybook UI. Start Storybook and use the "Run Tests" button in the sidebar, or navigate to a story to see interaction tests run automatically in the Interactions panel.
+
+## Code Coverage
+
+To collect coverage while running your stories, enable the V8 provider on the `storybook` test project:
+
+```ts
+test: {
+  name: 'storybook',
+  coverage: {
+    provider: 'v8',
+    include: ['src/**/*.ts'],
+  },
+  browser: {
+    enabled: true,
+    headless: true,
+    provider: playwright(),
+    instances: [{ browser: 'chromium' }],
+  },
+  setupFiles: ['.storybook/vitest.setup.ts'],
+},
+```
+
+### Monorepo configuration
+
+In a monorepo, a story often imports a shared library from another project through its package/barrel entry point (for example `@my-org/ui`). When coverage is configured to include those dependent-project sources, Vite pre-bundles the barrel and serves it from `node_modules/.vite/deps`. Browser-mode V8 coverage ignores any module served from `node_modules`, so the dependency is reported with **0 hits at its source path even though it executed** — and merging that report with your unit-test report double-counts the file and drags the overall percentage down.
+
+To collect real coverage for those dependencies, keep them out of Vite's dependency pre-bundling so they are served — and instrumented — from source. Add them to `optimizeDeps.exclude` in your `.storybook/main.ts` via `viteFinal`:
+
+```ts
+import { UserConfig, mergeConfig } from 'vite';
+
+import type { StorybookConfig } from '@analogjs/storybook-angular';
+
+const config: StorybookConfig = {
+  // ... other config, addons, etc.
+  async viteFinal(config: UserConfig) {
+    return mergeConfig(config, {
+      // serve workspace libraries from source so browser coverage can instrument them
+      optimizeDeps: {
+        exclude: ['@my-org/ui'],
+      },
+    });
+  },
+};
+
+export default config;
+```
+
+Alternatively, if you only want story-level coverage, scope `coverage.include` to the current project's files so dependent-project sources are not emitted as zero-hit records.


### PR DESCRIPTION
## PR Checklist

Closes #2349

Documents code coverage for Storybook + Vitest, including the monorepo pitfall where a workspace dependency imported through its package/barrel entry is reported with 0% coverage in browser V8 mode.

## Affected scope

- Primary scope: storybook-angular (docs)
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Adds a **Code Coverage** section to the Storybook integration guide:

- How to enable the V8 coverage provider for stories.
- A **Monorepo configuration** note: when a story imports a shared library through its package/barrel entry, Vite pre-bundles it and serves it from `node_modules/.vite/deps`. Browser-mode V8 coverage ignores any module served from `node_modules`, so the dependency is reported with **0 hits at its source path** even though it executed — and merging that with the unit-test report double-counts the file and lowers the overall percentage. Documents the `optimizeDeps.exclude` workaround (via `viteFinal` in `.storybook/main.ts`) that serves such dependencies from source so they are instrumented.

Documentation only — no runtime/code changes.

> Note: this PR originally also carried a sourcemap fix to strip Angular's AOT synthetic emit from coverage. It was dropped: that "phantom functions/branches" symptom only occurs under AOT test compilation (`jit: false`), while both Vitest unit tests and `@analogjs/storybook-angular` default to JIT, where the symptom does not occur. The remaining, real issue is the monorepo dependency configuration documented here.

## Test plan

- [x] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [x] Manual verification

Verified the documented `optimizeDeps.exclude` workaround end-to-end in `apps/analog-app` against the real `@analogjs/storybook-angular` + `@storybook/addon-vitest` V8 browser pipeline: a transitively-imported workspace dependency went from 0% to correct coverage once excluded from pre-bundling.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Docs only.
