### PR TITLE
fix(vite-plugin-angular): @Service detection and external styleUrl preprocessing in fastCompile

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -43,7 +43,11 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Download Angular ${{ matrix.angular-major }} compliance fixtures
         run: bash packages/vite-plugin-angular/scripts/setup-conformance.sh ${{ matrix.angular-major }}
-      - name: Run conformance tests
+      - name: Run conformance and upstream-drift tests
         env:
           ANGULAR_SOURCE_DIR: .angular-conformance
-        run: pnpm exec vitest run packages/vite-plugin-angular/src/lib/compiler/conformance.spec.ts
+        run: >-
+          pnpm exec vitest run
+          packages/vite-plugin-angular/src/lib/compiler/conformance.spec.ts
+          packages/vite-plugin-angular/src/lib/compiler/decorator-coverage.spec.ts
+          packages/vite-plugin-angular/src/lib/compiler/signal-api-coverage.spec.ts

--- a/packages/vite-plugin-angular/scripts/setup-conformance.sh
+++ b/packages/vite-plugin-angular/scripts/setup-conformance.sh
@@ -6,8 +6,19 @@
 set -e
 
 if [ -z "$1" ] || [ "$1" = "latest" ]; then
-  # Auto-detect latest release
-  VERSION=$(curl -sL https://api.github.com/repos/angular/angular/releases/latest | grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//')
+  # Latest stable release: highest x.y.z tag (excludes -next/-rc prereleases).
+  # Resolved with `git ls-remote` like the cases below — the unauthenticated
+  # GitHub releases API is rate-limited on shared CI runners and returned an
+  # empty tag, which produced a `git clone --branch ""` failure (exit 128).
+  VERSION=$(git ls-remote --tags https://github.com/angular/angular.git \
+    | grep -oE "refs/tags/v?[0-9]+\.[0-9]+\.[0-9]+$" \
+    | sed 's|refs/tags/||' \
+    | sort -V \
+    | tail -1)
+  if [ -z "$VERSION" ]; then
+    echo "Could not detect latest Angular release"
+    exit 1
+  fi
   echo "Detected latest Angular release: $VERSION"
 elif [ "$1" = "next" ]; then
   # Find the latest -next.N prerelease tag (may have v prefix)

--- a/packages/vite-plugin-angular/scripts/setup-conformance.sh
+++ b/packages/vite-plugin-angular/scripts/setup-conformance.sh
@@ -71,7 +71,12 @@ if ! git clone --depth 1 --branch "$VERSION" --filter=blob:none --sparse \
 fi
 
 cd "$TARGET"
-git sparse-checkout set packages/compiler-cli/test/compliance/test_cases
+# test_cases drives conformance.spec; core/src and the ngtsc initializer-function
+# list are the upstream sources the decorator / signal-API drift detectors read.
+git sparse-checkout set \
+  packages/compiler-cli/test/compliance/test_cases \
+  packages/core/src \
+  packages/compiler-cli/src/ngtsc/annotations/directive/src
 
 echo "Done. $(find packages/compiler-cli/test/compliance/test_cases -name '*.ts' | wc -l | tr -d ' ') test files downloaded."
 echo "Run: ANGULAR_SOURCE_DIR=$TARGET npx vitest run packages/vite-plugin-angular/src/lib/compiler/conformance.spec.ts"

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -63,6 +63,7 @@ import {
 import { routerPlugin } from './router-plugin.js';
 import { createHash } from 'node:crypto';
 import { fastCompilePlugin } from './fast-compile-plugin.js';
+import { ANGULAR_DECORATOR_CALL_RE } from './compiler/index.js';
 import {
   TS_EXT_REGEX,
   createTsConfigGetter,
@@ -623,8 +624,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           }
 
           if (pluginOptions.useAngularCompilationAPI) {
-            const isAngular =
-              /(Component|Directive|Pipe|Injectable|NgModule)\(/.test(code);
+            const isAngular = ANGULAR_DECORATOR_CALL_RE.test(code);
 
             if (!isAngular) {
               return;
@@ -716,7 +716,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           if (!typescriptResult) {
             const isAngular =
               !id.includes('@ng/component') &&
-              /(Component|Directive|Pipe|Injectable|NgModule)\(/.test(code);
+              ANGULAR_DECORATOR_CALL_RE.test(code);
             if (isAngular) {
               this.warn(
                 `[@analogjs/vite-plugin-angular]: "${id}" contains Angular decorators but is not in the TypeScript program. ` +

--- a/packages/vite-plugin-angular/src/lib/compiler/__fixtures__/test.component.less
+++ b/packages/vite-plugin-angular/src/lib/compiler/__fixtures__/test.component.less
@@ -1,0 +1,6 @@
+:host {
+  display: block;
+}
+.wrapper {
+  padding: 1rem;
+}

--- a/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
@@ -2446,6 +2446,33 @@ describe('OXC-based resource inlining', () => {
       expect(styleExtensions.get(0), `extension for .${ext}`).toBe(ext);
     }
   });
+
+  it('merges a singular `styles` string with an external styleUrl without duplicating the key', () => {
+    // Regression: a non-array `styles` (single string/template) plus an
+    // external `styleUrl` must collapse into one `styles` key, and the external
+    // style must be indexed *after* the existing inline style (index 1).
+    const { code, styleExtensions } = inlineResourceUrls(
+      `
+      import { Component } from '@angular/core';
+      @Component({
+        selector: 'app-ext',
+        template: '',
+        styles: \`:host { display: block; }\`,
+        styleUrl: './test.component.scss'
+      })
+      export class ExtComponent {}
+    `,
+      __dirname + '/__fixtures__/test.component.ts',
+    );
+
+    // Exactly one `styles` key — no duplicate object-literal key.
+    expect((code.match(/styles:/g) || []).length).toBe(1);
+    // The original inline style is preserved.
+    expect(code).toContain(':host { display: block; }');
+    // External scss is mapped after the singular inline style.
+    expect(styleExtensions.has(0)).toBe(false);
+    expect(styleExtensions.get(1)).toBe('scss');
+  });
 });
 
 describe.skipIf(!SUPPORTS_DEFER_RUNTIME)(

--- a/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
@@ -2424,6 +2424,28 @@ describe('OXC-based resource inlining', () => {
     expect(styleExtensions.has(0)).toBe(false);
     expect(styleExtensions.get(1)).toBe('scss');
   });
+
+  it('reports the source extension for each preprocessable styleUrl type', () => {
+    // The fast-compile path preprocesses each external style by its own
+    // extension, so every preprocessable style language must be surfaced
+    // distinctly (not collapsed onto a single `inlineStylesExtension`).
+    for (const ext of ['css', 'scss', 'less']) {
+      const { styleExtensions } = inlineResourceUrls(
+        `
+        import { Component } from '@angular/core';
+        @Component({
+          selector: 'app-ext',
+          template: '',
+          styleUrl: './test.component.${ext}'
+        })
+        export class ExtComponent {}
+      `,
+        __dirname + '/__fixtures__/test.component.ts',
+      );
+
+      expect(styleExtensions.get(0), `extension for .${ext}`).toBe(ext);
+    }
+  });
 });
 
 describe.skipIf(!SUPPORTS_DEFER_RUNTIME)(

--- a/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
@@ -2197,7 +2197,7 @@ describe('OXC-based resource inlining', () => {
   }
 
   it('inlines templateUrl via AST rewriting', () => {
-    const result = inlineResourceUrls(
+    const { code: result } = inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2214,7 +2214,7 @@ describe('OXC-based resource inlining', () => {
   });
 
   it('inlines styleUrls via AST rewriting', () => {
-    const result = inlineResourceUrls(
+    const { code: result } = inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2240,12 +2240,12 @@ describe('OXC-based resource inlining', () => {
       })
       export class InlineComponent {}
     `;
-    const result = inlineResourceUrls(src, 'inline.ts');
+    const { code: result } = inlineResourceUrls(src, 'inline.ts');
     expect(result).toBe(src);
   });
 
   it('merges styleUrl into existing inline styles array (no duplicate key)', () => {
-    const result = inlineResourceUrls(
+    const { code: result } = inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2269,7 +2269,7 @@ describe('OXC-based resource inlining', () => {
   });
 
   it('merges styleUrls into existing inline styles array (no duplicate key)', () => {
-    const result = inlineResourceUrls(
+    const { code: result } = inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2290,7 +2290,7 @@ describe('OXC-based resource inlining', () => {
   });
 
   it('merges styleUrl into an existing styles array with a trailing comma without producing a sparse element', () => {
-    const result = inlineResourceUrls(
+    const { code: result } = inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2318,7 +2318,7 @@ describe('OXC-based resource inlining', () => {
   });
 
   it('merges styleUrl into an empty styles array without producing a sparse element', () => {
-    const result = inlineResourceUrls(
+    const { code: result } = inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2364,6 +2364,65 @@ describe('OXC-based resource inlining', () => {
     expect(styles).toHaveLength(2);
     expect(styles[0]).toBe('h1 { color: red }');
     expect(styles[1]).toBe('p { margin: 0 }');
+  });
+
+  it('reports the source extension of an inlined external styleUrl', () => {
+    // Regression: fastCompile must preprocess external `styleUrl`s by their own
+    // file extension (e.g. `.scss`), independent of `inlineStylesExtension`.
+    // `inlineResourceUrls` surfaces each inlined external style's extension at
+    // the flat index that `extractInlineStyles`/`resolvedInlineStyles` use.
+    const { styleExtensions } = inlineResourceUrls(
+      `
+      import { Component } from '@angular/core';
+      @Component({
+        selector: 'app-ext',
+        template: '',
+        styleUrl: './test.component.scss'
+      })
+      export class ExtComponent {}
+    `,
+      __dirname + '/__fixtures__/test.component.ts',
+    );
+
+    expect(styleExtensions.get(0)).toBe('scss');
+  });
+
+  it('reports a css extension for plain external styleUrls', () => {
+    const { styleExtensions } = inlineResourceUrls(
+      `
+      import { Component } from '@angular/core';
+      @Component({
+        selector: 'app-ext',
+        template: '',
+        styleUrls: ['./test.component.css']
+      })
+      export class ExtComponent {}
+    `,
+      __dirname + '/__fixtures__/test.component.ts',
+    );
+
+    expect(styleExtensions.get(0)).toBe('css');
+  });
+
+  it('indexes an external styleUrl after pre-existing inline styles', () => {
+    // Inline `styles: [...]` come first in the flat list; the external scss
+    // styleUrl is appended after it, so it must map to index 1 (not 0).
+    const { styleExtensions } = inlineResourceUrls(
+      `
+      import { Component } from '@angular/core';
+      @Component({
+        selector: 'app-ext',
+        template: '',
+        styles: [\`:host { display: block; }\`],
+        styleUrl: './test.component.scss'
+      })
+      export class ExtComponent {}
+    `,
+      __dirname + '/__fixtures__/test.component.ts',
+    );
+
+    expect(styleExtensions.has(0)).toBe(false);
+    expect(styleExtensions.get(1)).toBe('scss');
   });
 });
 

--- a/packages/vite-plugin-angular/src/lib/compiler/constants.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/constants.ts
@@ -16,6 +16,15 @@ export const ANGULAR_DECORATORS = new Set([
 ]);
 
 /**
+ * Matches a call to any Angular class decorator (e.g. `Component(` or `Service(`).
+ * Derived from {@link ANGULAR_DECORATORS} so the fast-path "is this an Angular file?"
+ * checks stay in sync with the canonical decorator set and don't drift.
+ */
+export const ANGULAR_DECORATOR_CALL_RE = new RegExp(
+  `(${[...ANGULAR_DECORATORS].join('|')})\\(`,
+);
+
+/**
  * Angular decorators that produce compilable declarations (selector, template,
  * pipe name, or module exports).  Excludes `@Injectable` and `@Service`, which
  * self-register via ɵprov and don't need Ivy compilation.

--- a/packages/vite-plugin-angular/src/lib/compiler/decorator-coverage.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/decorator-coverage.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { ANGULAR_DECORATORS } from './constants';
+
+/**
+ * Drift detector against upstream `angular/angular`, mirroring the
+ * compliance-category detector in `conformance.spec.ts` but at the decorator
+ * level.
+ *
+ * The fast-compile path decides "is this an Angular file?" from a fixed set of
+ * class decorators ({@link ANGULAR_DECORATORS}). When Angular ships a new class
+ * decorator (e.g. `@Service` in v22) the set must grow with it — otherwise a
+ * file whose only Angular decorator is the new one is treated as non-Angular,
+ * skipped by the compiler, and silently falls back to JIT at runtime.
+ *
+ * Angular declares class decorators as
+ *   `export const X: XDecorator = makeDecorator(...)`
+ * and member decorators (`@Input`, `@Output`, ...) via `makePropDecorator`.
+ * Only the former trigger Ivy class compilation, so only the former belong in
+ * `ANGULAR_DECORATORS`.
+ */
+const ANGULAR_ROOT =
+  process.env.ANGULAR_SOURCE_DIR ||
+  path.resolve(process.env.HOME ?? '', 'projects/angular/angular');
+const CORE_SRC = path.join(ANGULAR_ROOT, 'packages/core/src');
+
+const CLASS_DECORATOR_RE =
+  /export const (\w+)\s*(?::[^=\n]*)?=\s*makeDecorator\b/g;
+
+function collectClassDecorators(dir: string): Set<string> {
+  const names = new Set<string>();
+  const walk = (current: string) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (
+        entry.name.endsWith('.ts') &&
+        !entry.name.endsWith('.d.ts') &&
+        !entry.name.endsWith('.spec.ts')
+      ) {
+        const code = fs.readFileSync(full, 'utf-8');
+        if (!code.includes('makeDecorator')) continue;
+        for (const match of code.matchAll(CLASS_DECORATOR_RE)) {
+          names.add(match[1]);
+        }
+      }
+    }
+  };
+  walk(dir);
+  return names;
+}
+
+describe.skipIf(!fs.existsSync(CORE_SRC))(
+  'Angular class decorator coverage',
+  () => {
+    it('ANGULAR_DECORATORS covers every class decorator @angular/core ships', () => {
+      const upstream = collectClassDecorators(CORE_SRC);
+
+      // Guard against a vacuous pass: if the upstream layout changed and the
+      // scan matched nothing, fail loudly instead of silently "covering" an
+      // empty set. `Component`/`Injectable` exist in every supported version.
+      expect(
+        upstream.has('Component') && upstream.has('Injectable'),
+        `Found no Angular class decorators under ${CORE_SRC}; the upstream ` +
+          `\`makeDecorator\` layout likely changed — update this detector.`,
+      ).toBe(true);
+
+      const missing = [...upstream].filter((d) => !ANGULAR_DECORATORS.has(d));
+
+      expect(
+        missing,
+        `@angular/core declares class decorator(s) the fast compiler does not ` +
+          `detect: [${missing.join(', ')}]. Add them to ANGULAR_DECORATORS in ` +
+          `compiler/constants.ts — the fast-compile "is this Angular?" gate and ` +
+          `the registry scan derive from it, so files using only those ` +
+          `decorators would be treated as non-Angular and skipped.`,
+      ).toEqual([]);
+    });
+  },
+);

--- a/packages/vite-plugin-angular/src/lib/compiler/decorator-coverage.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/decorator-coverage.spec.ts
@@ -1,34 +1,38 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { ANGULAR_DECORATORS } from './constants';
+import {
+  ANGULAR_DECORATORS,
+  COMPILABLE_DECORATORS,
+  FIELD_DECORATORS,
+} from './constants';
 
 /**
- * Drift detector against upstream `angular/angular`, mirroring the
+ * Drift detectors against upstream `angular/angular`, mirroring the
  * compliance-category detector in `conformance.spec.ts` but at the decorator
  * level.
  *
- * The fast-compile path decides "is this an Angular file?" from a fixed set of
- * class decorators ({@link ANGULAR_DECORATORS}). When Angular ships a new class
- * decorator (e.g. `@Service` in v22) the set must grow with it — otherwise a
- * file whose only Angular decorator is the new one is treated as non-Angular,
- * skipped by the compiler, and silently falls back to JIT at runtime.
+ * The fast-compile path decides "is this an Angular file?" and which class
+ * members to extract from fixed sets of decorator names. When Angular ships a
+ * new decorator (e.g. `@Service` in v22) the relevant set must grow with it —
+ * otherwise a class/member using only the new decorator is silently skipped.
  *
  * Angular declares class decorators as
  *   `export const X: XDecorator = makeDecorator(...)`
- * and member decorators (`@Input`, `@Output`, ...) via `makePropDecorator`.
- * Only the former trigger Ivy class compilation, so only the former belong in
- * `ANGULAR_DECORATORS`.
+ * and member decorators (`@Input`, `@Output`, `@ViewChild`, ...) as
+ *   `export const X: XDecorator = makePropDecorator(...)`
+ * so the factory name selects which set we extract.
  */
 const ANGULAR_ROOT =
   process.env.ANGULAR_SOURCE_DIR ||
   path.resolve(process.env.HOME ?? '', 'projects/angular/angular');
 const CORE_SRC = path.join(ANGULAR_ROOT, 'packages/core/src');
 
-const CLASS_DECORATOR_RE =
-  /export const (\w+)\s*(?::[^=\n]*)?=\s*makeDecorator\b/g;
-
-function collectClassDecorators(dir: string): Set<string> {
+function collectDeclarations(dir: string, factory: string): Set<string> {
+  const re = new RegExp(
+    `export const (\\w+)\\s*(?::[^=\\n]*)?=\\s*${factory}\\b`,
+    'g',
+  );
   const names = new Set<string>();
   const walk = (current: string) => {
     for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
@@ -41,10 +45,8 @@ function collectClassDecorators(dir: string): Set<string> {
         !entry.name.endsWith('.spec.ts')
       ) {
         const code = fs.readFileSync(full, 'utf-8');
-        if (!code.includes('makeDecorator')) continue;
-        for (const match of code.matchAll(CLASS_DECORATOR_RE)) {
-          names.add(match[1]);
-        }
+        if (!code.includes(factory)) continue;
+        for (const match of code.matchAll(re)) names.add(match[1]);
       }
     }
   };
@@ -53,22 +55,20 @@ function collectClassDecorators(dir: string): Set<string> {
 }
 
 describe.skipIf(!fs.existsSync(CORE_SRC))(
-  'Angular class decorator coverage',
+  'Angular decorator coverage (upstream drift)',
   () => {
     it('ANGULAR_DECORATORS covers every class decorator @angular/core ships', () => {
-      const upstream = collectClassDecorators(CORE_SRC);
+      const upstream = collectDeclarations(CORE_SRC, 'makeDecorator');
 
-      // Guard against a vacuous pass: if the upstream layout changed and the
-      // scan matched nothing, fail loudly instead of silently "covering" an
-      // empty set. `Component`/`Injectable` exist in every supported version.
+      // Guard against a vacuous pass: if the scan matched nothing the upstream
+      // layout changed. `Component`/`Injectable` exist in every version.
       expect(
         upstream.has('Component') && upstream.has('Injectable'),
-        `Found no Angular class decorators under ${CORE_SRC}; the upstream ` +
+        `No class decorators found under ${CORE_SRC}; the upstream ` +
           `\`makeDecorator\` layout likely changed — update this detector.`,
       ).toBe(true);
 
       const missing = [...upstream].filter((d) => !ANGULAR_DECORATORS.has(d));
-
       expect(
         missing,
         `@angular/core declares class decorator(s) the fast compiler does not ` +
@@ -78,5 +78,37 @@ describe.skipIf(!fs.existsSync(CORE_SRC))(
           `decorators would be treated as non-Angular and skipped.`,
       ).toEqual([]);
     });
+
+    it('FIELD_DECORATORS covers every member decorator @angular/core ships', () => {
+      const upstream = collectDeclarations(CORE_SRC, 'makePropDecorator');
+
+      expect(
+        upstream.has('Input') && upstream.has('Output'),
+        `No member decorators found under ${CORE_SRC}; the upstream ` +
+          `\`makePropDecorator\` layout likely changed — update this detector.`,
+      ).toBe(true);
+
+      const missing = [...upstream].filter((d) => !FIELD_DECORATORS.has(d));
+      expect(
+        missing,
+        `@angular/core declares member decorator(s) the fast compiler does not ` +
+          `extract: [${missing.join(', ')}]. Add them to FIELD_DECORATORS in ` +
+          `compiler/constants.ts, or their host bindings / queries are dropped.`,
+      ).toEqual([]);
+    });
   },
 );
+
+describe('Angular decorator set consistency', () => {
+  it('COMPILABLE_DECORATORS is a subset of ANGULAR_DECORATORS', () => {
+    const notAngular = [...COMPILABLE_DECORATORS].filter(
+      (d) => !ANGULAR_DECORATORS.has(d),
+    );
+    expect(notAngular).toEqual([]);
+  });
+
+  it('excludes @Injectable / @Service from COMPILABLE_DECORATORS (they self-register via ɵprov)', () => {
+    expect(COMPILABLE_DECORATORS.has('Injectable')).toBe(false);
+    expect(COMPILABLE_DECORATORS.has('Service')).toBe(false);
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/compiler/index.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/index.ts
@@ -1,4 +1,5 @@
 export { compile, type CompileResult, type CompileOptions } from './compile.js';
+export { ANGULAR_DECORATORS, ANGULAR_DECORATOR_CALL_RE } from './constants.js';
 export {
   scanFile,
   type RegistryEntry,

--- a/packages/vite-plugin-angular/src/lib/compiler/resource-inliner.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/resource-inliner.ts
@@ -4,30 +4,65 @@ import { parseSync } from 'oxc-parser';
 import MagicString from 'magic-string';
 import { extractInlineStyles as extractStylesFromAst } from './style-ast.js';
 
+export interface InlineResourceResult {
+  /** The modified source code, or the original if no changes were needed. */
+  code: string;
+  /**
+   * Source extension (without the leading dot, lower-cased — e.g. `scss`) of
+   * each inlined external style, keyed by its position in the flat per-file
+   * style list produced by {@link extractInlineStyles}. Lets the caller run
+   * each external `styleUrl` through the right preprocessor by its own file
+   * extension, independent of the `inlineStylesExtension` option (which governs
+   * truly-inline `styles: [...]` template strings).
+   */
+  styleExtensions: Map<number, string>;
+}
+
+/** Count the elements of a `styles: [...]` array that {@link extractInlineStyles} would emit. */
+function countInlineStyleLiterals(arrayExpr: any): number {
+  let count = 0;
+  for (const el of arrayExpr.elements ?? []) {
+    if (el?.type === 'Literal' && typeof el.value === 'string') count++;
+    else if (el?.type === 'TemplateLiteral' && el.quasis?.length === 1) count++;
+  }
+  return count;
+}
+
 /**
  * Inline external templateUrl and styleUrl/styleUrls into the source code
  * using OXC parser for precise AST-based rewriting.
  *
  * Replaces:
  *   templateUrl: './file.html'  →  template: "...file contents..."
- *   styleUrl: './file.css'      →  styles: ["...file contents..."]
- *   styleUrls: ['./a.css']      →  styles: ["...contents..."]
+ *   styleUrl: './file.scss'     →  styles: ["...file contents..."]
+ *   styleUrls: ['./a.scss']     →  styles: ["...contents..."]
  *
  * When the decorator already has a `styles: [...]` array, inlined CSS is
  * merged into that existing array instead of emitting a second `styles`
  * property (which would be a duplicate object literal key).
  *
- * Returns the modified source code, or the original if no changes were needed.
+ * Returns the modified source code plus the per-style-index extension map
+ * (see {@link InlineResourceResult}).
  */
-export function inlineResourceUrls(code: string, fileName: string): string {
+export function inlineResourceUrls(
+  code: string,
+  fileName: string,
+): InlineResourceResult {
+  const styleExtensions = new Map<number, string>();
+
   if (!code.includes('templateUrl') && !code.includes('styleUrl')) {
-    return code;
+    return { code, styleExtensions };
   }
 
   const { program } = parseSync(fileName, code);
   const ms = new MagicString(code);
   let changed = false;
   const dir = path.dirname(fileName);
+
+  // Running base index into the flat per-file style list (matching the order
+  // `extractInlineStyles` walks classes/decorators/properties) so external
+  // styles can be mapped to the index `resolvedInlineStyles` later keys on.
+  let flatStyleBase = 0;
 
   for (const node of program.body) {
     const decl =
@@ -57,11 +92,22 @@ export function inlineResourceUrls(code: string, fileName: string): string {
         }
       }
 
+      // Inline `styles: [...]` entries already present come first in the flat
+      // list; appended external styles follow them.
+      const existingInlineCount = existingStylesArray
+        ? countInlineStyleLiterals(existingStylesArray)
+        : 0;
+
       // Collect the props we want to rewrite. Contents from styleUrl /
       // styleUrls are accumulated so that multiple url-based props in one
-      // decorator collapse into a single `styles` array write.
+      // decorator collapse into a single `styles` array write. `extensions`
+      // tracks each content's source extension in the same order.
       const templateUrlRewrites: Array<{ prop: any; content: string }> = [];
-      const cssProps: Array<{ prop: any; contents: string[] }> = [];
+      const cssProps: Array<{
+        prop: any;
+        contents: string[];
+        extensions: string[];
+      }> = [];
 
       for (const prop of arg.properties) {
         if (prop.type !== 'Property') continue;
@@ -91,7 +137,11 @@ export function inlineResourceUrls(code: string, fileName: string): string {
           try {
             const filePath = path.resolve(dir, val.value);
             const content = fs.readFileSync(filePath, 'utf-8');
-            cssProps.push({ prop, contents: [content] });
+            cssProps.push({
+              prop,
+              contents: [content],
+              extensions: [extensionOf(filePath)],
+            });
           } catch {
             // Keep original if file can't be read
           }
@@ -100,12 +150,14 @@ export function inlineResourceUrls(code: string, fileName: string): string {
 
         if (key === 'styleUrls' && val?.type === 'ArrayExpression') {
           const contents: string[] = [];
+          const extensions: string[] = [];
           let allRead = true;
           for (const el of val.elements) {
             if (el?.type === 'Literal' && typeof el.value === 'string') {
               try {
                 const filePath = path.resolve(dir, el.value);
                 contents.push(fs.readFileSync(filePath, 'utf-8'));
+                extensions.push(extensionOf(filePath));
               } catch {
                 allRead = false;
                 break;
@@ -113,7 +165,7 @@ export function inlineResourceUrls(code: string, fileName: string): string {
             }
           }
           if (allRead && contents.length > 0) {
-            cssProps.push({ prop, contents });
+            cssProps.push({ prop, contents, extensions });
           }
         }
       }
@@ -129,6 +181,7 @@ export function inlineResourceUrls(code: string, fileName: string): string {
 
       if (cssProps.length > 0) {
         const allContents = cssProps.flatMap((c) => c.contents);
+        const allExtensions = cssProps.flatMap((c) => c.extensions);
 
         if (existingStylesArray) {
           // Filter out null holes in case the source already has a sparse array.
@@ -172,11 +225,26 @@ export function inlineResourceUrls(code: string, fileName: string): string {
           }
         }
         changed = true;
+
+        // The appended external styles occupy the flat indices after any
+        // pre-existing inline styles for this component.
+        const externalBase = flatStyleBase + existingInlineCount;
+        allExtensions.forEach((ext, k) => {
+          if (ext) styleExtensions.set(externalBase + k, ext);
+        });
+        flatStyleBase = externalBase + allContents.length;
+      } else {
+        flatStyleBase += existingInlineCount;
       }
     }
   }
 
-  return changed ? ms.toString() : code;
+  return { code: changed ? ms.toString() : code, styleExtensions };
+}
+
+/** Lower-cased file extension without the leading dot (e.g. `scss`), or `''`. */
+function extensionOf(filePath: string): string {
+  return path.extname(filePath).slice(1).toLowerCase();
 }
 
 /**

--- a/packages/vite-plugin-angular/src/lib/compiler/resource-inliner.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/resource-inliner.ts
@@ -18,6 +18,14 @@ export interface InlineResourceResult {
   styleExtensions: Map<number, string>;
 }
 
+/** Whether a node is an inline style value (string literal or single-quasi template). */
+function isInlineStyleValue(node: any): boolean {
+  return (
+    (node?.type === 'Literal' && typeof node.value === 'string') ||
+    (node?.type === 'TemplateLiteral' && node.quasis?.length === 1)
+  );
+}
+
 /** Count the elements of a `styles: [...]` array that {@link extractInlineStyles} would emit. */
 function countInlineStyleLiterals(arrayExpr: any): number {
   let count = 0;
@@ -80,23 +88,31 @@ export function inlineResourceUrls(
       const arg = expr.arguments?.[0];
       if (!arg || arg.type !== 'ObjectExpression') continue;
 
-      // First pass: locate an existing `styles: [...]` array in the same
-      // decorator. Inlined CSS will be merged into it to avoid duplicate keys.
+      // First pass: locate an existing `styles` property in the same decorator.
+      // Inlined CSS is merged into it — converting a singular string/template
+      // value to an array when needed — to avoid emitting a duplicate `styles`
+      // key.
+      let existingStylesProp: any = null;
       let existingStylesArray: any = null;
       for (const prop of arg.properties) {
         if (prop.type !== 'Property') continue;
         const key: string = prop.key?.name ?? prop.key?.value;
-        if (key === 'styles' && prop.value?.type === 'ArrayExpression') {
-          existingStylesArray = prop.value;
+        if (key === 'styles') {
+          existingStylesProp = prop;
+          if (prop.value?.type === 'ArrayExpression') {
+            existingStylesArray = prop.value;
+          }
           break;
         }
       }
 
-      // Inline `styles: [...]` entries already present come first in the flat
-      // list; appended external styles follow them.
+      // Inline `styles` entries already present come first in the flat list;
+      // appended external styles follow them.
       const existingInlineCount = existingStylesArray
         ? countInlineStyleLiterals(existingStylesArray)
-        : 0;
+        : isInlineStyleValue(existingStylesProp?.value)
+          ? 1
+          : 0;
 
       // Collect the props we want to rewrite. Contents from styleUrl /
       // styleUrls are accumulated so that multiple url-based props in one
@@ -207,6 +223,25 @@ export function inlineResourceUrls(
             ms.appendLeft(existingStylesArray.end - 1, insertion);
           }
 
+          for (const { prop } of cssProps) {
+            removePropertyWithSeparator(ms, code, prop.start, prop.end);
+          }
+        } else if (isInlineStyleValue(existingStylesProp?.value)) {
+          // Singular `styles: '...'` / `styles: \`...\`` — wrap the original
+          // value into an array merged with the inlined styles, then drop the
+          // styleUrl props so only one `styles` key remains.
+          const original = code.slice(
+            existingStylesProp.value.start,
+            existingStylesProp.value.end,
+          );
+          const merged = allContents
+            .map((c) => `, ${JSON.stringify(c)}`)
+            .join('');
+          ms.overwrite(
+            existingStylesProp.value.start,
+            existingStylesProp.value.end,
+            `[${original}${merged}]`,
+          );
           for (const { prop } of cssProps) {
             removePropertyWithSeparator(ms, code, prop.start, prop.end);
           }

--- a/packages/vite-plugin-angular/src/lib/compiler/resource-parity.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/resource-parity.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { compile } from './compile';
+import { inlineResourceUrls } from './resource-inliner';
+import type { ComponentRegistry } from './registry';
+
+/**
+ * Structural guard for the resource-inlining seam that the conformance suite
+ * bypasses (it feeds inline code straight to `compile()`).
+ *
+ * A component authored with external `templateUrl` / `styleUrls` must emit the
+ * exact same Ivy output as the same component authored inline. If the
+ * resource-inlining pipeline ever diverges from the inline path (the class of
+ * bug behind the external-`styleUrl` SCSS regression), the two outputs drift
+ * and this test fails.
+ */
+const FIXTURES = path.join(__dirname, '__fixtures__');
+const ID = path.join(FIXTURES, 'test.component.ts');
+
+function compileSource(src: string): string {
+  const registry: ComponentRegistry = new Map();
+  return compile(inlineResourceUrls(src, ID).code, ID, {
+    registry,
+    useDefineForClassFields: true,
+  }).code;
+}
+
+describe('resource inlining ↔ inline output parity', () => {
+  it('emits identical Ivy for external templateUrl/styleUrls and their inline form', () => {
+    const html = fs.readFileSync(
+      path.join(FIXTURES, 'test.component.html'),
+      'utf-8',
+    );
+    const css = fs.readFileSync(
+      path.join(FIXTURES, 'test.component.css'),
+      'utf-8',
+    );
+
+    const external = `import { Component } from '@angular/core';
+@Component({
+  selector: 'app-parity',
+  templateUrl: './test.component.html',
+  styleUrls: ['./test.component.css'],
+})
+export class ParityComponent {}
+`;
+
+    const inline = `import { Component } from '@angular/core';
+@Component({
+  selector: 'app-parity',
+  template: ${JSON.stringify(html)},
+  styles: [${JSON.stringify(css)}],
+})
+export class ParityComponent {}
+`;
+
+    const externalOut = compileSource(external);
+    const inlineOut = compileSource(inline);
+
+    // Guard against a vacuous pass: real Ivy must have been emitted for both.
+    expect(externalOut).toContain('ɵcmp');
+    expect(externalOut).toContain('ParityComponent');
+
+    expect(externalOut).toBe(inlineOut);
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/compiler/signal-api-coverage.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/signal-api-coverage.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { SIGNAL_APIS } from './constants';
+
+/**
+ * Drift detector for signal / initializer authoring APIs against upstream
+ * `angular/angular`.
+ *
+ * The fast-compile path extracts metadata for signal-based members (inputs,
+ * outputs, queries) by matching the initializer call against {@link SIGNAL_APIS}
+ * (see `metadata.ts`). If Angular adds a new initializer API and the set does
+ * not grow with it, members declared with the new API silently lose their
+ * metadata — broken inputs/outputs/queries at runtime.
+ *
+ * ngtsc's canonical list lives in the `InitializerApiFunction['functionName']`
+ * union, which is the authoritative source the Angular compiler itself uses.
+ */
+const ANGULAR_ROOT =
+  process.env.ANGULAR_SOURCE_DIR ||
+  path.resolve(process.env.HOME ?? '', 'projects/angular/angular');
+const INITIALIZER_FNS_FILE = path.join(
+  ANGULAR_ROOT,
+  'packages/compiler-cli/src/ngtsc/annotations/directive/src/initializer_functions.ts',
+);
+
+function upstreamInitializerApis(): Set<string> {
+  const code = fs.readFileSync(INITIALIZER_FNS_FILE, 'utf-8');
+  const union = code.match(/functionName:\s*([^;]+);/);
+  const names = new Set<string>();
+  if (union) {
+    for (const m of union[1].matchAll(/'([A-Za-z]+)'/g)) names.add(m[1]);
+  }
+  return names;
+}
+
+describe.skipIf(!fs.existsSync(INITIALIZER_FNS_FILE))(
+  'Angular signal/initializer API coverage (upstream drift)',
+  () => {
+    it('SIGNAL_APIS covers every initializer API ngtsc recognizes', () => {
+      const upstream = upstreamInitializerApis();
+
+      // Guard against a vacuous pass if the upstream union shape changed.
+      expect(
+        upstream.has('input') && upstream.has('output'),
+        `No initializer APIs parsed from ${INITIALIZER_FNS_FILE}; the upstream ` +
+          `\`InitializerApiFunction\` shape changed — update this detector.`,
+      ).toBe(true);
+
+      const missing = [...upstream].filter((api) => !SIGNAL_APIS.has(api));
+      expect(
+        missing,
+        `ngtsc recognizes initializer API(s) the fast compiler does not ` +
+          `extract: [${missing.join(', ')}]. Add them to SIGNAL_APIS in ` +
+          `compiler/constants.ts, or signal inputs/outputs/queries declared ` +
+          `with them lose their metadata.`,
+      ).toEqual([]);
+    });
+  },
+);

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 let mockRolldownVersion: string | undefined;
 const mockTransformWithOxc = vi.fn();
 const mockTransformWithEsbuild = vi.fn();
+const mockPreprocessCSS = vi.fn();
 
 vi.mock('vite', async () => {
   const actual = await vi.importActual<typeof import('vite')>('vite');
@@ -17,6 +18,7 @@ vi.mock('vite', async () => {
     transformWithOxc: (...args: unknown[]) => mockTransformWithOxc(...args),
     transformWithEsbuild: (...args: unknown[]) =>
       mockTransformWithEsbuild(...args),
+    preprocessCSS: (...args: unknown[]) => mockPreprocessCSS(...args),
   };
 });
 
@@ -299,6 +301,37 @@ export class MyService {
       ([, , opts]: any[]) => opts?.sourcemap === true,
     );
     expect(sawBypassCall).toBe(false);
+  });
+
+  it('preprocesses an external .scss styleUrl by its own extension when inlineStylesExtension is css', async () => {
+    // Regression: external `.scss` styleUrls must be run through the Sass
+    // preprocessor based on their own file extension — even with the default
+    // `inlineStylesExtension: 'css'`. Without this the inlined SCSS is scoped
+    // but never compiled, so nested rules / `&` silently fail to apply.
+    mockPreprocessCSS.mockResolvedValue({ code: ':host{}\n' });
+    mockTransformWithOxc.mockResolvedValue({ code: '', map: { mappings: '' } });
+
+    const plugin = buildPlugin(); // inlineStylesExtension: 'css'
+    const handler = getTransformHandler(plugin);
+
+    const id = `${__dirname}/compiler/__fixtures__/ext.component.ts`;
+    const code = `
+import { Component } from '@angular/core';
+@Component({ selector: 'app-ext', template: '', styleUrl: './test.component.scss' })
+export class ExtComponent {}
+`;
+    try {
+      await handler.call({ addWatchFile: () => undefined }, code, id);
+    } catch {
+      // The full compile path may throw under the mocked transforms; we only
+      // assert the external scss was sent to the preprocessor as `.scss`.
+    }
+
+    const scssCall = mockPreprocessCSS.mock.calls.find(
+      ([, fakePath]: any[]) =>
+        typeof fakePath === 'string' && fakePath.endsWith('.scss'),
+    );
+    expect(scssCall).toBeDefined();
   });
 });
 

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
@@ -268,6 +268,38 @@ export class XComponent {}
     );
     expect(sawBypassCall).toBe(false);
   });
+
+  it('does not run the bypass strip when the file has only @Service', async () => {
+    // Regression: Angular v22's `@Service` decorator must be detected as an
+    // Angular file so it takes the full compile path (emitting ɵfac/ɵprov)
+    // rather than the strip-only bypass. When skipped, the class is left
+    // without Ivy defs and falls back to the JIT compiler at runtime.
+    const plugin = buildPlugin();
+    const handler = getTransformHandler(plugin);
+
+    const code = `
+import { Service, inject } from '@angular/core';
+@Service({ autoProvided: false })
+export class MyService {
+  private dep = inject(Object);
+}
+`;
+    try {
+      await handler.call(
+        { addWatchFile: () => undefined },
+        code,
+        '/src/app/my.service.ts',
+      );
+    } catch {
+      // The full compile path may throw under the mocked OXC return value;
+      // we only care that the bypass branch was not taken.
+    }
+
+    const sawBypassCall = mockTransformWithOxc.mock.calls.some(
+      ([, , opts]: any[]) => opts?.sourcemap === true,
+    );
+    expect(sawBypassCall).toBe(false);
+  });
 });
 
 describe('fastCompilePlugin transform filter', () => {

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -23,6 +23,7 @@ import {
   generateHmrCode,
   debugCompile,
   debugRegistry,
+  ANGULAR_DECORATOR_CALL_RE,
   type ComponentRegistry,
 } from './compiler/index.js';
 
@@ -266,7 +267,7 @@ export function fastCompilePlugin(
     code: string,
     id: string,
   ): Promise<{ code: string; map: any } | undefined> {
-    if (!/(Component|Directive|Pipe|Injectable|NgModule)\(/.test(code)) {
+    if (!ANGULAR_DECORATOR_CALL_RE.test(code)) {
       // Non-Angular file — strip TS-only syntax ourselves so barrels
       // like `export { Foo, type Bar } from './x'` and other TS-only
       // forms don't leak unstripped to Rolldown. In rolldown-vite the

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -328,24 +328,36 @@ export function fastCompilePlugin(
       return { code: stripped.code, map: stripped.map };
     }
 
-    // Inline external templateUrl/styleUrl(s) into the source before compilation
-    code = inlineResourceUrls(code, id);
+    // Inline external templateUrl/styleUrl(s) into the source before compilation.
+    // `styleExtensions` carries the source extension of each inlined external
+    // style so it can be preprocessed by its own file type (e.g. an external
+    // `.scss` styleUrl) regardless of the `inlineStylesExtension` option.
+    const inlined = inlineResourceUrls(code, id);
+    code = inlined.code;
+    const { styleExtensions } = inlined;
 
-    // Pre-resolve inline styles that need preprocessing (SCSS/Sass/Less)
+    // Pre-resolve inline styles that need preprocessing (SCSS/Sass/Less). Run
+    // whenever a style needs a non-`css` preprocessor — either the configured
+    // `inlineStylesExtension` for truly-inline styles, or an external styleUrl's
+    // own extension.
     let resolvedStyles: Map<string, string> | undefined;
     let resolvedInlineStyles: Map<number, string> | undefined;
 
-    if (pluginOptions.inlineStylesExtension !== 'css') {
+    const inlineExt = pluginOptions.inlineStylesExtension;
+    const styleNeedsPreprocess = (ext: string) => ext !== '' && ext !== 'css';
+
+    if (styleNeedsPreprocess(inlineExt) || styleExtensions.size > 0) {
       const styleStrings = extractInlineStyles(code, id);
 
       if (styleStrings.length > 0) {
         resolvedInlineStyles = new Map();
         for (let i = 0; i < styleStrings.length; i++) {
+          // External styleUrls are preprocessed by their own extension; truly
+          // inline `styles: [...]` fall back to `inlineStylesExtension`.
+          const ext = styleExtensions.get(i) ?? inlineExt;
+          if (!styleNeedsPreprocess(ext)) continue;
           try {
-            const fakePath = id.replace(
-              /\.ts$/,
-              `.inline-${i}.${pluginOptions.inlineStylesExtension}`,
-            );
+            const fakePath = id.replace(/\.ts$/, `.inline-${i}.${ext}`);
             const processed = await preprocessCSS(
               styleStrings[i],
               fakePath,


### PR DESCRIPTION
## PR Checklist

Two related correctness fixes in the `fastCompile` path of `@analogjs/vite-plugin-angular`, plus regression and upstream-drift coverage. No associated issue.

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

> Note: the branch contains two distinct `fix:` commits (`@Service` detection and external-`styleUrl` preprocessing). Squash collapses them into one changelog entry; rebase-merge if you'd prefer a separate entry per fix.

## What is the new behavior?

**1. `@Service` detection in fastCompile**

The fast-path "is this an Angular file?" gate and the registry scan hard-coded a decorator regex (`Component|Directive|Pipe|Injectable|NgModule`) that omitted Angular v22's new `@Service` decorator. A class whose only Angular decorator was `@Service` was treated as non-Angular, stripped of its decorator without Ivy defs, and fell back to the JIT compiler at runtime (`'@angular/compiler' is not available`). The three gates now derive from the canonical `ANGULAR_DECORATORS` set (which already included `Service`) so they can't drift from it again.

**2. External `styleUrl` preprocessing in fastCompile**

fastCompile inlines external `styleUrl`/`styleUrls` into the `styles: []` array but only ran the preprocessor when `inlineStylesExtension !== 'css'`, applying that single global extension to every style. With the default `'css'`, an external `.scss` styleUrl was scoped but never Sass-compiled — nested rules and `&` leaked as invalid CSS and silently failed to apply. `inlineResourceUrls` now reports each inlined external style's source extension, and fastCompile preprocesses each style by its own extension (external styleUrls) or `inlineStylesExtension` (truly-inline `styles`).

**3. Coverage for the gaps the conformance suite (which tests `compile()` directly) bypasses**

- Upstream-drift detectors that fail when Angular ships a new class decorator, member decorator, or signal/initializer API the fast compiler doesn't recognize (sourced from `makeDecorator`/`makePropDecorator` and ngtsc's canonical `InitializerApiFunction` list).
- `COMPILABLE_DECORATORS ⊆ ANGULAR_DECORATORS` consistency.
- External `styleUrl` extension-reporting matrix (css/scss/less).
- Resource↔inline Ivy parity: an external `templateUrl`/`styleUrls` component must emit identical Ivy to its inline form.

## Test plan

- [x] `nx format:check` — ran `prettier --check` on all changed files; clean
- [ ] `pnpm build`
- [x] `pnpm test` — `vite-plugin-angular` suite via vitest: **1203 passed / 21 skipped, 0 failed**; conformance pass-rate unchanged at 92.0%; `tsc -p tsconfig.lib.json` clean
- [x] Manual verification — exercised against a real Angular app (the angular/components docs site) running this plugin in fastCompile mode: confirmed `@Service` classes AOT-compile with `ɵfac`/`ɵprov` (no JIT fallback) and external `.scss` styleUrls compile to flattened, scoped CSS. Each drift detector was verified to fail when a known decorator/API is removed from its set.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The `@Service` fix has been validated downstream via a local `pnpm patch` while this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)