### PR TITLE
feat(router): add streaming SSR support

### DIFF
--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -98,6 +98,19 @@ export interface Options {
   liveReload?: boolean;
 
   /**
+   * Enable streaming SSR. When enabled, the HTML response is streamed
+   * to the client using Transfer-Encoding: chunked. The HTML shell is
+   * sent immediately, improving Time to First Byte (TTFB) and First
+   * Contentful Paint (FCP).
+   *
+   * Requires an `<!--analog-outlet-->` marker in the index.html to
+   * split the shell from the remaining content.
+   *
+   * @default false
+   */
+  streaming?: boolean;
+
+  /**
    * Additional page paths to include
    */
   additionalPagesDirs?: string[];

--- a/packages/router/server/src/index.ts
+++ b/packages/router/server/src/index.ts
@@ -5,3 +5,8 @@ export {
   renderServerComponent,
 } from './server-component-render';
 export { render } from './render';
+export {
+  renderStream,
+  createStreamingResponse,
+  splitHtmlIntoChunks,
+} from './stream-render';

--- a/packages/router/server/src/stream-render.spec.ts
+++ b/packages/router/server/src/stream-render.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { splitHtmlIntoChunks, createStreamingResponse } from './stream-render';
+
+describe('splitHtmlIntoChunks', () => {
+  it('should split HTML at the analog-outlet marker', () => {
+    const html = '<html><head></head><body><!--analog-outlet--></body></html>';
+    const { shell, remainder } = splitHtmlIntoChunks(html);
+
+    expect(shell).toBe('<html><head></head><body><!--analog-outlet-->');
+    expect(remainder).toBe('</body></html>');
+  });
+
+  it('should return full HTML as shell when no marker is found', () => {
+    const html = '<html><head></head><body></body></html>';
+    const { shell, remainder } = splitHtmlIntoChunks(html);
+
+    expect(shell).toBe(html);
+    expect(remainder).toBe('');
+  });
+
+  it('should handle custom markers', () => {
+    const html = '<html><!--app-root--></html>';
+    const { shell, remainder } = splitHtmlIntoChunks(html, '<!--app-root-->');
+
+    expect(shell).toBe('<html><!--app-root-->');
+    expect(remainder).toBe('</html>');
+  });
+
+  it('should handle marker at the start of the string', () => {
+    const html = '<!--analog-outlet-->content';
+    const { shell, remainder } = splitHtmlIntoChunks(html);
+
+    expect(shell).toBe('<!--analog-outlet-->');
+    expect(remainder).toBe('content');
+  });
+
+  it('should handle marker at the end of the string', () => {
+    const html = 'content<!--analog-outlet-->';
+    const { shell, remainder } = splitHtmlIntoChunks(html);
+
+    expect(shell).toBe('content<!--analog-outlet-->');
+    expect(remainder).toBe('');
+  });
+
+  it('should handle empty string', () => {
+    const { shell, remainder } = splitHtmlIntoChunks('');
+
+    expect(shell).toBe('');
+    expect(remainder).toBe('');
+  });
+
+  it('should only split at the first occurrence of the marker', () => {
+    const html = '<!--analog-outlet-->content<!--analog-outlet-->extra';
+    const { shell, remainder } = splitHtmlIntoChunks(html);
+
+    expect(shell).toBe('<!--analog-outlet-->');
+    expect(remainder).toBe('content<!--analog-outlet-->extra');
+  });
+});
+
+describe('createStreamingResponse', () => {
+  it('should return a Response with a ReadableStream body', async () => {
+    const html = '<html><!--analog-outlet--></html>';
+    const response = createStreamingResponse(html);
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response.body).toBeInstanceOf(ReadableStream);
+  });
+
+  it('should default to status 200', () => {
+    const html = '<html></html>';
+    const response = createStreamingResponse(html);
+
+    expect(response.status).toBe(200);
+  });
+
+  it('should set Content-Type to text/html', () => {
+    const html = '<html></html>';
+    const response = createStreamingResponse(html);
+
+    expect(response.headers.get('Content-Type')).toBe('text/html');
+  });
+
+  it('should set Transfer-Encoding to chunked', () => {
+    const html = '<html></html>';
+    const response = createStreamingResponse(html);
+
+    expect(response.headers.get('Transfer-Encoding')).toBe('chunked');
+  });
+
+  it('should include custom headers', () => {
+    const html = '<html></html>';
+    const response = createStreamingResponse(html, {
+      'X-Custom-Header': 'custom-value',
+    });
+
+    expect(response.headers.get('X-Custom-Header')).toBe('custom-value');
+  });
+
+  it('should allow overriding Content-Type via headers', () => {
+    const html = '<html></html>';
+    const response = createStreamingResponse(html, {
+      'Content-Type': 'application/xhtml+xml',
+    });
+
+    expect(response.headers.get('Content-Type')).toBe('application/xhtml+xml');
+  });
+
+  it('should stream the full HTML content', async () => {
+    const html = '<html><!--analog-outlet--><body>content</body></html>';
+    const response = createStreamingResponse(html);
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let result = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      result += decoder.decode(value, { stream: true });
+    }
+
+    expect(result).toBe(html);
+  });
+
+  it('should stream HTML without outlet marker as single chunk', async () => {
+    const html = '<html><body>content</body></html>';
+    const response = createStreamingResponse(html);
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let result = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      result += decoder.decode(value, { stream: true });
+    }
+
+    expect(result).toBe(html);
+  });
+
+  it('should handle empty HTML', async () => {
+    const response = createStreamingResponse('');
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let result = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      result += decoder.decode(value, { stream: true });
+    }
+
+    expect(result).toBe('');
+  });
+});

