### PR TITLE
fix(vite-plugin-angular): aggregate and locate template diagnostics on the default compilation path

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -12,14 +12,18 @@ vi.mock('vite', async () => {
   };
 });
 
+import type ts from 'typescript';
 import {
   angular,
+  collectEmittedDiagnostics,
   createFsWatcherCacheInvalidator,
+  formatDiagnosticWithLocation,
   groupDiagnosticsByFile,
   mapTemplateUpdatesToFiles,
   toAngularCompilationFileReplacements,
   isTestWatchMode,
 } from './angular-vite-plugin';
+import type { EmitFileResult } from './models';
 
 describe('angularVitePlugin', () => {
   it('should work', () => {
@@ -634,5 +638,120 @@ describe('groupDiagnosticsByFile', () => {
     expect(result.warningsByFile.size).toBe(0);
     expect(result.globalErrors).toEqual([]);
     expect(result.globalWarnings).toEqual([]);
+  });
+});
+
+describe('collectEmittedDiagnostics', () => {
+  const file = (over: Partial<EmitFileResult>): EmitFileResult => ({
+    dependencies: [],
+    ...over,
+  });
+
+  it('aggregates errors and warnings across every output file', () => {
+    const outputFiles = new Map<string, EmitFileResult>([
+      ['/src/a.component.ts', file({ errors: ['a: error one'] })],
+      [
+        '/src/b.component.ts',
+        file({ errors: ['b: error two'], warnings: ['b: warning one'] }),
+      ],
+      ['/src/c.component.ts', file({ warnings: ['c: warning two'] })],
+    ]);
+
+    const { errors, warnings } = collectEmittedDiagnostics(outputFiles);
+
+    // Every file contributes — a single errored file does not hide the rest.
+    expect(errors).toEqual(['a: error one', 'b: error two']);
+    expect(warnings).toEqual(['b: warning one', 'c: warning two']);
+  });
+
+  it('flattens diagnostic message chains into strings', () => {
+    const chain = {
+      messageText: 'Type X is not assignable to type Y',
+      category: 1,
+      code: 2322,
+      next: [
+        { messageText: "Property 'foo' is missing", category: 1, code: 1 },
+      ],
+    };
+
+    const outputFiles = new Map<string, EmitFileResult>([
+      ['/src/a.component.ts', file({ errors: [chain] })],
+    ]);
+
+    const { errors } = collectEmittedDiagnostics(outputFiles);
+
+    expect(errors).toEqual([
+      "Type X is not assignable to type Y\n  Property 'foo' is missing",
+    ]);
+  });
+
+  it('ignores files without diagnostics and returns empty arrays', () => {
+    const outputFiles = new Map<string, EmitFileResult>([
+      ['/src/a.component.ts', file({ content: 'compiled' })],
+    ]);
+
+    expect(collectEmittedDiagnostics(outputFiles)).toEqual({
+      errors: [],
+      warnings: [],
+    });
+  });
+});
+
+describe('formatDiagnosticWithLocation', () => {
+  // Minimal `ts.SourceFile` stand-in: only the bits the formatter touches.
+  const sourceFile = (fileName: string, line: number, character: number) =>
+    ({
+      fileName,
+      getLineAndCharacterOfPosition: () => ({ line, character }),
+    }) as unknown as ts.SourceFile;
+
+  it('prefixes the message with normalized file:line:column (1-based)', () => {
+    const diagnostic = {
+      file: sourceFile('/src/app/a.component.ts', 4, 19),
+      start: 42,
+      messageText: "Property 'foo' does not exist on type 'AppComponent'.",
+      category: 1,
+      code: 2339,
+    } as unknown as ts.Diagnostic;
+
+    // line 4/char 19 (0-based) render as 5:20, matching the Compilation API path.
+    expect(formatDiagnosticWithLocation(diagnostic)).toBe(
+      "/src/app/a.component.ts:5:20: Property 'foo' does not exist on type 'AppComponent'.",
+    );
+  });
+
+  it('flattens message chains and keeps the location prefix', () => {
+    const diagnostic = {
+      file: sourceFile('/src/app/a.component.ts', 0, 0),
+      start: 0,
+      messageText: {
+        messageText: 'Type X is not assignable to type Y',
+        category: 1,
+        code: 2322,
+        next: [
+          { messageText: "Property 'foo' is missing", category: 1, code: 1 },
+        ],
+      },
+      category: 1,
+      code: 2322,
+    } as unknown as ts.Diagnostic;
+
+    expect(formatDiagnosticWithLocation(diagnostic)).toBe(
+      "/src/app/a.component.ts:1:1: Type X is not assignable to type Y\n  Property 'foo' is missing",
+    );
+  });
+
+  it('falls back to the bare message for location-less diagnostics', () => {
+    const diagnostic = {
+      file: undefined,
+      start: undefined,
+      messageText: 'Cannot find a tsconfig option.',
+      category: 1,
+      code: 5000,
+    } as unknown as ts.Diagnostic;
+
+    expect(formatDiagnosticWithLocation(diagnostic)).toBe(
+      'Cannot find a tsconfig option.',
+    );
   });
 });

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -359,6 +359,29 @@ export function angular(options?: PluginOptions): Plugin[] {
           initialCompilation = true;
         }
       },
+      buildEnd() {
+        // Report diagnostics for production builds. Watch/serve already report
+        // per-module from `transform`; build mode defers to here so a single
+        // errored file no longer aborts the build before the rest are checked
+        // — every file's diagnostics are aggregated and reported together.
+        // Which diagnostics exist is governed by `disableTypeChecking` inside
+        // `getDiagnosticsForSourceFile` (syntactic-only by default, full
+        // semantic + Angular template diagnostics when type checking is on),
+        // so reporting itself is unconditional.
+        if (watchMode) {
+          return;
+        }
+
+        const { errors, warnings } = collectEmittedDiagnostics(outputFiles);
+
+        if (warnings.length > 0) {
+          this.warn(warnings.join('\n'));
+        }
+
+        if (errors.length > 0) {
+          this.error(errors.join('\n\n'));
+        }
+      },
       async handleHotUpdate(ctx) {
         if (TS_EXT_REGEX.test(ctx.file)) {
           let [fileId] = ctx.file.split('?');
@@ -702,7 +725,15 @@ export function angular(options?: PluginOptions): Plugin[] {
             this.warn(`${typescriptResult.warnings.join('\n')}`);
           }
 
-          if (typescriptResult.errors && typescriptResult.errors.length > 0) {
+          // In watch/serve, surface this module's errors immediately so the
+          // dev overlay points at the edited file. In build mode, defer to the
+          // `buildEnd` hook, which aggregates diagnostics across every file
+          // instead of aborting the whole build at the first errored module.
+          if (
+            watchMode &&
+            typescriptResult.errors &&
+            typescriptResult.errors.length > 0
+          ) {
             this.error(`${typescriptResult.errors.join('\n')}`);
           }
 
@@ -1321,7 +1352,13 @@ export function angular(options?: PluginOptions): Plugin[] {
         return;
       }
 
-      const metadata = watchMode ? fileMetadata(filename) : {};
+      // Collect diagnostics for every emitted file in both watch/serve (for
+      // the dev overlay and HMR metadata) and build, so the `buildEnd` hook
+      // can report them aggregated across every file instead of aborting at
+      // the first error. `getDiagnosticsForSourceFile` honours
+      // `disableTypeChecking`, returning syntactic-only diagnostics by default
+      // and the full semantic + Angular template set when type checking is on.
+      const metadata = fileMetadata(filename);
       const existing = outputFiles.get(filename);
 
       outputFiles.set(filename, {
@@ -1590,6 +1627,70 @@ function sendHMRComponentUpdate(server: ViteDevServer, id: string) {
   classNames.delete(id);
 }
 
+/**
+ * Flatten the per-file diagnostics accumulated on the emitted output files
+ * into a single list of error and warning strings.
+ *
+ * Each {@link EmitFileResult} carries the diagnostics for its own source file
+ * (populated as the file is emitted). The build-mode `buildEnd` hook drains
+ * them here so it can report every file's diagnostics together instead of
+ * throwing on the first errored file — which would otherwise abort the build
+ * before the remaining files are ever checked.
+ */
+export function collectEmittedDiagnostics(
+  outputFiles: Map<string, EmitFileResult>,
+): { errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  for (const result of outputFiles.values()) {
+    if (result.errors?.length) {
+      errors.push(...result.errors.map(diagnosticMessageToString));
+    }
+    if (result.warnings?.length) {
+      warnings.push(...result.warnings.map(diagnosticMessageToString));
+    }
+  }
+
+  return { errors, warnings };
+}
+
+function diagnosticMessageToString(
+  message: string | ts.DiagnosticMessageChain,
+): string {
+  return typeof message === 'string'
+    ? message
+    : ts.flattenDiagnosticMessageText(message, '\n');
+}
+
+/**
+ * Format a TypeScript/Angular diagnostic as `file:line:column: message`.
+ *
+ * This mirrors the Compilation API path's `groupDiagnosticsByFile` output so
+ * both compilation paths report diagnostics in the same shape — the default
+ * path previously discarded the location and emitted only the message text.
+ * Line/column are 1-based (matching `tsc` and editor gutters). Diagnostics
+ * without a source location (program-wide / option diagnostics) fall back to
+ * the bare flattened message.
+ */
+export function formatDiagnosticWithLocation(
+  diagnostic: ts.Diagnostic,
+): string {
+  const text = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+
+  if (!diagnostic.file || diagnostic.start == null) {
+    return text;
+  }
+
+  const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(
+    diagnostic.start,
+  );
+
+  return `${normalizePath(diagnostic.file.fileName)}:${line + 1}:${
+    character + 1
+  }: ${text}`;
+}
+
 export function getFileMetadata(
   program: ts.BuilderProgram,
   angularCompiler?: NgtscProgram['compiler'],
@@ -1612,15 +1713,11 @@ export function getFileMetadata(
 
     const errors = diagnostics
       .filter((d) => d.category === ts.DiagnosticCategory?.Error)
-      .map((d) =>
-        typeof d.messageText === 'object'
-          ? d.messageText.messageText
-          : d.messageText,
-      );
+      .map(formatDiagnosticWithLocation);
 
     const warnings = diagnostics
       .filter((d) => d.category === ts.DiagnosticCategory?.Warning)
-      .map((d) => d.messageText);
+      .map(formatDiagnosticWithLocation);
 
     let hmrUpdateCode: string | null | undefined = undefined;
 


### PR DESCRIPTION
## PR Checklist

Diagnostics on the default (non Compilation API) compilation path were reported one file at a time from the `transform` hook, which threw on the first errored file — so a production build aborted before the remaining files were ever checked, and build mode collected no diagnostics at all. Reported messages also discarded the source location and mishandled `ts.DiagnosticMessageChain` (warnings rendered as `[object Object]`, error chains were truncated).

Closes #

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Diagnostics are now accumulated across every emitted file and reported together, at parity with the Compilation API path:

- **Aggregate, don't abort.** Per-file diagnostics are collected for every emitted file (no longer watch-only) and reported once in a new `buildEnd` hook, instead of aborting the build at the first errored module. `transform` still reports per-module in watch/serve so the dev overlay points at the edited file.
- **Locations.** Every diagnostic is formatted as `file:line:column: message`, mirroring the Compilation API path's `groupDiagnosticsByFile`. Location-less (program-wide / option) diagnostics fall back to the bare message.
- **Message chains.** Both errors and warnings are flattened via `flattenDiagnosticMessageText`, fixing the `[object Object]` warning output and truncated error chains.

Reporting is unconditional; *which* diagnostics exist is still governed by `disableTypeChecking` inside `getDiagnosticsForSourceFile` — syntactic-only by default, full semantic + Angular template diagnostics when type checking is enabled. So with the default config, builds now surface syntax errors with `file:line:column`, and the `disableTypeChecking: false` opt-in reaches full parity with the Compilation API path.

## Test plan

Ran for the affected package:

- `npx nx test vite-plugin-angular` — 1171 passed, 23 skipped (incl. 6 new unit tests for `collectEmittedDiagnostics` and `formatDiagnosticWithLocation`)
- `npx tsc --noEmit -p packages/vite-plugin-angular/tsconfig.lib.json` — clean
- `npx prettier --check` on the changed files — clean

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

(Full-repo `format:check` / `build` and end-to-end manual verification left for CI / maintainer.)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

With the default config (`disableTypeChecking: true`), build mode now surfaces **syntactic** errors that were previously emitted silently. This is a correctness fix rather than a breaking change: a file with a TypeScript syntax error already produces broken output and a non-running app, so failing the build reports an existing failure instead of breaking working software. Semantic/template type-checking remains opt-in and unchanged by default.

## Other information

The aggregation and `buildEnd` reporting are shared by both compilation paths, so the Compilation API path also moves from per-file `transform` reporting to aggregated `buildEnd` reporting in build mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
