### PR TITLE
fix(vite-plugin-angular): support build.lib + dedupe diagnostics on the Angular Compilation API path

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -15,6 +15,7 @@ vi.mock('vite', async () => {
 import {
   angular,
   createFsWatcherCacheInvalidator,
+  groupDiagnosticsByFile,
   mapTemplateUpdatesToFiles,
   toAngularCompilationFileReplacements,
   isTestWatchMode,
@@ -535,5 +536,103 @@ describe('mapTemplateUpdatesToFiles', () => {
       'BarComponent',
       'FooComponent',
     ]);
+  });
+});
+
+describe('groupDiagnosticsByFile', () => {
+  it('groups each diagnostic under its own file with file:line:column', () => {
+    const { errorsByFile, warningsByFile } = groupDiagnosticsByFile({
+      errors: [
+        {
+          text: 'TS2339: Property does not exist',
+          location: { file: '/src/app/a.component.ts', line: 5, column: 20 },
+        },
+      ],
+      warnings: [
+        {
+          text: 'NG8113: All imports are unused',
+          location: { file: '/src/app/b.component.ts', line: 3, column: 50 },
+        },
+      ],
+    });
+
+    expect(errorsByFile.get(normalizePath('/src/app/a.component.ts'))).toEqual([
+      '/src/app/a.component.ts:5:20: TS2339: Property does not exist',
+    ]);
+    expect(
+      warningsByFile.get(normalizePath('/src/app/b.component.ts')),
+    ).toEqual(['/src/app/b.component.ts:3:50: NG8113: All imports are unused']);
+  });
+
+  it('does not duplicate a diagnostic across files (one bucket per file)', () => {
+    const { warningsByFile } = groupDiagnosticsByFile({
+      warnings: [
+        {
+          text: 'NG8113: unused a',
+          location: { file: '/src/a.component.ts', line: 1, column: 0 },
+        },
+        {
+          text: 'NG8113: unused b',
+          location: { file: '/src/b.component.ts', line: 1, column: 0 },
+        },
+      ],
+    });
+
+    expect(warningsByFile.size).toBe(2);
+    expect(
+      [...warningsByFile.values()].every((bucket) => bucket.length === 1),
+    ).toBe(true);
+  });
+
+  it('accumulates multiple diagnostics for the same file', () => {
+    const { errorsByFile } = groupDiagnosticsByFile({
+      errors: [
+        {
+          text: 'TS1: first',
+          location: { file: '/src/a.component.ts', line: 1, column: 1 },
+        },
+        {
+          text: 'TS2: second',
+          location: { file: '/src/a.component.ts', line: 9, column: 4 },
+        },
+      ],
+    });
+
+    expect(errorsByFile.get(normalizePath('/src/a.component.ts'))).toEqual([
+      '/src/a.component.ts:1:1: TS1: first',
+      '/src/a.component.ts:9:4: TS2: second',
+    ]);
+  });
+
+  it('routes location-less diagnostics to the global buckets', () => {
+    const { errorsByFile, warningsByFile, globalErrors, globalWarnings } =
+      groupDiagnosticsByFile({
+        errors: [{ text: 'NG: program-wide error' }],
+        warnings: [{ text: 'NG: program-wide warning', location: null }],
+      });
+
+    expect(errorsByFile.size).toBe(0);
+    expect(warningsByFile.size).toBe(0);
+    expect(globalErrors).toEqual(['NG: program-wide error']);
+    expect(globalWarnings).toEqual(['NG: program-wide warning']);
+  });
+
+  it('defaults missing line/column to 0', () => {
+    const { errorsByFile } = groupDiagnosticsByFile({
+      errors: [{ text: 'TS1: msg', location: { file: '/src/a.ts' } }],
+    });
+
+    expect(errorsByFile.get(normalizePath('/src/a.ts'))).toEqual([
+      '/src/a.ts:0:0: TS1: msg',
+    ]);
+  });
+
+  it('returns empty structures for empty/undefined input', () => {
+    const result = groupDiagnosticsByFile({});
+
+    expect(result.errorsByFile.size).toBe(0);
+    expect(result.warningsByFile.size).toBe(0);
+    expect(result.globalErrors).toEqual([]);
+    expect(result.globalWarnings).toEqual([]);
   });
 });

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -131,6 +131,19 @@ interface DeclarationFile {
   data: string;
 }
 