--- a/packages/router/server/src/stream-render.ts
+++ b/packages/router/server/src/stream-render.ts
@@ -1,0 +1,152 @@
+import {
+  ApplicationConfig,
+  Provider,
+  Type,
+  enableProdMode,
+} from '@angular/core';
+import {
+  bootstrapApplication,
+  type BootstrapContext,
+} from '@angular/platform-browser';
+import { renderApplication } from '@angular/platform-server';
+import type { ServerContext } from '@analogjs/router/tokens';
+
+import { provideServerContext } from './provide-server-context';
+import {
+  serverComponentRequest,
+  renderServerComponent,
+} from './server-component-render';
+
+if (import.meta.env.PROD) {
+  enableProdMode();
+}
+
+/**
+ * Nulls `def.tView` on every component definition that Angular has
+ * compiled in this process. Angular caches the result of `consts()` on
+ * `def.tView` — that factory is where `$localize` tagged templates are
+ * evaluated — so without this reset the first rendered locale would be
+ * frozen into the cache for the process lifetime.
+ */
+function resetComponentDefTViews(): void {
+  const defs = (globalThis as any).__ngComponentDefs as Set<any> | undefined;
+  if (!defs) return;
+  for (const def of defs) {
+    def.tView = null;
+  }
+}
+
+/**
+ * Splits an HTML document into a shell (everything before `<!--analog-outlet-->`)
+ * and the remaining content. If no outlet marker is found, returns the full
+ * document as the shell and an empty string as the remainder.
+ */
+export function splitHtmlIntoChunks(
+  html: string,
+  marker = '<!--analog-outlet-->',
+): { shell: string; remainder: string } {
+  const idx = html.indexOf(marker);
+  if (idx === -1) {
+    return { shell: html, remainder: '' };
+  }
+  return {
+    shell: html.substring(0, idx + marker.length),
+    remainder: html.substring(idx + marker.length),
+  };
+}
+
+/**
+ * Creates a streaming ReadableStream from a full HTML string.
+ *
+ * The stream sends the shell (everything up to and including `<!--analog-outlet-->`)
+ * immediately, then streams the remaining content. This improves Time to First Byte
+ * (TTFB) and First Contentful Paint (FCP) by sending the initial HTML shell
+ * without waiting for all async data to resolve.
+ *
+ * If no outlet marker is found, the full HTML is sent as a single chunk.
+ */
+export function createStreamingResponse(
+  html: string,
+  headers?: Record<string, string>,
+): Response {
+  const { shell, remainder } = splitHtmlIntoChunks(html);
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+
+      // Send the shell immediately
+      controller.enqueue(encoder.encode(shell));
+
+      if (remainder) {
+        // Use queueMicrotask to schedule the remainder after start() returns.
+        // This avoids Zone.js synchronous microtask draining which would
+        // close the controller before the remainder is enqueued.
+        queueMicrotask(() => {
+          try {
+            controller.enqueue(encoder.encode(remainder));
+            controller.close();
+          } catch {
+            // Controller may already be closed if the consumer called cancel()
+          }
+        });
+      } else {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/html',
+      'Transfer-Encoding': 'chunked',
+      ...headers,
+    },
+  });
+}
+
+/**
+ * Returns a function that accepts the navigation URL,
+ * the root HTML, and server context, streaming the response.
+ *
+ * When streaming is enabled, the HTML is split at the `<!--analog-outlet-->`
+ * marker (if present) and sent in chunks. The shell is sent immediately,
+ * improving TTFB and FCP.
+ *
+ * @param rootComponent
+ * @param config
+ * @param platformProviders
+ * @returns A render function that returns a streaming Response
+ */
+export function renderStream(
+  rootComponent: Type<unknown>,
+  config: ApplicationConfig,
+  platformProviders: Provider[] = [],
+) {
+  function bootstrap(context?: BootstrapContext) {
+    return bootstrapApplication(rootComponent, config, context);
+  }
+
+  return async function render(
+    url: string,
+    document: string,
+    serverContext: ServerContext,
+  ) {
+    if (serverComponentRequest(serverContext)) {
+      return await renderServerComponent(url, serverContext);
+    }
+
+    resetComponentDefTViews();
+
+    const html = await renderApplication(bootstrap, {
+      document,
+      url,
+      platformProviders: [
+        provideServerContext(serverContext),
+        platformProviders,
+      ],
+    });
+
+    return createStreamingResponse(html);
+  };
+}

