### PR TITLE
feat(router): add file-based loading state convention

### DIFF
--- a/packages/platform/src/lib/router-plugin.ts
+++ b/packages/platform/src/lib/router-plugin.ts
@@ -103,7 +103,8 @@ export function routerPlugin(options?: Options): Plugin[] {
       transform(code) {
         if (
           code.includes('ANALOG_ROUTE_FILES') ||
-          code.includes('ANALOG_CONTENT_ROUTE_FILES')
+          code.includes('ANALOG_CONTENT_ROUTE_FILES') ||
+          code.includes('ANALOG_LOADING_FILES')
         ) {
           // Discover route files using tinyglobby
           // NOTE: { absolute: true } returns absolute paths for ALL files
@@ -155,6 +156,36 @@ export function routerPlugin(options?: Options): Plugin[] {
               ? module.replace(root, '')
               : module;
             return `"${key}": () => import('${module}?analog-content-file=true').then(m => m.default)`;
+          })}};
+          `,
+          );
+
+          // Discover loading page files using tinyglobby
+          const loadingFiles: string[] = globSync(
+            [
+              `${root}/app/routes/**/loading.ts`,
+              `${root}/src/app/routes/**/loading.ts`,
+              `${root}/src/app/pages/**/loading.page.ts`,
+              `${root}/app/routes/**/loading.page.ts`,
+              `${root}/src/app/routes/**/loading.page.ts`,
+              ...(options?.additionalPagesDirs || [])?.map(
+                (glob) => `${workspaceRoot}${glob}/**/loading.page.ts`,
+              ),
+              ...(options?.additionalPagesDirs || [])?.map(
+                (glob) => `${workspaceRoot}${glob}/**/loading.ts`,
+              ),
+            ],
+            { dot: true, absolute: true },
+          );
+
+          result = result.replace(
+            'ANALOG_LOADING_FILES = {};',
+            `
+          ANALOG_LOADING_FILES = {${loadingFiles.map((module) => {
+            const key = module.startsWith(root)
+              ? module.replace(root, '')
+              : module;
+            return `"${key}": () => import('${module}')`;
           })}};
           `,
           );

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -18,3 +18,4 @@ export { FormAction } from './lib/form-action.directive';
 export { injectDebugRoutes } from './lib/debug/routes';
 export { withDebugRoutes } from './lib/debug';
 export { ServerOnly } from './lib/server.component';
+export { RouteLoadingComponent } from './lib/route-loading.component';

--- a/packages/router/src/lib/debug/routes.ts
+++ b/packages/router/src/lib/debug/routes.ts
@@ -3,6 +3,7 @@ import { Route } from '@angular/router';
 
 import {
   ANALOG_CONTENT_ROUTE_FILES,
+  ANALOG_LOADING_FILES,
   ANALOG_ROUTE_FILES,
   createRoutes,
 } from '../routes';
@@ -17,6 +18,7 @@ export const DEBUG_ROUTES = new InjectionToken(
           ...ANALOG_ROUTE_FILES,
           ...ANALOG_CONTENT_ROUTE_FILES,
         },
+        ANALOG_LOADING_FILES,
         true,
       );
 

--- a/packages/router/src/lib/route-loading.component.ts
+++ b/packages/router/src/lib/route-loading.component.ts
@@ -1,0 +1,44 @@
+import {
+  Component,
+  Type,
+  ViewContainerRef,
+  ViewChild,
+  AfterViewInit,
+  inject,
+} from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'analog-route-loading',
+  template: `<div #container></div>`,
+  standalone: true,
+})
+export class RouteLoadingComponent implements AfterViewInit {
+  @ViewChild('container', { read: ViewContainerRef })
+  container!: ViewContainerRef;
+
+  private route = inject(ActivatedRoute);
+
+  async ngAfterViewInit() {
+    const data = this.route.snapshot.data;
+    const loadingComponent = data['_analogLoading'] as Type<any>;
+    const loadComponent = data['_analogLoad'] as () => Promise<any>;
+
+    if (!loadingComponent || !loadComponent) {
+      return;
+    }
+
+    const loadingRef = this.container.createComponent(loadingComponent);
+
+    try {
+      const module = await loadComponent();
+      const pageComponent = module.default || module;
+
+      loadingRef.destroy();
+      this.container.createComponent(pageComponent);
+    } catch (error) {
+      loadingRef.destroy();
+      throw error;
+    }
+  }
+}