+/**
+ * Subset of the esbuild-style `PartialMessage` that `@angular/build`'s
+ * `diagnoseFiles()` returns. Only the fields the plugin reads are modeled.
+ */
+export interface AngularDiagnostic {
+  text?: string;
+  location?: {
+    file?: string;
+    line?: number;
+    column?: number;
+  } | null;
+}
+
 export function angular(options?: PluginOptions): Plugin[] {
   /**
    * Normalize plugin options so defaults
@@ -924,10 +937,27 @@ export function angular(options?: PluginOptions): Plugin[] {
           tsCompilerOptions['supportJitMode'] = true;
         }
 
-        if (!isTest && config.build?.lib) {
-          tsCompilerOptions['declaration'] = true;
-          tsCompilerOptions['declarationMap'] = watchMode;
-          tsCompilerOptions['inlineSources'] = true;
+        // The Angular Compilation API path must NOT enable declaration emit for
+        // library builds. Unlike the legacy path, it has no mechanism to write
+        // `.d.ts` files to disk, and `@angular/build`'s `emitAffectedFiles()`
+        // keys outputs by source file (last-write-wins) — so a `.d.ts` would
+        // overwrite the `.js` content for the same source, feeding declaration
+        // text back to Vite as if it were the module source. Enabling
+        // `inlineSources` here is also invalid: this path forces `sourceMap`
+        // off, so an unpaired `inlineSources` trips TS5051. See #2324.
+
+        // Force whole-program TypeScript transpilation. `@angular/build`'s
+        // `emitAffectedFiles()` skips full TS emit when `isolatedModules` is on
+        // and no sourcemap is set, instead printing Angular-only transforms that
+        // leave TS type annotations in the output. Analog returns that emitted
+        // content to Vite/Rolldown as the module source, so the leftover types
+        // (e.g. `App_Factory(__ngFactoryType__: any)`) fail to parse. Disabling
+        // `isolatedModules` for emit makes TypeScript strip types, matching the
+        // legacy path. Currently-working builds are unaffected (they already
+        // have it off); only the otherwise-broken `isolatedModules: true` case
+        // changes. The user's editor/`tsc` still enforces it. See #2324.
+        if (!isTest) {
+          tsCompilerOptions['isolatedModules'] = false;
         }
 
         if (isTest) {
@@ -949,8 +979,16 @@ export function angular(options?: PluginOptions): Plugin[] {
         : DiagnosticModes.All,
     );
 
-    const errors = diagnostics.errors?.length ? diagnostics.errors : [];
-    const warnings = diagnostics.warnings?.length ? diagnostics.warnings : [];
+    // `diagnoseFiles()` returns whole-program diagnostics. Group them by the
+    // source file they point at so each is attached to its own emitted file and
+    // reported exactly once — on that file's transform — instead of duplicating
+    // the entire global list across every emitted file (an N×M explosion, e.g.
+    // 485 warnings × 85 files). `groupDiagnosticsByFile` also folds the
+    // `file:line:column` from `location` into each message, which was
+    // previously discarded. #2317
+    const { errorsByFile, warningsByFile, globalErrors, globalWarnings } =
+      groupDiagnosticsByFile(diagnostics);
+
     // Angular encodes template updates as `encodedFilePath@ClassName` keys.
     // `mapTemplateUpdatesToFiles` decodes them back to absolute file paths so
     // we can attach HMR metadata to the correct `EmitFileResult` below.
@@ -958,6 +996,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       compilationResult.templateUpdates,
     );
 
+    let globalsAttached = false;
     for (const file of await angularCompilation.emitAffectedFiles()) {
       const normalizedFilename = normalizePath(file.filename);
       const templateUpdate = templateUpdates.get(normalizedFilename);
@@ -966,15 +1005,24 @@ export function angular(options?: PluginOptions): Plugin[] {
         classNames.set(normalizedFilename, templateUpdate.className);
       }
 
+      const fileErrors = errorsByFile.get(normalizedFilename) ?? [];
+      const fileWarnings = warningsByFile.get(normalizedFilename) ?? [];
+
+      // Location-less diagnostics (e.g. program-wide errors) have no owning
+      // file, so surface them once on the first emitted file.
+      if (!globalsAttached) {
+        fileErrors.push(...globalErrors);
+        fileWarnings.push(...globalWarnings);
+        globalsAttached = true;
+      }
+
       // Surface Angular's HMR payloads into Analog's existing live-reload
       // flow via the `hmrUpdateCode` / `hmrEligible` fields.
       outputFiles.set(normalizedFilename, {
         content: file.contents,
         dependencies: [],
-        errors: errors.map((error: { text?: string }) => error.text || ''),
-        warnings: warnings.map(
-          (warning: { text?: string }) => warning.text || '',
-        ),
+        errors: fileErrors,
+        warnings: fileWarnings,
         hmrUpdateCode: templateUpdate?.code,
         hmrEligible: !!templateUpdate?.code,
       });
@@ -1074,7 +1122,16 @@ export function angular(options?: PluginOptions): Plugin[] {
     if (!isTest && config.build?.lib) {
       tsCompilerOptions['declaration'] = true;
       tsCompilerOptions['declarationMap'] = watchMode;
-      tsCompilerOptions['inlineSources'] = true;
+      // `inlineSources` is only valid alongside a sourcemap option — an
+      // unpaired `inlineSources` trips TS5051. In production this path leaves
+      // both `sourceMap` and `inlineSourceMap` off, so only enable it when one
+      // is set (e.g. dev/watch builds). See #2324.
+      if (
+        tsCompilerOptions['inlineSourceMap'] ||
+        tsCompilerOptions['sourceMap']
+      ) {
+        tsCompilerOptions['inlineSources'] = true;
+      }
     }
 
     if (isTest) {
@@ -1422,6 +1479,63 @@ export function toAngularCompilationFileReplacements(
  * them so the caller can look up updates by the same normalized absolute path
  * used elsewhere in the plugin (`outputFiles`, `classNames`, etc.).
  */
+/**
+ * Group `@angular/build` `diagnoseFiles()` diagnostics by the source file they
+ * point at, folding the esbuild-style `location` into each message as
+ * `file:line:column`. Diagnostics without a file location are collected into
+ * the `globalErrors` / `globalWarnings` buckets.
+ *
+ * Grouping lets the caller attach each diagnostic to its own emitted file so it
+ * is reported exactly once, rather than duplicating the whole global list
+ * across every emitted file (the N×M explosion in #2317).
+ */
+export function groupDiagnosticsByFile(diagnostics: {
+  errors?: AngularDiagnostic[];
+  warnings?: AngularDiagnostic[];
+}): {
+  errorsByFile: Map<string, string[]>;
+  warningsByFile: Map<string, string[]>;
+  globalErrors: string[];
+  globalWarnings: string[];
+} {
+  const errorsByFile = new Map<string, string[]>();
+  const warningsByFile = new Map<string, string[]>();
+  const globalErrors: string[] = [];
+  const globalWarnings: string[] = [];
+
+  const group = (
+    list: AngularDiagnostic[] | undefined,
+    byFile: Map<string, string[]>,
+    global: string[],
+  ) => {
+    for (const diagnostic of list ?? []) {
+      const location = diagnostic.location;
+      const message = location?.file
+        ? `${location.file}:${location.line ?? 0}:${location.column ?? 0}: ${
+            diagnostic.text ?? ''
+          }`
+        : (diagnostic.text ?? '');
+
+      if (location?.file) {
+        const key = normalizePath(location.file);
+        const bucket = byFile.get(key);
+        if (bucket) {
+          bucket.push(message);
+        } else {
+          byFile.set(key, [message]);
+        }
+      } else {
+        global.push(message);
+      }
+    }
+  };
+
+  group(diagnostics.errors, errorsByFile, globalErrors);
+  group(diagnostics.warnings, warningsByFile, globalWarnings);
+
+  return { errorsByFile, warningsByFile, globalErrors, globalWarnings };
+}
+
 export function mapTemplateUpdatesToFiles(
   templateUpdates: ReadonlyMap<string, string> | undefined,
 ) {


### PR DESCRIPTION
## PR Checklist

The `experimental.useAngularCompilationAPI` path was incompatible with Vite's library mode (`build.lib`) and duplicated diagnostics across every emitted file. This fixes both.

Closes #2324
Closes #2317

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: —

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

All changes are scoped to the `useAngularCompilationAPI` (Angular Compilation API) path in `angular-vite-plugin.ts`.

**`build.lib` compatibility (#2324)**

- No longer forces `declaration: true` / `inlineSources: true` for library builds on this path. The path has no mechanism to write `.d.ts` to disk, and `@angular/build`'s `emitAffectedFiles()` keys outputs by source file (last-write-wins) — so the emitted `.d.ts` overwrote the `.js` content and was returned to Vite as the module source (`export declare class …` → `[PARSE_ERROR]`). The unpaired `inlineSources` also tripped **TS5051**, because this path forces `sourceMap` off.
- Forces whole-program transpilation (`isolatedModules: false`) for emit so TypeScript strips type annotations. `emitAffectedFiles()` otherwise skips full TS emit when `isolatedModules` is enabled with no sourcemap, leaving annotations like `App_Factory(__ngFactoryType__: any)` that Rolldown can't parse. This is side-effect-free for currently-working builds (any build with `isolatedModules: true` was already failing); the user's editor/`tsc` still enforces `isolatedModules`.
- Legacy compilation path: only sets `inlineSources` when a sourcemap option is present, avoiding the same unpaired-option inconsistency.

**Diagnostics dedup + location (#2317)**

- `diagnoseFiles()` returns whole-program diagnostics that were attached to *every* emitted file, then re-emitted per file in `transform` — an N×M explosion (e.g. 485 warnings × 85 files ≈ 41k log lines). Diagnostics are now grouped by their source file and attached only to that file, so each is reported exactly once.
- The `file:line:column` from each diagnostic's `location` is now folded into the message, restoring the origin that was previously discarded (warnings showed text only).
- Grouping logic extracted into an exported, unit-tested `groupDiagnosticsByFile` helper.

## Test plan

- [x] `nx format:check` (prettier `--check` on the changed files — clean)
- [ ] `pnpm build` (built the affected package via `nx build vite-plugin-angular` — succeeds)
- [x] `pnpm test` (`nx test vite-plugin-angular` — 1165 passed, incl. 6 new `groupDiagnosticsByFile` tests)
- [x] Manual verification

Manual verification ran real `vite build --mode production` with the rebuilt plugin across a matrix:

| Path | `build.lib` | `isolatedModules` | Result |
|------|-----------|-------------------|--------|
| Compilation API | ✅ | not set | ✅ builds, type-free output |
| Compilation API | ✅ | `true` | ✅ builds (was: TS5051 / `: any`) |
| Compilation API | ❌ rollupOptions | `true` | ✅ builds |
| Legacy | ✅ | `true` | ✅ builds (unregressed) |

For #2317, a project with two components each carrying an unused standalone import produced exactly one `NG8113` per file (e.g. `a.component.ts:3:50: NG8113: All imports are unused`) across 245 emitted modules — previously this duplicated per emitted file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The `isolatedModules: true` type-stripping issue surfaced while fixing #2324 and also affected the non-`build.lib` compilation API path; it is fixed here for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)