### PR TITLE
fix(vite-plugin-angular): emit fastCompile JIT metadata in nested class scope

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-transform.spec.ts
@@ -632,6 +632,64 @@ describe('JIT transform nested class support', () => {
     expect(result).toContain('TopComponent.decorators');
     expect(result).toContain('InnerComponent.decorators');
   });
+
+  // Regression for #2360: a component declared inside a function/callback
+  // scope (the common "host component to test a directive" pattern, where the
+  // class lives inside a `describe(...)`/`it(...)` block) must have its
+  // metadata statements emitted IN SCOPE — emitting them at the end of the
+  // file would reference an undefined name and throw `ReferenceError` when the
+  // spec module is evaluated.
+  it('emits nested-class metadata in scope (no ReferenceError on eval)', () => {
+    const emitted = jitTransform(
+      `
+      import { Component } from '@angular/core';
+
+      export function makeHost() {
+        @Component({ selector: 'app-host', template: '' })
+        class TestComponent {}
+        return TestComponent;
+      }
+    `,
+      'example.component.spec.ts',
+    ).code;
+
+    // Stub @angular/core so the emitted JS can run under \`new Function\`.
+    const stubs = {
+      Component: () => () => undefined,
+      ɵcompileComponent: () => undefined,
+      ɵcompileDirective: () => undefined,
+      ɵcompilePipe: () => undefined,
+      ɵcompileNgModule: () => undefined,
+    };
+    const runnable = emitted
+      .replace(
+        /import\s+\{([^}]+)\}\s+from\s+['"]@angular\/core['"];?/g,
+        (_m, specs: string) => {
+          const destructured = specs
+            .split(',')
+            .map((s) => {
+              const parts = s.trim().match(/^(\S+)(?:\s+as\s+(\S+))?$/);
+              if (!parts) return '';
+              const [, imported, local] = parts;
+              return local ? `${imported}: ${local}` : imported;
+            })
+            .filter(Boolean)
+            .join(', ');
+          return `const { ${destructured} } = __stubs__;`;
+        },
+      )
+      .replace(/^\s*export\s+(?=function)/gm, '');
+
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const fn = new Function('__stubs__', `${runnable}\nreturn makeHost();`);
+    const Cls = fn(stubs);
+
+    // Evaluating the factory must not throw, and the in-scope statements must
+    // have attached the metadata to the nested class.
+    expect(typeof Cls).toBe('function');
+    expect((Cls as any).decorators).toBeDefined();
+    expect((Cls as any).decorators[0].args[0].selector).toBe('app-host');
+  });
 });
 
 describe('JIT transform auto-imports decorator classes for signal API downleveling', () => {

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-transform.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-transform.ts
@@ -69,7 +69,15 @@ export function jitTransform(
 
   const allClasses = findAllClasses(program.body);
 
-  const postClassStatements: string[] = [];
+  // Accumulates every class's emitted statements so the post-loop import
+  // detection (missing field-decorator imports) can scan all of them.
+  // The statements themselves are inserted in-scope after each class via
+  // `ms.appendLeft(node.end, ...)` rather than dumped at the end of the
+  // file — a class declared inside a function/callback scope (e.g. a host
+  // `@Component` defined inside a `describe(...)`/`it(...)` block in a test)
+  // is not in scope at module end, so a file-end emit would reference an
+  // undefined name (#2360).
+  const allEmittedStatements: string[] = [];
   let importCounter = 0;
   const resourceImports: string[] = [];
   let needsJitImport = false;
@@ -92,6 +100,10 @@ export function jitTransform(
     const className: string | undefined = node.id?.name;
     if (!className) continue;
     hasAngularClass = true;
+
+    // Statements emitted for THIS class. Inserted directly after the class
+    // body (see end of loop) so they run in the class's own lexical scope.
+    const classStatements: string[] = [];
 
     // 1. Remove Angular decorators from source
     for (const dec of angularDecs) {
@@ -182,7 +194,7 @@ export function jitTransform(
       decoratorMeta.push({ name: decName, argsText: '{}' });
       return `{ type: ${decName} }`;
     });
-    postClassStatements.push(
+    classStatements.push(
       `${className}.decorators = [${decoratorEntries.join(', ')}];`,
     );
 
@@ -191,22 +203,22 @@ export function jitTransform(
       needsJitImport = true;
       switch (dm.name) {
         case 'Component':
-          postClassStatements.push(
+          classStatements.push(
             `_jitCompileComponent(${className}, ${dm.argsText});`,
           );
           break;
         case 'Directive':
-          postClassStatements.push(
+          classStatements.push(
             `_jitCompileDirective(${className}, ${dm.argsText});`,
           );
           break;
         case 'Pipe':
-          postClassStatements.push(
+          classStatements.push(
             `_jitCompilePipe(${className}, ${dm.argsText});`,
           );
           break;
         case 'NgModule':
-          postClassStatements.push(
+          classStatements.push(
             `_jitCompileNgModule(${className}, ${dm.argsText});`,
           );
           break;
@@ -216,7 +228,7 @@ export function jitTransform(
     // 3. Emit Class.ctorParameters for constructor DI
     const ctorParams = buildCtorParameters(node, sourceCode, typeOnlyImports);
     if (ctorParams) {
-      postClassStatements.push(
+      classStatements.push(
         `${className}.ctorParameters = () => [${ctorParams}];`,
       );
     }
@@ -224,9 +236,7 @@ export function jitTransform(
     // 4. Emit Class.propDecorators for field decorators + signal APIs
     const propDecorators = buildPropDecorators(node, sourceCode);
     if (propDecorators) {
-      postClassStatements.push(
-        `${className}.propDecorators = ${propDecorators};`,
-      );
+      classStatements.push(`${className}.propDecorators = ${propDecorators};`);
     }
 
     // 5. Remove member and parameter decorators from source now that
@@ -267,6 +277,17 @@ export function jitTransform(
         }
       }
     }
+
+    // Insert this class's metadata statements directly after the class body
+    // so they execute in the class's own lexical scope. `node.end` is the
+    // position just past the closing brace (decorators were stripped before
+    // `node.start`), so for a top-level class this is module scope and for a
+    // class nested in a function/callback it is that enclosing scope —
+    // keeping the class identifier in scope either way (#2360).
+    if (classStatements.length > 0) {
+      allEmittedStatements.push(...classStatements);
+      ms.appendLeft(node.end, '\n' + classStatements.join('\n') + '\n');
+    }
   }
 
   if (!hasAngularClass) {
@@ -293,7 +314,7 @@ export function jitTransform(
       }
     }
   }
-  const allPostCode = postClassStatements.join('\n');
+  const allPostCode = allEmittedStatements.join('\n');
   const missingDecorators: string[] = [];
   for (const dec of FIELD_DECORATORS) {
     if (allPostCode.includes(`type: ${dec}`) && !existingImports.has(dec)) {
@@ -311,11 +332,6 @@ export function jitTransform(
     ms.prepend(
       `import { ɵcompileComponent as _jitCompileComponent, ɵcompileDirective as _jitCompileDirective, ɵcompilePipe as _jitCompilePipe, ɵcompileNgModule as _jitCompileNgModule } from '@angular/core';\n`,
     );
-  }
-
-  // Append all post-class statements at the end
-  if (postClassStatements.length > 0) {
-    ms.append('\n' + postClassStatements.join('\n') + '\n');
   }
 
   const map = ms.generateMap({


### PR DESCRIPTION
## PR Checklist

Components defined directly inside a test spec file — e.g. a host component declared within a `describe()`/`it()`/`beforeEach()` callback to test a directive — threw `ReferenceError: <Class> is not defined` under `fastCompile`.

Closes #2360

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

In test mode `fastCompile` uses the JIT path (`angular-vite-plugin.ts` sets `jit` to `isTest` when not explicitly provided), so `jitTransform()` runs rather than the AOT registry path.

`jitTransform` calls `findAllClasses()`, which walks the AST **recursively** and therefore finds classes nested inside function/callback scopes — including a host `@Component` declared inside a `describe(...)`/`it(...)` block, the common "host component to test a directive" pattern. For every such class it collected the generated metadata statements (`<Class>.decorators = [...]`, `_jitCompileComponent(<Class>, ...)`, `<Class>.ctorParameters = ...`, `<Class>.propDecorators = ...`) into a single array and appended them all at the **end of the file** (module scope). A class declared inside a callback is not in scope there, so the appended statement referenced an undefined name and threw `ReferenceError: <Class> is not defined` when the spec module was evaluated.

This was missed because the existing nested-class tests only asserted the emitted **string** contained `<Class>.decorators` — they never evaluated the code.

The fix emits each class's metadata statements directly after its class body via `ms.appendLeft(node.end, ...)`, so they run in the class's own lexical scope:

- top-level classes → module scope (unchanged behavior)
- nested classes → the enclosing function/callback scope (now correct)

`node.end` is the position just past the class's closing brace (decorators were already stripped before `node.start`), so the statements land as the next statement(s) in the same block. A separate accumulator string preserves the existing post-loop detection of missing field-decorator imports. Angular's `ɵcompileComponent` installs a lazy `ɵcmp`, so emitting a top-level component's `_jitCompileComponent(...)` right after its own declaration (instead of after every class) is safe.

Before / after for a component declared inside a function:

```js
// before — appended at end of file, TestComponent out of scope → ReferenceError
export function makeHost() {
  class TestComponent {}
  return TestComponent;
}
TestComponent.decorators = [...];          // ReferenceError
_jitCompileComponent(TestComponent, {...});

// after — emitted in scope
export function makeHost() {
  class TestComponent {}
  TestComponent.decorators = [...];
  _jitCompileComponent(TestComponent, {...});
  return TestComponent;
}
```

## Test plan

- [x] `nx format:check` (touched files)
- [x] `nx build vite-plugin-angular`
- [x] `nx test vite-plugin-angular` — 620 passed, 3 skipped
- [x] Manual verification — confirmed against built output that the metadata statements are emitted inside the enclosing function scope

Adds an evaluating regression test (`jit-transform.spec.ts`) that runs the emitted JS through `new Function` with stubbed `@angular/core` exports — it would throw `ReferenceError` under the old file-end emit and passes with the fix.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`fastCompile` is opt-in, and top-level class emit is unchanged — only the out-of-scope placement for nested classes is corrected.

## Other information

Scoped to the JIT path, which is the path test mode uses, directly resolving the reported error. The AOT registry's `.spec.ts` handling in `fast-compile-plugin.ts` is not on the test path and is out of scope for this issue.

https://claude.ai/code/session_01DEPPXW9VMWVXNYmYDM2Y6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEPPXW9VMWVXNYmYDM2Y6A)_