### PR TITLE
fix(vite-plugin-angular): restore esbuild export

### DIFF
--- a/packages/vite-plugin-angular/esbuild.ts
+++ b/packages/vite-plugin-angular/esbuild.ts
@@ -1,0 +1,4 @@
+export {
+  createCompilerPlugin,
+  createRolldownCompilerPlugin,
+} from './src/lib/compiler-plugin.js';

--- a/packages/vite-plugin-angular/project.json
+++ b/packages/vite-plugin-angular/project.json
@@ -17,6 +17,7 @@
         ],
         "updateBuildableProjectDepsInPackageJson": false,
         "additionalEntryPoints": [
+          "packages/vite-plugin-angular/esbuild.ts",
           "packages/vite-plugin-angular/setup-vitest.ts"
         ],
         "generateExportsField": false

--- a/packages/vite-plugin-angular/src/lib/utils/compiler-plugin-options.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/compiler-plugin-options.ts
@@ -1,4 +1,4 @@
-import { SourceFileCache } from './source-file-cache';
+import type { SourceFileCache } from './source-file-cache.js';
 
 export interface CompilerPluginOptions {
   sourcemap: boolean;


### PR DESCRIPTION
## Summary

Restores the published `@analogjs/vite-plugin-angular/esbuild` subpath by adding the missing package entrypoint to the build output.

The package `exports` map advertises `./esbuild` as `./esbuild.js`, but the build config only emitted `src/index` and `setup-vitest`. A clean install of `@analogjs/vite-plugin-angular@2.6.0` currently fails before loading the subpath:

```text
ERR_MODULE_NOT_FOUND Cannot find module '.../node_modules/@analogjs/vite-plugin-angular/esbuild.js'
```

This PR:

- adds `packages/vite-plugin-angular/esbuild.ts`, re-exporting `createCompilerPlugin` and `createRolldownCompilerPlugin`
- includes that file in `build-package.additionalEntryPoints` so `esbuild.js` and `esbuild.d.ts` are published
- updates a type-only relative import to include the `.js` extension so a `NodeNext` TypeScript consumer can resolve the exposed declarations

## Verification

```text
pnpm nx build-package vite-plugin-angular --skip-nx-cache
pnpm exec eslint packages/vite-plugin-angular/esbuild.ts packages/vite-plugin-angular/src/lib/utils/compiler-plugin-options.ts
git diff --check
pnpm nx test vite-plugin-angular --skip-nx-cache --runInBand
```

The package-wide lint target still fails on pre-existing lint errors in untouched files. I ran focused lint for the files changed in this PR.

I also packed the built package and verified a clean consumer:

```text
PATCHED_IMPORT_OK function function createCompilerPlugin,createRolldownCompilerPlugin
PATCHED_TYPES_OK
```
