### PR TITLE
fix(vite-plugin-angular): remove stale esbuild export

### DIFF
--- a/packages/vite-plugin-angular/package.json
+++ b/packages/vite-plugin-angular/package.json
@@ -80,7 +80,6 @@
       "require": "./src/index.js",
       "default": "./src/index.js"
     },
-    "./esbuild": "./esbuild.js",
     "./setup-vitest": "./setup-vitest.js"
   },
   "publishConfig": {


### PR DESCRIPTION
## PR Checklist

Removes the stale `./esbuild` subpath export from `@analogjs/vite-plugin-angular`. The package build only emits the main entry point and `setup-vitest`, so the current export points at a file that is not produced or packaged.

External report: https://github.com/charles-openclaw/charles-microbounties/issues/1289

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

`@analogjs/vite-plugin-angular` no longer advertises `./esbuild` as an exported subpath. This avoids resolving `@analogjs/vite-plugin-angular/esbuild` to a missing `esbuild.js` file in the published package.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [x] Manual verification

Manual verification performed:

- `node -e "const p=require('./packages/vite-plugin-angular/package.json'); if (p.exports['./esbuild']) throw new Error('./esbuild export still present'); for (const key of ['.','./setup-vitest','./package.json']) if (!p.exports[key]) throw new Error('missing export '+key); console.log('manifest exports ok:', Object.keys(p.exports).join(', '));"`
- `npm pack --dry-run --ignore-scripts --json .\packages\vite-plugin-angular`
- `git diff --check`

Full Nx build/test were not run because this is a package-manifest-only export removal and dependencies were not installed in the local checkout.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The removed subpath currently resolves to a missing file in the published package, so this fixes stale package metadata rather than removing a working entry point.

## Other information

The latest `3.0.0-alpha.59` package metadata also no longer includes the stale `./esbuild` export.

## [optional] What gif best describes this PR or how it makes you feel?