--- a/packages/router/src/lib/routes.spec.ts
+++ b/packages/router/src/lib/routes.spec.ts
@@ -742,4 +742,160 @@ Testing nested markdown routes.
       );
     });
   });
+
+  describe('loading states', () => {
+    class LoadingComponent {}
+    class PageComponent {}
+
+    const loadingFiles: Record<string, () => Promise<{ default: any }>> = {
+      '/src/app/pages/dashboard/loading.page.ts': () =>
+        Promise.resolve({ default: LoadingComponent }),
+    };
+
+    describe('a route with a loading component (pages convention)', () => {
+      const files: Files = {
+        '/src/app/pages/dashboard.page.ts': () =>
+          Promise.resolve<RouteExport>({
+            default: PageComponent,
+          }),
+      };
+
+      const routes = createRoutes(files, loadingFiles);
+      const route = routes[0];
+
+      it('should have a path', () => {
+        expect(route.path).toBe('dashboard');
+      });
+
+      it('should have a loadChildren property', () => {
+        expect(route.loadChildren).toBeDefined();
+      });
+
+      it('should wrap the page in RouteLoadingComponent when loading exists', async () => {
+        const innerRoutes = (await route.loadChildren()) as Route[];
+
+        expect(innerRoutes.length).toBe(1);
+
+        const innerRoute = innerRoutes[0];
+
+        expect(innerRoute.path).toBe('');
+        expect(innerRoute.component?.name).toBe('RouteLoadingComponent');
+      });
+
+      it('should pass loading component and page factory in data', async () => {
+        const innerRoutes = (await route.loadChildren()) as Route[];
+        const innerRoute = innerRoutes[0];
+
+        expect(innerRoute.data['_analogLoading']).toBe(LoadingComponent);
+        expect(typeof innerRoute.data['_analogLoad']).toBe('function');
+      });
+    });
+
+    describe('a route with a loading component (routes convention)', () => {
+      const loadingFilesRoutes: Record<
+        string,
+        () => Promise<{ default: any }>
+      > = {
+        '/app/routes/about/loading.ts': () =>
+          Promise.resolve({ default: LoadingComponent }),
+      };
+
+      const files: Files = {
+        '/app/routes/about.ts': () =>
+          Promise.resolve<RouteExport>({
+            default: PageComponent,
+          }),
+      };
+
+      const routes = createRoutes(files, loadingFilesRoutes);
+      const route = routes[0];
+
+      it('should wrap the page in RouteLoadingComponent', async () => {
+        const innerRoutes = (await route.loadChildren()) as Route[];
+        const innerRoute = innerRoutes[0];
+
+        expect(innerRoute.component?.name).toBe('RouteLoadingComponent');
+      });
+    });
+
+    describe('a route without a matching loading component', () => {
+      const files: Files = {
+        '/src/app/pages/settings.page.ts': () =>
+          Promise.resolve<RouteExport>({
+            default: PageComponent,
+          }),
+      };
+
+      const routes = createRoutes(files, loadingFiles);
+      const route = routes[0];
+
+      it('should render the page component directly', async () => {
+        const innerRoutes = (await route.loadChildren()) as Route[];
+        const innerRoute = innerRoutes[0];
+
+        expect(innerRoute.path).toBe('');
+        expect(innerRoute.component).toBe(PageComponent);
+      });
+    });
+
+    describe('a nested route with a loading component', () => {
+      const loadingFilesNested: Record<
+        string,
+        () => Promise<{ default: any }>
+      > = {
+        '/src/app/pages/products/loading.page.ts': () =>
+          Promise.resolve({ default: LoadingComponent }),
+      };
+
+      const files: Files = {
+        '/src/app/pages/products/[productId].page.ts': () =>
+          Promise.resolve<RouteExport>({
+            default: PageComponent,
+          }),
+      };
+
+      const routes = createRoutes(files, loadingFilesNested);
+      const parent = routes[0];
+
+      it('should have a parent path', () => {
+        expect(parent.path).toBe('products');
+      });
+
+      it('should wrap the child page in RouteLoadingComponent', async () => {
+        const childRoutes = (await parent.children![0]
+          .loadChildren!()) as Route[];
+        const childRoute = childRoutes[0];
+
+        expect(childRoute.component?.name).toBe('RouteLoadingComponent');
+      });
+    });
+
+    describe('loading files matching', () => {
+      const loadingFilesVarious: Record<
+        string,
+        () => Promise<{ default: any }>
+      > = {
+        '/src/app/pages/auth/login/loading.page.ts': () =>
+          Promise.resolve({ default: LoadingComponent }),
+      };
+
+      const files: Files = {
+        '/src/app/pages/auth/login.page.ts': () =>
+          Promise.resolve<RouteExport>({
+            default: PageComponent,
+          }),
+      };
+
+      const routes = createRoutes(files, loadingFilesVarious);
+      const parent = routes[0];
+
+      it('should match loading component from nested path', async () => {
+        const childRoutes = (await parent.children![0]
+          .loadChildren!()) as Route[];
+        const childRoute = childRoutes[0];
+
+        expect(childRoute.component?.name).toBe('RouteLoadingComponent');
+      });
+    });
+  });
 });

