### PR TITLE
fix: reference tsconfig.spec.json from package solution tsconfigs

### DIFF
--- a/packages/content/tsconfig.json
+++ b/packages/content/tsconfig.json
@@ -18,6 +18,9 @@
   "references": [
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ],
   "extends": "../../tsconfig.base.json",

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.lib.prod.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ],
   "compilerOptions": {

--- a/packages/vitest-angular/tsconfig.json
+++ b/packages/vitest-angular/tsconfig.json
@@ -20,6 +20,9 @@
   "references": [
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }


### PR DESCRIPTION
## PR Checklist

Fixes a tsconfig-resolution regression surfaced by vite-ecosystem-ci under Vite 8 / rolldown v1.1.0 (no separate Analog issue — see **Other information** for the failing run). The solution-style `tsconfig.json` of `content`, `router`, and `vitest-angular` did not reference `tsconfig.spec.json`, so under the new tsconfig discovery their test files were no longer owned by the package and resolved against the outermost workspace `tsconfig.json`.

## Affected scope

- Primary scope: `content`
- Secondary scopes: `router`, `vitest-angular`

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A — single, identical config fix applied across three packages for one root cause; squash is fine.

## What is the new behavior?

With `tsconfig.spec.json` referenced from each package's solution `tsconfig.json`, test files (`**/*.spec.ts`, `**/*.test.ts`) are owned by their package again under Vite's new tsconfig discovery (rolldown v1.1.0+). Their compiler options / `paths` now resolve from the intended package config instead of falling through to the outermost workspace `tsconfig.json`. No runtime or public-API change.

## Test plan

- [x] `nx format:check`
- [x] `pnpm build`
- [x] `pnpm test`
- [x] Manual verification

Primary verification is the vite-ecosystem-ci `analogjs` suite, which fails on the linked run without this change and is expected to pass with it. Local `nx format:check` / `pnpm build` / `pnpm test` to be run before merge.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of the Vite 8 / rolldown migration. The trigger is the tsconfig-resolution change shipped in rolldown v1.1.0 (https://github.com/rolldown/rolldown/releases/tag/v1.1.0), which no longer falls back to the nearest `tsconfig.json` and instead selects the config that owns the file (or the outermost one). Failing run before this fix: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/27599464088/job/81596799019

## [optional] What gif best describes this PR or how it makes you feel?