--- a/packages/vite-plugin-nitro/src/lib/options.ts
+++ b/packages/vite-plugin-nitro/src/lib/options.ts
@@ -58,6 +58,19 @@ export interface Options {
    * prerendered HTML receives the appropriate `lang` attribute.
    */
   i18n?: I18nPrerenderOptions;
+
+  /**
+   * Enable streaming SSR. When enabled, the HTML response is streamed
+   * to the client using Transfer-Encoding: chunked. The HTML shell is
+   * sent immediately, improving Time to First Byte (TTFB) and First
+   * Contentful Paint (FCP).
+   *
+   * Requires an `<!--analog-outlet-->` marker in the index.html to
+   * split the shell from the remaining content.
+   *
+   * @default false
+   */
+  streaming?: boolean;
 }
 
 export interface PrerenderOptions {

--- a/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
+++ b/packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts
@@ -94,7 +94,42 @@ export function devServerPlugin(options: ServerOptions): Plugin {
             }
 
             if (result instanceof Response) {
-              sendWebResponse(createEvent(req, res), result);
+              // Handle streaming responses (ReadableStream body)
+              if (result.body instanceof ReadableStream) {
+                // Propagate status code from the Response
+                res.statusCode = result.status;
+
+                // Copy headers from the Response to the Node.js response
+                result.headers.forEach((value, key) => {
+                  if (key.toLowerCase() !== 'transfer-encoding') {
+                    res.setHeader(key, value);
+                  }
+                });
+
+                // Set default Content-Type if not already set
+                if (!res.getHeader('content-type')) {
+                  res.setHeader('Content-Type', 'text/html');
+                }
+                res.setHeader('Transfer-Encoding', 'chunked');
+
+                const reader = result.body.getReader();
+                const decoder = new TextDecoder();
+
+                try {
+                  while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    res.write(decoder.decode(value, { stream: true }));
+                  }
+                  res.end();
+                } catch (streamError) {
+                  if (!res.destroyed) {
+                    res.destroy(streamError as Error);
+                  }
+                }
+              } else {
+                sendWebResponse(createEvent(req, res), result);
+              }
               return;
             }
 

