### PR TITLE
fix(vite-plugin-angular): skip rolldown dep optimizer transform in test mode and close transformer

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler-plugin.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { createRolldownCompilerPlugin } from './compiler-plugin.js';
+
+const pluginOptions = {
+  tsconfig: 'tsconfig.spec.json',
+  sourcemap: false,
+  incremental: false,
+};
+
+describe('createRolldownCompilerPlugin', () => {
+  it('skips the dependency transform in test mode', () => {
+    const plugin = createRolldownCompilerPlugin(pluginOptions, true, true);
+
+    expect(plugin.load).toBeUndefined();
+  });
+
+  it('keeps the dependency transform outside test mode', () => {
+    const plugin = createRolldownCompilerPlugin(pluginOptions, false, true);
+
+    expect(plugin.load).toBeDefined();
+  });
+
+  it('closes the JavaScript transformer when the build ends', async () => {
+    const plugin = createRolldownCompilerPlugin(pluginOptions, false, true);
+
+    expect(plugin.buildEnd).toBeDefined();
+    await expect(
+      (plugin.buildEnd as unknown as () => Promise<void>)(),
+    ).resolves.toBeUndefined();
+  });
+
+  it('keeps the transformer open when closeTransformer is false', () => {
+    const plugin = createRolldownCompilerPlugin(pluginOptions, false, false);
+
+    expect(plugin.buildEnd).toBeUndefined();
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/compiler-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler-plugin.ts
@@ -50,14 +50,20 @@ export function createCompilerPlugin(
 
 export function createRolldownCompilerPlugin(
   pluginOptions: CompilerPluginOptions,
+  isTest: boolean,
+  closeTransformer: boolean,
 ): Rolldown.Plugin {
   const javascriptTransformer = new JavaScriptTransformer(
     { ...pluginOptions, jit: true },
     1,
   );
-  return {
+
+  const plugin: Rolldown.Plugin = {
     name: 'analogjs-rolldown-deps-optimizer-plugin',
-    load: {
+  };
+
+  if (!isTest) {
+    plugin.load = {
       filter: {
         id: /\.[cm]?js$/,
       },
@@ -69,6 +75,12 @@ export function createRolldownCompilerPlugin(
           loader: 'js',
         } as any;
       },
-    },
-  };
+    };
+  }
+
+  if (closeTransformer) {
+    plugin.buildEnd = () => javascriptTransformer.close();
+  }
+
+  return plugin;
 }

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
@@ -100,13 +100,17 @@ export function createDepOptimizerConfig(opts: DepOptimizerOptions) {
 
   const rolldownOptions: vite.DepOptimizationOptions['rolldownOptions'] = {
     plugins: [
-      createRolldownCompilerPlugin({
-        tsconfig: opts.tsconfig,
-        sourcemap: !opts.isProd,
-        advancedOptimizations: opts.isProd,
-        jit: opts.jit,
-        incremental: opts.watchMode,
-      }),
+      createRolldownCompilerPlugin(
+        {
+          tsconfig: opts.tsconfig,
+          sourcemap: !opts.isProd,
+          advancedOptimizations: opts.isProd,
+          jit: opts.jit,
+          incremental: opts.watchMode,
+        },
+        opts.isTest,
+        !opts.isAstroIntegration,
+      ),
     ],
   };
 


### PR DESCRIPTION
## PR Checklist

On Vite 8 (rolldown), the dep optimizer compiler plugin runs Angular's `JavaScriptTransformer` over every prebundled `.js`/`.cjs`/`.mjs` dependency even in test mode, and never closes the transformer's worker. The esbuild variant of the same plugin skips the transform in test mode (`if (!isTest)`) and closes the transformer in `onEnd`. Large packages in `optimizeDeps.include` can stall the optimizer before the vitest RUN banner because everything funnels through that single never-closed worker.

Closes #2371

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

n/a

## What is the new behavior?

`createRolldownCompilerPlugin` now takes the same `isTest` and `closeTransformer` flags as the esbuild variant:

- in test mode it does not register the `load` transform, so prebundled deps are not piped through the Babel linker — same as the esbuild path;
- when `closeTransformer` is set (everything except the Astro integration), the transformer is closed in `buildEnd`. `JavaScriptTransformer.close()` resets its lazy worker pool, so a later optimizer run re-creates it on demand.

`createDepOptimizerConfig` passes `opts.isTest` and `!opts.isAstroIntegration`, mirroring the esbuild call right below it.

## Test plan

- [x] `nx format:check`
- [x] `pnpm build` (`nx build-package vite-plugin-angular`, tsc, no errors)
- [x] `pnpm test` (full workspace green; `nx test vite-plugin-angular`: 625 passed, 3 skipped)
- [x] Manual verification: new unit tests in `compiler-plugin.spec.ts` fail on the old code (the `load` hook was registered in test mode; no `buildEnd`) and pass with the fix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`createRolldownCompilerPlugin` is internal — the package entry point only exports `angular`. The only call site is `createDepOptimizerConfig`.

## Other information

The rest of the dep optimizer behavior on the rolldown path is unchanged.
