### PR TITLE
fix(vite-plugin-angular): treat the vitest run command as a single run instead of watch mode

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -38,6 +38,24 @@ describe('isTestWatchMode', () => {
     expect(result).toBeFalsy();
   });
 
+  it('should return false for vitest run', () => {
+    const result = isTestWatchMode(['run']);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for vitest run with a file filter', () => {
+    const result = isTestWatchMode(['run', 'src/example.spec.ts']);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return true for a file filter that contains run', () => {
+    const result = isTestWatchMode(['src/run-helpers.spec.ts']);
+
+    expect(result).toBeTruthy();
+  });
+
   it('should return true for vitest --no-run', () => {
     const result = isTestWatchMode(['--no-run']);
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1825,6 +1825,11 @@ export function isTestWatchMode(args = process.argv) {
     return false;
   }
 
+  // vitest run
+  if (args.includes('run')) {
+    return false;
+  }
+
   // vitest --no-run
   const hasNoRun = args.find((arg) => arg.includes('--no-run'));
   if (hasNoRun) {


### PR DESCRIPTION
## PR Checklist

`isTestWatchMode()` only detects the `--run` flag. The `vitest run` subcommand form (common in CI scripts and nx) falls through to `return true`, so one-shot runs keep watch-mode caches and pay extra incremental recompiles when modules are invalidated mid-run (for example by a dep re-optimize).

Closes #2372

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

n/a

## What is the new behavior?

`isTestWatchMode()` also treats an exact `run` argument as a one-shot run. The check uses exact match (`args.includes('run')`), so file filters like `src/run-helpers.spec.ts` are not affected (covered by a test). Watch runs started by nx still resolve to watch mode through the existing OR with `config.server.watch` in `configResolved`.

## Test plan

- [x] `nx format:check`
- [x] `pnpm build` (`nx build-package vite-plugin-angular`, tsc, no errors)
- [x] `pnpm test` (full workspace green; `nx test vite-plugin-angular`: 624 passed, 3 skipped)
- [x] Manual verification: new unit tests for `isTestWatchMode(['run'])` and `isTestWatchMode(['run', 'src/example.spec.ts'])` fail on the old code and pass with the fix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Speed-only fix; no change to compile output.
