### PR TITLE
fix(vite-plugin-angular): parse skipped .ts files as TypeScript in vitest sourcemap plugin

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -111,7 +111,9 @@ export function angularVitestSourcemapPlugin(
       }
 
       if (vite.transformWithOxc) {
-        const result = await vite.transformWithOxc(code, id, { lang: 'js' });
+        const result = await vite.transformWithOxc(code, id, {
+          lang: /\.tsx(\?|$)/.test(bareId) ? 'tsx' : 'ts',
+        });
         return result as unknown as vite.TransformResult;
       } else {
         const result = await vite.transformWithEsbuild(code, id, {

--- a/tests/vitest-angular/src/sourcemap/no-decorator-ts-syntax.spec.ts
+++ b/tests/vitest-angular/src/sourcemap/no-decorator-ts-syntax.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+
+// Regression test for #2364. This spec has no Angular decorators, so Angular's
+// compilation skips it and the file reaches the vitest sourcemap plugin as raw
+// TypeScript. The plugin's OXC path previously forced `lang: 'js'`, which
+// failed to parse top-level TS-only syntax like the type annotation below
+// (`[PARSE_ERROR] Missing initializer in const declaration`). If the file
+// transforms and this test runs at all, the regression is fixed.
+const data: [string, string][] = [['a', 'A']];
+
+function mapToLabel(key: string): string {
+  return data.find(([k]) => k === key)?.[1] ?? '';
+}
+
+test('transforms a decorator-free spec with TS-only syntax', () => {
+  expect(mapToLabel('a')).toBe('A');
+});


### PR DESCRIPTION
## PR Checklist

Closes #2364

The vitest sourcemap plugin's OXC transform path forced `lang: 'js'`, so it parsed TypeScript source as JavaScript. Files that Angular's compilation skips (e.g. decorator-free specs when `useAngularCompilationAPI` is on) reach this post-processing pass as raw TypeScript. Any top-level TS-only syntax — type annotations, generics, `as` — then failed with `[PARSE_ERROR] Missing initializer in const declaration` on rolldown-vite. Surfaced as a regression upgrading 2.4.0 → 2.6.0.

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: vitest-angular (regression test)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

`angularVitestSourcemapPlugin` now derives the OXC `lang` from the file extension (`'tsx'` for `.tsx`, otherwise `'ts'`), matching the esbuild fallback's `loader: 'ts'`. Skipped `.ts`/`.tsx` files are correctly parsed as TypeScript, so TS-only syntax no longer triggers a parse error.

## Test plan

- [x] `pnpm test` (sourcemap project — `nx build vite-plugin-angular` + `vitest run --project sourcemap`, both specs pass on rolldown-vite where the OXC path is active)
- [ ] `nx format:check`
- [ ] `pnpm build`
- [x] Manual verification — reproduced the exact `PARSE_ERROR` with `lang: 'js'` and confirmed clean transform with `lang: 'ts'` via `vite.transformWithOxc`; added a decorator-free regression spec with top-level TS-only syntax that fails to transform under the old behavior.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Root cause traced to `packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts:114`. The `lang: 'js'` predates #2333, but #2333's `getInMap` early-return is what routes still-TypeScript (Angular-skipped) files through this branch, exposing the wrong `lang`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)