### PR TITLE
fix(vite-plugin-angular): import NgModule/tuple exports from their defining file in fastCompile

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/compile.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/compile.ts
@@ -32,7 +32,7 @@ import {
   compileDeclareClassMetadata,
 } from '@angular/compiler';
 import { ComponentRegistry } from './registry.js';
-import { findAllClasses } from './utils.js';
+import { findAllClasses, resolveSyntheticImportSpecifier } from './utils.js';
 import { ANGULAR_DECORATORS, FIELD_DECORATORS } from './constants.js';
 import { angularVersionAtLeast } from './angular-version.js';
 import {
@@ -461,12 +461,14 @@ export function compile(
                 const memberEntry = registry?.get(memberName);
                 if (!memberEntry || memberEntry.kind === 'tuple') continue;
                 const memberRef = new o.WrappedNodeExpr(memberName);
-                if (memberEntry.sourcePackage || tupleSpecifier) {
-                  if (!importedNames.has(memberName)) {
-                    syntheticImports.set(
-                      memberName,
-                      memberEntry.sourcePackage || tupleSpecifier!,
-                    );
+                if (!importedNames.has(memberName)) {
+                  const memberSpecifier = resolveSyntheticImportSpecifier(
+                    fileName,
+                    memberEntry,
+                    tupleSpecifier,
+                  );
+                  if (memberSpecifier) {
+                    syntheticImports.set(memberName, memberSpecifier);
                   }
                 }
                 const kind = memberEntry.kind === 'pipe' ? 1 : 0;
@@ -527,11 +529,13 @@ export function compile(
                   // Create a reference to the exported class. If it's not
                   // already imported, track it for synthetic import injection.
                   const exportedRef = new o.WrappedNodeExpr(exportedName);
-                  if (exportedEntry.sourcePackage || moduleSpecifier) {
-                    syntheticImports.set(
-                      exportedName,
-                      exportedEntry.sourcePackage || moduleSpecifier!,
-                    );
+                  const exportedSpecifier = resolveSyntheticImportSpecifier(
+                    fileName,
+                    exportedEntry,
+                    moduleSpecifier,
+                  );
+                  if (exportedSpecifier) {
+                    syntheticImports.set(exportedName, exportedSpecifier);
                   }
                   const decl: CompileDeclaration = {
                     type: exportedRef,

--- a/packages/vite-plugin-angular/src/lib/compiler/ngmodule.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/ngmodule.spec.ts
@@ -129,6 +129,47 @@ describe('NgModule export expansion', () => {
     // The template should resolve ui-button from the NgModule exports
     expect(result).toContain('"ui-button"');
   });
+
+  it('imports an expanded NgModule export from its defining file, not the module file', () => {
+    // Component lives in its own file; the NgModule only re-exports it.
+    const buttonSrc = `
+      import { Component } from '@angular/core';
+      @Component({ selector: 'ui-button', template: '<button><ng-content /></button>' })
+      export class ButtonComponent {}
+    `;
+    const moduleSrc = `
+      import { NgModule } from '@angular/core';
+      import { ButtonComponent } from './button.component';
+      @NgModule({ declarations: [ButtonComponent], exports: [ButtonComponent] })
+      export class SharedModule {}
+    `;
+    const appSrc = `
+      import { Component } from '@angular/core';
+      import { SharedModule } from './shared.module';
+      @Component({
+        selector: 'app-root',
+        imports: [SharedModule],
+        template: '<ui-button>Click</ui-button>'
+      })
+      export class AppComponent {}
+    `;
+
+    const registry = buildRegistry({
+      'button.component.ts': buttonSrc,
+      'shared.module.ts': moduleSrc,
+    });
+    const result = compile(appSrc, 'app.ts', registry);
+
+    expectCompiles(result);
+    // The synthetic import must point at the component's own file...
+    expect(result).toContain(
+      'import { ButtonComponent } from "./button.component"',
+    );
+    // ...not the NgModule file, which doesn't export the component.
+    expect(result).not.toContain(
+      'import { ButtonComponent } from "./shared.module"',
+    );
+  });
 });
 
 describe('Recursive NgModule export expansion', () => {

--- a/packages/vite-plugin-angular/src/lib/compiler/utils.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/utils.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import * as path from 'node:path';
 
 /** Collect type-only imported names: `import type { X }` and `import { type X }`. */
 export function collectTypeOnlyImports(sf: ts.SourceFile): Set<string> {
@@ -96,6 +97,58 @@ export function unwrapForwardRefOxc(node: any): any {
     }
   }
   return node;
+}
+
+/**
+ * Resolve the module specifier to use for a synthetic import of a registry
+ * declaration referenced from `currentFileName`.
+ *
+ * Order of preference:
+ *  1. `entry.sourcePackage` — external packages scanned from `.d.ts` resolve
+ *     via their package name (proper barrel exports).
+ *  2. A relative path derived from `currentFileName` to `entry.fileName` — for
+ *     local workspace classes scanned from real source files. This is what
+ *     NgModule/tuple export expansion must use: the class lives in its own
+ *     file, not the module/barrel file that re-exports it, so importing from
+ *     the module specifier fails with
+ *     `"X" is not exported by ".../the.module.ts"`.
+ *  3. `fallbackSpecifier` — the import path of the module/tuple itself, used
+ *     for `.d.ts` entries (whose file path is not a usable import target) and
+ *     when the registry has no file location for the class.
+ *
+ * Returns `undefined` when the class is declared in `currentFileName` itself
+ * (already in scope — no synthetic import needed).
+ */
+export function resolveSyntheticImportSpecifier(
+  currentFileName: string,
+  entry: { sourcePackage?: string; fileName?: string },
+  fallbackSpecifier: string | undefined,
+): string | undefined {
+  if (entry.sourcePackage) return entry.sourcePackage;
+  // `.d.ts` entries come from scanning external package type declarations;
+  // their file path is not a usable relative import target, so defer to the
+  // module/tuple specifier the consumer already imports from.
+  if (entry.fileName && !entry.fileName.endsWith('.d.ts')) {
+    if (entry.fileName === currentFileName) return undefined;
+    return deriveRelativeImportPath(currentFileName, entry.fileName);
+  }
+  return fallbackSpecifier;
+}
+
+/**
+ * Derive a relative module specifier from `fromFile` to `toFile`, suitable for
+ * a synthetic `import { … } from '…'` statement: strips the file extension,
+ * normalizes to POSIX separators, and ensures an explicit `./` prefix.
+ */
+export function deriveRelativeImportPath(
+  fromFile: string,
+  toFile: string,
+): string {
+  let rel = path.relative(path.dirname(fromFile), toFile);
+  rel = rel.replace(/\.[cm]?[jt]sx?$/, '');
+  rel = rel.split(path.sep).join('/');
+  if (!rel.startsWith('.')) rel = './' + rel;
+  return rel;
 }
 
 export { ANGULAR_DECORATORS } from './constants.js';


### PR DESCRIPTION
## PR Checklist

Fixes a `fastCompile` bug where expanding an NgModule's `exports` (or a tuple barrel's members) generated a synthetic import that pointed at the **module** file rather than the file the class is actually defined in, causing build errors like:

```
"MyComponent" is not exported by "libs/.../my.module.ts"
```

## Affected scope

- Primary scope: `vite-plugin-angular` (fast compiler — `compiler/compile.ts`, `compiler/utils.ts`)
- Secondary scopes: none

## What is the new behavior?

When a standalone component imports a local NgModule, the fast compiler expands the module's exports into direct declarations and injects synthetic imports for each exported class. For local classes (no `sourcePackage`), it previously fell back to the **module's** import specifier — but the module file only re-exports the module, not the component, so the import failed.

The synthetic import specifier is now resolved from the declaration's own `fileName` in the registry, deriving a relative path from the consuming file (`./my.component` instead of `./my.module`). Details:

- External `.d.ts` entries continue to fall back to the module specifier (their file path is not a usable relative import target; package-name/`sourcePackage` resolution is preserved).
- Same-file declarations emit no synthetic import (already in scope).
- The identical bug in the **tuple barrel** expansion path (`imports: [SomeImports]` where the const is `[A, B] as const`) is fixed by the same shared helper.

New shared helpers live in `compiler/utils.ts`: `resolveSyntheticImportSpecifier` and `deriveRelativeImportPath`.

## Test plan

- [ ] `nx format:check` — ran `prettier --write/--check` on changed files instead
- [ ] `pnpm build`
- [x] `pnpm test` — `vitest run packages/vite-plugin-angular/src/lib/compiler` (1072 passed, 0 failures; conformance baseline unchanged)
- [x] Manual verification — added a regression test asserting the synthetic import targets `./button.component`, not `./shared.module`; confirmed it fails without the fix and passes with it

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Reported via a detailed write-up; no linked issue. The report cited line numbers from a built `compile.js`; the live source locations are the NgModule (`~497`) and tuple (`~457`) export-expansion branches in `compiler/compile.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)