### PR TITLE
fix(vite-plugin-angular): don't shadow Vite ?raw imports of .ts files

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -192,6 +192,29 @@ describe('JIT resolveId', () => {
     expect(assetRE.test(virtualId)).toBe(false);
   });
 
+  it('should exclude .ts?raw ids from the transform filter so Vite raw handling stands', () => {
+    const plugins = angular({ jit: true });
+    const mainPlugin = plugins.find(
+      (p) => p.name === '@analogjs/vite-plugin-angular',
+    );
+
+    const exclude = (mainPlugin as any).transform.filter.id
+      .exclude as unknown[];
+    const matchesExclude = (id: string) =>
+      exclude.some((re) => re instanceof RegExp && re.test(id));
+
+    // `?raw` ids must be skipped, letting Vite's native raw loader stand (#2356)
+    expect(matchesExclude('/project/src/app/foo.ts?raw')).toBe(true);
+    expect(matchesExclude('/project/src/app/foo.cts?raw')).toBe(true);
+    expect(matchesExclude('/project/src/app/foo.mts?raw')).toBe(true);
+    expect(matchesExclude('/project/src/app/foo.ts?import&raw')).toBe(true);
+
+    // Plain and HMR/query .ts ids must still be compiled by Angular
+    expect(matchesExclude('/project/src/app/foo.ts')).toBe(false);
+    expect(matchesExclude('/project/src/app/foo.ts?t=12345')).toBe(false);
+    expect(matchesExclude('/project/src/app/foo.ts?component')).toBe(false);
+  });
+
   it('should resolve style ?inline imports to absolute ?inline paths', () => {
     const plugins = angular({ jit: true });
     const mainPlugin = plugins.find(

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -600,7 +600,15 @@ export function angular(options?: PluginOptions): Plugin[] {
         filter: {
           id: {
             include: [TS_EXT_REGEX],
-            exclude: [/node_modules/, 'type=script', '@ng/component'],
+            // `?raw` ids already carry Vite's native raw-loader output
+            // (`export default "<source>"`). Recompiling them as Angular/TS
+            // would strip that default export, so leave them to Vite (#2356).
+            exclude: [
+              /node_modules/,
+              'type=script',
+              '@ng/component',
+              /[?&]raw\b/,
+            ],
           },
         },
         async handler(code, id) {

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
@@ -269,3 +269,21 @@ export class XComponent {}
     expect(sawBypassCall).toBe(false);
   });
 });
+
+describe('fastCompilePlugin transform filter', () => {
+  it('excludes .ts?raw ids so Vite raw handling stands (#2356)', () => {
+    const plugin = buildPlugin();
+    const exclude = (plugin.transform as any).filter.id.exclude as unknown[];
+    const matchesExclude = (id: string) =>
+      exclude.some((re) => re instanceof RegExp && re.test(id));
+
+    expect(matchesExclude('/src/app/foo.ts?raw')).toBe(true);
+    expect(matchesExclude('/src/app/foo.cts?raw')).toBe(true);
+    expect(matchesExclude('/src/app/foo.mts?raw')).toBe(true);
+    expect(matchesExclude('/src/app/foo.ts?import&raw')).toBe(true);
+
+    expect(matchesExclude('/src/app/foo.ts')).toBe(false);
+    expect(matchesExclude('/src/app/foo.ts?t=12345')).toBe(false);
+    expect(matchesExclude('/src/app/foo.ts?component')).toBe(false);
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -572,7 +572,15 @@ export function fastCompilePlugin(
       filter: {
         id: {
           include: [TS_EXT_REGEX],
-          exclude: [/node_modules/, 'type=script', '@ng/component'],
+          // `?raw` ids already carry Vite's native raw-loader output
+          // (`export default "<source>"`). Recompiling them as Angular/TS
+          // would strip that default export, so leave them to Vite (#2356).
+          exclude: [
+            /node_modules/,
+            'type=script',
+            '@ng/component',
+            /[?&]raw\b/,
+          ],
         },
       },
       async handler(code, id) {


### PR DESCRIPTION
## PR Checklist

The Angular `transform` filter matched query-stringed ids like `foo.ts?raw` via `TS_EXT_REGEX`
(`/\.[cm]?ts(?[a-z])/`, which is not anchored and ignores the query string). The id entered the
handler, the query was stripped, and Angular/esbuild recompiled the file as TypeScript — discarding
the `export default "<source>"` that Vite's native raw loader had already produced. As a result
`import src from './file.ts?raw'` failed with `"default" is not exported by "….ts?raw"`. This broke
the documented Vite `?raw` import for every `.ts`/`.cts`/`.mts` file (Angular component or plain
TypeScript alike), e.g. feeding a story component's source into a Storybook "Show code" panel.

Closes #2356

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

`?raw`-queried ids are now added to the `transform.filter.id.exclude` array in both the AOT
(`angular-vite-plugin.ts`) and fast-compile (`fast-compile-plugin.ts`) plugins, so the Angular
transform never runs for them and Vite's built-in raw handling stands:

```ts
exclude: [/node_modules/, 'type=script', '@ng/component', /[?&]raw\b/],
```

`/[?&]raw\b/` matches `foo.ts?raw` and `foo.ts?import&raw`, but not plain `foo.ts` nor legitimate
query ids the handler must still compile (HMR `foo.ts?t=123`, `foo.ts?component`). The fix is
content-agnostic, so it covers both Angular and non-Angular `.ts` files.

```ts
// now works as with stock Vite
import source from './my-component.ts?raw';
console.log(source); // the file contents as a string
```

## Test plan

- [x] `nx format:check`
- [x] `pnpm test` (vite-plugin-angular — new exclusion specs in `angular-vite-plugin.spec.ts` and
  `fast-compile-plugin.spec.ts` assert `?raw` ids are excluded while plain/HMR ids still compile)
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The plugin already routed `.html?raw` through a virtual id, but that mechanism exists solely to
satisfy Vite's `server.fs` Denied-ID security check — `.html` never reaches the Angular transform.
The `.ts?raw` problem is purely the transform filter shadowing Vite's raw output, so the narrow
filter-exclusion fix is the right tool and leaves the `.html?raw` path untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D4SdPZwfD2LtzqmZLQwdmw)_