### PR TITLE
fix(vite-plugin-angular): respect explicit declaration:false in lib-mode builds

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -924,7 +924,13 @@ export function angular(options?: PluginOptions): Plugin[] {
           tsCompilerOptions['supportJitMode'] = true;
         }
 
-        if (!isTest && config.build?.lib) {
+        // Respect an explicit `declaration: false` from the user's tsconfig so
+        // app builds going through Vite's library mode don't emit `.d.ts`. #2348
+        if (
+          !isTest &&
+          config.build?.lib &&
+          tsCompilerOptions['declaration'] !== false
+        ) {
           tsCompilerOptions['declaration'] = true;
           tsCompilerOptions['declarationMap'] = watchMode;
           tsCompilerOptions['inlineSources'] = true;
@@ -1038,8 +1044,10 @@ export function angular(options?: PluginOptions): Plugin[] {
         sourceMap: !isProd,
         inlineSourceMap: false,
         inlineSources: !isProd,
-        declaration: false,
-        declarationMap: false,
+        // Don't force-override `declaration`/`declarationMap` here — the
+        // user's tsconfig value is respected below so that app builds running
+        // through Vite's library mode (e.g. WXT entrypoints) can opt out of
+        // declaration emit. See #2348.
         allowEmptyCodegenFiles: false,
         annotationsAs: 'decorators',
         enableResourceInlining: false,
@@ -1071,10 +1079,21 @@ export function angular(options?: PluginOptions): Plugin[] {
       tsCompilerOptions['supportJitMode'] = true;
     }
 
-    if (!isTest && config.build?.lib) {
+    // Library builds emit `.d.ts` by default, but an explicit
+    // `declaration: false` in the user's tsconfig is respected — this prevents
+    // declaration emit for app builds that run through Vite's library mode
+    // (e.g. WXT extension entrypoints). Every other build never emits. #2348
+    if (
+      !isTest &&
+      config.build?.lib &&
+      tsCompilerOptions['declaration'] !== false
+    ) {
       tsCompilerOptions['declaration'] = true;
       tsCompilerOptions['declarationMap'] = watchMode;
       tsCompilerOptions['inlineSources'] = true;
+    } else {
+      tsCompilerOptions['declaration'] = false;
+      tsCompilerOptions['declarationMap'] = false;
     }
 
     if (isTest) {
@@ -1287,14 +1306,25 @@ export function angular(options?: PluginOptions): Plugin[] {
           if (
             !watchMode &&
             !isTest &&
+            config.build?.lib &&
             /\.d\.ts/.test(filename) &&
             !filename.includes('.ngtypecheck.')
           ) {
+            const relativeToRoot = relative(config.root, filename);
+
+            // Never write declarations for source files that live outside the
+            // project root (e.g. a path-mapped workspace library imported from
+            // the entrypoint). Their relative path would escape `outDir` and
+            // land back in the app source tree. See #2348.
+            if (relativeToRoot.startsWith('..') || isAbsolute(relativeToRoot)) {
+              return;
+            }
+
             // output to library root instead /src
             const declarationPath = resolve(
               config.root,
               config.build.outDir,
-              relative(config.root, filename),
+              relativeToRoot,
             ).replace('/src/', '/');
 
             const declarationFileDir = declarationPath


### PR DESCRIPTION
## PR Checklist

Closes #2348

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: —

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

`@analogjs/vite-plugin-angular` no longer writes generated `.d.ts` files into an app's source directory.

Vite's library mode (`build.lib`) is also used by application bundlers such as WXT for their `background.ts`/`content.ts` entrypoints (not by the popup, which is a normal HTML app build — matching the reported asymmetry). The plugin treated **any** `build.lib` build as an Angular library build and force-enabled declaration emit, overriding the user's `declaration: false`. For a path-mapped workspace library imported from such an entrypoint, the source file lives outside the project root, so its relative-to-root path (`../../libs/...`) escaped `outDir` and the declarations were written back into the app source tree (e.g. `apps/testbed/libs/testbed/util-protocol/index.d.ts`).

Changes:

1. **Respect the user's `declaration` setting.** Removed the hard `declaration: false` override in `readConfiguration` so the resolved tsconfig value flows through, and only auto-enable declarations for lib builds when the user hasn't explicitly set `declaration: false` (`config.build?.lib && tsCompilerOptions['declaration'] !== false`), in both the Angular Compilation API path and the legacy `builder.emit` path.
2. **Scope the declaration capture.** Skip any `.d.ts` whose source file lives outside the project root, so a path-mapped library's declarations can never be written back into the source tree.

No regression for conventional library builds: lib builds resolve `tsconfig.lib.json` (which sets `declaration: true` by convention), so they continue to emit. An unspecified `declaration` resolves to `undefined`, which still enables emit. The only behavior change is that an effective `declaration: false` is now respected instead of force-overridden — which is the fix.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

> Note: dependencies were not installed in my working checkout, so the suite has not been run locally yet — relying on CI / maintainer verification.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Root cause: `config.build.lib` was overloaded as the signal for "Angular library publish build," but it only means "Vite library bundle," which app bundlers legitimately use for sub-entrypoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)