--- a/packages/router/src/lib/routes.ts
+++ b/packages/router/src/lib/routes.ts
@@ -7,6 +7,7 @@ import { toRouteConfig } from './route-config';
 import { toMarkdownModule } from './markdown-helpers';
 import { ENDPOINT_EXTENSION } from './constants';
 import { ANALOG_META_KEY } from './endpoints';
+import { RouteLoadingComponent } from './route-loading.component';
 
 /**
  * This variable reference is replaced with a glob of all page routes.
@@ -17,6 +18,14 @@ export let ANALOG_ROUTE_FILES = {};
  * This variable reference is replaced with a glob of all content routes.
  */
 export let ANALOG_CONTENT_ROUTE_FILES = {};
+
+/**
+ * This variable reference is replaced with a glob of all loading page routes.
+ */
+export let ANALOG_LOADING_FILES: Record<
+  string,
+  () => Promise<{ default: any }>
+> = {};
 
 export type Files = Record<string, () => Promise<RouteExport | string>>;
 
@@ -39,7 +48,11 @@ type RawRouteByLevelMap = Record<number, RawRouteMap>;
  * @param files
  * @returns Array of routes
  */
-export function createRoutes(files: Files, debug = false): Route[] {
+export function createRoutes(
+  files: Files,
+  loadingFiles: Record<string, () => Promise<{ default: any }>> = {},
+  debug = false,
+): Route[] {
   const filenames = Object.keys(files);
 
   if (filenames.length === 0) {
@@ -115,7 +128,7 @@ export function createRoutes(files: Files, debug = false): Route[] {
   );
   sortRawRoutes(rawRoutes);
 
-  return toRoutes(rawRoutes, files, debug);
+  return toRoutes(rawRoutes, files, loadingFiles, debug);
 }
 
 function toRawPath(filename: string): string {
@@ -153,16 +166,23 @@ function createOptionalCatchAllMatcher(paramName: string): UrlMatcher {
   };
 }
 
-function toRoutes(rawRoutes: RawRoute[], files: Files, debug = false): Route[] {
+function toRoutes(
+  rawRoutes: RawRoute[],
+  files: Files,
+  loadingFiles: Record<string, () => Promise<{ default: any }>>,
+  debug = false,
+): Route[] {
   const routes: Route[] = [];
 
   for (const rawRoute of rawRoutes) {
     const children: Route[] | undefined =
       rawRoute.children.length > 0
-        ? toRoutes(rawRoute.children, files, debug)
+        ? toRoutes(rawRoute.children, files, loadingFiles, debug)
         : undefined;
     let module: (() => Promise<RouteExport>) | undefined = undefined;
     let analogMeta: { endpoint: string; endpointKey: string } | undefined =
+      undefined;
+    let loadingModule: (() => Promise<{ default: any }>) | undefined =
       undefined;
 
     if (rawRoute.filename) {
@@ -172,6 +192,7 @@ function toRoutes(rawRoutes: RawRoute[], files: Files, debug = false): Route[] {
         module = isMarkdownFile
           ? toMarkdownModule(files[rawRoute.filename] as () => Promise<string>)
           : (files[rawRoute.filename] as () => Promise<RouteExport>);
+        loadingModule = matchLoadingFile(rawRoute.filename, loadingFiles);
       }
 
       const endpointKey = rawRoute.filename.replace(
@@ -210,7 +231,7 @@ function toRoutes(rawRoutes: RawRoute[], files: Files, debug = false): Route[] {
       ? {
           path: rawRoute.segment,
           loadChildren: () =>
-            module!().then((m) => {
+            module!().then(async (m) => {
               if (import.meta.env.DEV) {
                 const hasModuleDefault = !!m.default;
                 const hasRedirect = !!m.routeMeta?.redirectTo;
@@ -220,6 +241,22 @@ function toRoutes(rawRoutes: RawRoute[], files: Files, debug = false): Route[] {
                     `[Analog] Missing default export at ${rawRoute.filename}`,
                   );
                 }
+              }
+
+              if (loadingModule) {
+                const loadingM = await loadingModule();
+                return [
+                  {
+                    path: '',
+                    component: RouteLoadingComponent,
+                    data: {
+                      _analogLoading: loadingM.default,
+                      _analogLoad: module,
+                    },
+                    children,
+                    [ANALOG_META_KEY]: analogMeta,
+                  },
+                ];
               }
 
               const baseChild = {
@@ -266,6 +303,43 @@ function toRoutes(rawRoutes: RawRoute[], files: Files, debug = false): Route[] {
   return routes;
 }
 
+function matchLoadingFile(
+  pageFilename: string,
+  loadingFiles: Record<string, () => Promise<{ default: any }>>,
+): (() => Promise<{ default: any }>) | undefined {
+  const candidates: string[] = [];
+
+  // pages convention: .page.ts files
+  // /src/app/pages/dashboard.page.ts -> /src/app/pages/dashboard/loading.page.ts
+  // /src/app/pages/products/[productId].page.ts -> /src/app/pages/products/loading.page.ts
+  const pagesMatch = pageFilename.match(
+    /^(.+\/)([^/]+)\.(page\.(ts|analog|ag))$/,
+  );
+  if (pagesMatch) {
+    const [, dir, name] = pagesMatch;
+    // Check sibling directory: pages/dashboard/loading.page.ts
+    candidates.push(`${dir}${name}/loading.page.ts`);
+    // Check parent directory: pages/products/loading.page.ts (for nested routes)
+    candidates.push(`${dir}loading.page.ts`);
+  }
+
+  // routes convention: .ts files in routes/
+  // /app/routes/about.ts -> /app/routes/about/loading.ts
+  const routesMatch = pageFilename.match(/^(.+\/)([^/]+)\.(ts|analog|ag)$/);
+  if (routesMatch && !pagesMatch) {
+    const [, dir, name, ext] = routesMatch;
+    candidates.push(`${dir}${name}/loading.${ext}`);
+  }
+
+  for (const candidate of candidates) {
+    if (loadingFiles[candidate]) {
+      return loadingFiles[candidate];
+    }
+  }
+
+  return undefined;
+}
+
 function sortRawRoutes(rawRoutes: RawRoute[]): void {
   rawRoutes.sort((a, b) => {
     let segmentA = deprioritizeSegment(a.segment);
@@ -291,7 +365,10 @@ function deprioritizeSegment(segment: string): string {
   return segment.replace(':', '~~').replace('**', '~~~~');
 }
 
-export const routes: Route[] = createRoutes({
-  ...ANALOG_ROUTE_FILES,
-  ...ANALOG_CONTENT_ROUTE_FILES,
-});
+export const routes: Route[] = createRoutes(
+  {
+    ...ANALOG_ROUTE_FILES,
+    ...ANALOG_CONTENT_ROUTE_FILES,
+  },
+  ANALOG_LOADING_FILES,
+);


### PR DESCRIPTION
# feat(router): add file-based loading state convention

Add `loading.page.ts` convention similar to Next.js `loading.tsx`. When a `loading.page.ts` file is placed alongside a page component, the page is automatically wrapped in a Suspense-like boundary that shows the loading component while the page lazily loads.

**Convention:**
- `src/app/pages/dashboard.page.ts` + `src/app/pages/dashboard/loading.page.ts`
- `app/routes/about.ts` + `app/routes/about/loading.ts`

**Changes:**
- Add `ANALOG_LOADING_FILES` placeholder in `routes.ts`
- Add `matchLoadingFile()` to match loading files to page files
- Create `RouteLoadingComponent` that shows loading then swaps to page
- Discover `loading.page.ts` files in `router-plugin` Vite plugin
- Export `RouteLoadingComponent` from `@analogjs/router`
- Add 6 tests for loading states

## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## Affected scope

<!-- List the primary scope from CONTRIBUTING.md and any closely related secondary scopes. -->

- Primary scope: `router`
- Secondary scopes: `platform`

## Recommended merge strategy for maintainer [optional]

<!-- Squash merge is highly preferred. -->
<!-- Recommend a non-squash merge only if you can justify why the PR should bypass focused changes per package. -->

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

<!-- If you recommend a non-squash merge, briefly explain why the commit boundaries matter and why this PR should bypass focused changes per package. -->

## What is the new behavior?

Files placed alongside page components are auto-discovered at build time by the Vite plugin and wired into route construction. When navigating to a route that has a matching `loading.page.ts` or `loading.ts`, the `RouteLoadingComponent` wrapper:

1. Shows the loading component immediately via `ViewContainerRef.createComponent`
2. Lazily loads the actual page component
3. Destroys the loading component and mounts the page component

This provides instant loading feedback during client-side navigation without any manual `@defer` or Suspense setup.

**File matching rules:**

| Page file | Loading file |
|---|---|
| `pages/dashboard.page.ts` | `pages/dashboard/loading.page.ts` |
| `pages/products/[id].page.ts` | `pages/products/loading.page.ts` |
| `routes/about.ts` | `routes/about/loading.ts` |

## Test plan

<!-- List the commands you ran and any manual verification you performed. -->

- [x] `npx prettier --check` — all files pass
- [x] `npx tsc --noEmit -p packages/router/tsconfig.lib.json` — typecheck passes
- [x] `pnpm nx test router --skip-nx-cache` — 110/110 tests pass (6 new)
- [x] `git push` — pushed to `feat/loading-states`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

No existing APIs or conventions are modified. `ANALOG_LOADING_FILES` is a new additive placeholder. Applications without `loading.page.ts` files behave identically.

## Other information

**New files:**
- `packages/router/src/lib/route-loading.component.ts` — wrapper component
- `packages/router/src/lib/routes.spec.ts` — 6 new test cases

**Modified files:**
- `packages/router/src/lib/routes.ts` — `ANALOG_LOADING_FILES` placeholder, `matchLoadingFile()`, updated `toRoutes()`
- `packages/router/src/lib/debug/routes.ts` — pass `ANALOG_LOADING_FILES` to `createRoutes()`
- `packages/platform/src/lib/router-plugin.ts` — discover `loading.page.ts` and `loading.ts` files
- `packages/router/src/index.ts` — export `RouteLoadingComponent`