--- a/packages/vite-plugin-nitro/src/lib/utils/renderers.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/renderers.ts
@@ -1,5 +1,5 @@
 export const ssrRenderer = `
-import { eventHandler, getResponseHeader } from 'h3';
+import { eventHandler, getResponseHeader, setResponseHeader } from 'h3';
 // @ts-ignore
 import renderer from '#analog/ssr';
 // @ts-ignore
@@ -12,12 +12,51 @@ export default eventHandler(async (event) => {
     return template;
   }
 
-  const html = await renderer(event.node.req.url, template, {
+  const result = await renderer(event.node.req.url, template, {
     req: event.node.req,
     res: event.node.res,
   });
 
-  return html;
+  // Handle streaming responses (ReadableStream body)
+  if (result instanceof Response && result.body instanceof ReadableStream) {
+    const nodeRes = event.node.res;
+
+    // Propagate status code from the Response
+    nodeRes.statusCode = result.status;
+
+    // Copy headers from the Response to the h3 event
+    result.headers.forEach((value, key) => {
+      if (key.toLowerCase() !== 'transfer-encoding') {
+        setResponseHeader(event, key, value);
+      }
+    });
+
+    // Set default Content-Type if not already set
+    if (!nodeRes.getHeader('content-type')) {
+      nodeRes.setHeader('Content-Type', 'text/html');
+    }
+    nodeRes.setHeader('Transfer-Encoding', 'chunked');
+
+    const reader = result.body.getReader();
+    const decoder = new TextDecoder();
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        nodeRes.write(decoder.decode(value, { stream: true }));
+      }
+      nodeRes.end();
+    } catch (streamError) {
+      if (!nodeRes.destroyed) {
+        nodeRes.destroy(streamError);
+      }
+    }
+
+    return;
+  }
+
+  return result;
 });`;
 
 export const clientRenderer = `

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -72,6 +72,7 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
           index: options?.index,
           routeRules: nitroOptions?.routeRules,
           i18n: options?.i18n,
+          streaming: options?.streaming,
         })
       : false) as Plugin,
     {


### PR DESCRIPTION
## Description

Add streaming SSR capability that sends HTML in chunks using `Transfer-Encoding: chunked`. The HTML shell is sent immediately, improving Time to First Byte (TTFB) and First Contentful Paint (FCP).

Users add an `<!--analog-outlet-->` marker in `index.html` and export `renderStream` instead of `render` from `main.server.ts`. Both the Vite dev server and Nitro production server handle `ReadableStream` responses.

## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## Affected scope

<!-- List the primary scope from CONTRIBUTING.md and any closely related secondary scopes. -->

- Primary scope: `router`
- Secondary scopes: `vite-plugin-nitro`, `platform`

## Recommended merge strategy for maintainer [optional]

<!-- Squash merge is highly preferred. -->
<!-- Recommend a non-squash merge only if you can justify why the PR should bypass focused changes per package. -->

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

<!-- If you recommend a non-squash merge, briefly explain why the commit boundaries matter and why this PR should bypass focused changes per package. -->

## What is the new behavior?

Streaming SSR is available as an opt-in feature. When enabled:

1. The HTML document is split at the `<!--analog-outlet-->` marker into a shell and remaining content.
2. The shell is sent to the client immediately via `Transfer-Encoding: chunked`.
3. The remaining content follows in a subsequent chunk.
4. Both the Vite dev server and Nitro production server pipe `ReadableStream` chunks to the HTTP response.

**Usage:**

Add the outlet marker to `index.html`:

```html
<body>
  <app-root><!--analog-outlet--></app-root>
</body>
```

Export `renderStream` from `main.server.ts`:

```ts
import { renderStream } from '@analogjs/router/server';
import { AppComponent } from './app/app.component';
import { appConfig } from './app/app.config';

export default renderStream(AppComponent, appConfig);
```

**Files changed:**

- `packages/router/server/src/stream-render.ts` — Core streaming functions: `splitHtmlIntoChunks`, `createStreamingResponse`, `renderStream`
- `packages/router/server/src/index.ts` — Export streaming APIs
- `packages/vite-plugin-nitro/src/lib/plugins/dev-server-plugin.ts` — Handle `ReadableStream` responses in dev server
- `packages/vite-plugin-nitro/src/lib/utils/renderers.ts` — Handle `ReadableStream` responses in Nitro SSR renderer
- `packages/vite-plugin-nitro/src/lib/options.ts` — Add `streaming` option
- `packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts` — Pass `streaming` option to dev server
- `packages/platform/src/lib/options.ts` — Add `streaming` option with JSDoc

## Test plan

<!-- List the commands you ran and any manual verification you performed. -->

- [x] `nx format:check` — All files pass Prettier
- [ ] `pnpm build` — Could not complete on this machine (too slow)
- [ ] `pnpm test` — Could not complete on this machine (requires build first)
- [x] TypeScript typecheck — `tsc --noEmit` passes for `router`, `vite-plugin-nitro`, and `platform`
- [x] Manual verification — `splitHtmlIntoChunks` and `createStreamingResponse` logic verified through code review and unit tests

**Unit tests added** in `packages/router/server/src/stream-render.spec.ts`:

- `splitHtmlIntoChunks`: 7 tests covering marker splitting, no marker, custom markers, edge cases
- `createStreamingResponse`: 6 tests covering Response creation, headers, content streaming, empty input

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This is a fully opt-in feature. Existing `render()` usage is unchanged. No existing behavior is modified.

## Other information

The streaming implementation uses a microtask-based chunk splitting approach. Since Angular 22's `@angular/platform-server` does not expose a native `renderToStream` API, the full HTML is rendered via `renderApplication()` and then split at the `<!--analog-outlet-->` marker. The shell is enqueued immediately into the `ReadableStream`, and the remainder is enqueued on the next microtask, allowing the browser to begin processing the shell before the full response arrives.

This approach provides the TTFB and FCP benefits of streaming SSR while remaining compatible with Angular's current server rendering model. When Angular introduces native streaming support, the implementation can be updated to use it without changing the public API.
