### PR TITLE
fix(vite-plugin-angular): remove stale esbuild export

### DIFF
--- a/packages/vite-plugin-angular/package.json
+++ b/packages/vite-plugin-angular/package.json
@@ -80,7 +80,6 @@
       "require": "./src/index.js",
       "default": "./src/index.js"
     },
-    "./esbuild": "./esbuild.js",
     "./setup-vitest": "./setup-vitest.js"
   },
   "publishConfig": {
@@ -88,3 +87,4 @@
     "provenance": true
   }
 }
+


### PR DESCRIPTION
## Summary

Removes the stale `./esbuild` subpath export from `@analogjs/vite-plugin-angular`.

The 2.x package manifest currently points `./esbuild` to `./esbuild.js`, but published 2.x packages no longer include that file. Importing `@analogjs/vite-plugin-angular/esbuild` therefore resolves to a missing file and fails with `ERR_MODULE_NOT_FOUND`.

## Notes

- `1.22.5` included `esbuild.js` / `esbuild.d.ts`.
- `2.0.0` through `2.6.1` no longer include those files but still keep the export.
- `3.0.0-alpha.59` no longer exports `./esbuild`.

Fixes #2377.