### PR TITLE
fix(vite-plugin-angular): emit fastCompile providers referenced by a const

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/compile.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/compile.ts
@@ -125,6 +125,27 @@ function hasExportModifier(node: ts.Node): boolean {
 }
 
 /**
+ * Normalize a `providers` / `viewProviders` metadata value into the single
+ * `o.Expression` Angular's injector/host emitters expect.
+ *
+ * `extractMetadata` stores these as an array of `WrappedNodeExpr` when the
+ * source used an inline array literal (`providers: [A, B]`) — those get
+ * wrapped in a `LiteralArrayExpr`. When the source referenced a const,
+ * spread, or call instead (`providers: safeProviders`), it stores the raw
+ * expression, which is emitted by value. Returns `null` when there is
+ * nothing to emit so callers skip the feature entirely.
+ */
+function providersToExpr(
+  value: o.Expression[] | o.Expression | undefined | null,
+): o.Expression | null {
+  if (!value) return null;
+  if (Array.isArray(value)) {
+    return value.length ? new o.LiteralArrayExpr(value) : null;
+  }
+  return value;
+}
+
+/**
  * Collect identifier names referenced in eagerly-evaluated code only.
  * Skips function/arrow/class bodies so that lazy references
  * (e.g. `const TOKEN = () => LaterClass`) are not treated as dependencies.
@@ -728,12 +749,8 @@ export function compile(
             changeDetection: meta.changeDetection ?? (isPartial ? null : 1),
             encapsulation: meta.encapsulation ?? 0,
             exportAs: meta.exportAs,
-            providers: meta.providers?.length
-              ? new o.LiteralArrayExpr(meta.providers)
-              : null,
-            viewProviders: meta.viewProviders?.length
-              ? new o.LiteralArrayExpr(meta.viewProviders)
-              : null,
+            providers: providersToExpr(meta.providers),
+            viewProviders: providersToExpr(meta.viewProviders),
             animations: meta.animations?.length
               ? new o.LiteralArrayExpr(meta.animations)
               : null,
@@ -885,16 +902,13 @@ export function compile(
             queries: [...fields.contentQueries, ...sigs.contentQueries],
             // Angular's compiler treats `providers` as an Expression and
             // emits `ɵɵProvidersFeature(<expr>)` whenever it is truthy.
-            // Passing the bare JS array of WrappedNodeExpr from
-            // extractMetadata causes the emitter to lower it to `null`,
-            // which then crashes Angular at runtime in `resolveProvider`
-            // because it tries to read `.provide` on `null`. Wrap into a
-            // LiteralArrayExpr (matching the Component branch) so it
-            // emits a real array literal — and pass `null` when there are
-            // no providers so Angular skips the feature entirely.
-            providers: meta.providers?.length
-              ? new o.LiteralArrayExpr(meta.providers)
-              : null,
+            // `providersToExpr` lowers an inline array literal to a
+            // LiteralArrayExpr (matching the Component branch) and passes a
+            // const/spread reference through by value — returning `null`
+            // when there are no providers so Angular skips the feature
+            // entirely. Passing the bare JS array would otherwise be lowered
+            // to `null` and crash Angular at runtime in `resolveProvider`.
+            providers: providersToExpr(meta.providers),
             exportAs: meta.exportAs,
             isStandalone: meta.standalone,
             lifecycle: { usesOnChanges: false },
@@ -1054,9 +1068,7 @@ export function compile(
           const injectorMeta = {
             name: className,
             type: classRef,
-            providers: meta.providers
-              ? new o.LiteralArrayExpr(meta.providers)
-              : null,
+            providers: providersToExpr(meta.providers),
             imports: ngModuleImports.map((e: o.WrappedNodeExpr<any>) => e),
           };
           if (isPartial) {

--- a/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
@@ -284,8 +284,6 @@ export function extractMetadata(
         }
         break;
       case 'imports':
-      case 'providers':
-      case 'viewProviders':
       case 'animations':
       case 'rawImports':
       case 'declarations':
@@ -295,6 +293,28 @@ export function extractMetadata(
           meta[key] = (valNode.elements || []).map(
             (e: any) => new o.WrappedNodeExpr(unwrapForwardRefOxc(e)),
           );
+        }
+        break;
+      case 'providers':
+      case 'viewProviders':
+        if (valNode.type === 'ArrayExpression') {
+          meta[key] = (valNode.elements || []).map(
+            (e: any) => new o.WrappedNodeExpr(unwrapForwardRefOxc(e)),
+          );
+        } else {
+          // `providers: safeProviders` / `viewProviders: SHARED_PROVIDERS`
+          // — a reference to a module-level const (or any non-literal
+          // expression such as a spread or function call) rather than an
+          // inline array literal. ngtsc's partial evaluator expands the
+          // identifier to its array; fastCompile does no static evaluation,
+          // so it cannot. But Angular emits injector/host `providers` as a
+          // single Expression and flattens nested arrays at runtime, so the
+          // reference can be passed through by value. Storing it as a bare
+          // `o.Expression` (not an array) signals the emission sites to emit
+          // it directly instead of wrapping it in a `LiteralArrayExpr`.
+          // Without this, the whole `providers` list is silently dropped and
+          // every token it provides fails at runtime with NG0201.
+          meta[key] = new o.WrappedNodeExpr(valNode);
         }
         break;
       // @Injectable provider configuration. Pass these through to

--- a/packages/vite-plugin-angular/src/lib/compiler/ngmodule.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/ngmodule.spec.ts
@@ -49,6 +49,65 @@ describe('@NgModule', () => {
     expect(result).toContain('MyService');
   });
 
+  it('emits providers referenced by a const identifier instead of an inline array', () => {
+    // `providers: <identifier>` (a module-level const array, common with
+    // helpers like Bitwarden's `safeProvider(...)` collected into a
+    // `safeProviders` const) must be passed through to `ɵɵdefineInjector`
+    // by reference. fastCompile does no static evaluation, so it cannot
+    // expand the identifier the way ngtsc does — but Angular flattens the
+    // expression at runtime. Previously the non-array value was dropped,
+    // emitting `ɵɵdefineInjector({})` and failing every provided token with
+    // NG0201 at runtime.
+    const result = compile(
+      `
+      import { NgModule, Injectable } from '@angular/core';
+
+      @Injectable()
+      export class MyService {}
+
+      const providers = [MyService];
+
+      @NgModule({
+        providers,
+      })
+      export class ServiceModule {}
+    `,
+      'ref-service.module.ts',
+    );
+
+    expectCompiles(result);
+    expect(result).toContain('ɵinj');
+    // The injector definition must reference the const, not be emitted empty.
+    expect(result).toMatch(/ɵɵdefineInjector\(\{\s*providers\b/);
+    expect(result).not.toMatch(/ɵɵdefineInjector\(\{\s*\}\)/);
+  });
+
+  it('emits component providers referenced by a const identifier', () => {
+    const result = compile(
+      `
+      import { Component, Injectable } from '@angular/core';
+
+      @Injectable()
+      export class PanelService {}
+
+      const PANEL_PROVIDERS = [PanelService];
+
+      @Component({
+        selector: 'app-panel',
+        template: '<span>panel</span>',
+        providers: PANEL_PROVIDERS,
+      })
+      export class PanelComponent {}
+    `,
+      'panel.component.ts',
+    );
+
+    expectCompiles(result);
+    // ɵɵProvidersFeature must receive the referenced const, not null.
+    expect(result).toContain('ɵɵProvidersFeature');
+    expect(result).toContain('PANEL_PROVIDERS');
+  });
+
   it('resolves NgModule exports when imported by a component', () => {
     const childSrc = `
       import { Component } from '@angular/core';


### PR DESCRIPTION
## PR Checklist

Fixes a fastCompile bug where an NgModule/component `providers` (or `viewProviders`) value referenced by a const identifier — rather than written as an inline array literal — was silently dropped, so every token it provided failed at runtime with `NG0201: No provider for X`.

Closes #

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: —

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

`extractMetadata` only captured `providers` / `viewProviders` when the decorator value was an inline `ArrayExpression`. When the value was anything else — most commonly a reference to a module-level const, but also a spread or a function call:

```ts
const providers = [
  { provide: FooService, useClass: DefaultFooService, deps: [BarService] },
  // ...
];

@NgModule({ providers })            // ← identifier, not an inline array
export class FeatureModule {}
```

…the value fell through the `if (valNode.type === 'ArrayExpression')` guard and `meta.providers` stayed `null`. The class was then emitted with an empty injector — `ɵɵdefineInjector({})` (or `ɵɵProvidersFeature` skipped for components/directives) — so none of the providers were registered and the first token consumed from them threw `NG0201` at runtime.

`ngtsc`'s partial evaluator resolves such an identifier to its underlying array; fastCompile does no static evaluation, so it can't. But Angular emits injector/host `providers` as a single `Expression` and flattens nested arrays at runtime, so the reference can simply be passed through **by value** — `ɵɵdefineInjector({ providers })` works exactly as written.

Changes:

- `metadata.ts`: split `providers` / `viewProviders` out of the array-only case. For a non-array value, store the raw expression (`new o.WrappedNodeExpr(valNode)`) instead of dropping it. `imports` / `declarations` / `exports` / `bootstrap` / `animations` keep their existing array-only handling (those must be real arrays for NgModule scope/selector resolution, which fastCompile can't synthesize from a reference anyway).
- `compile.ts`: added a shared `providersToExpr()` helper used at all three emission sites (Component, Directive, NgModule injector). It lowers an inline array literal to a `LiteralArrayExpr` (unchanged behavior) and passes a const/spread/call reference through by value, returning `null` when there's nothing to emit so Angular skips the feature.

This is purely additive for the existing inline-array path; only the previously-dropped non-array path changes.

## Test plan

- [x] `nx format:check` (changed files)
- [x] `pnpm test` — `vite-plugin-angular` suite green; added two regression specs in `ngmodule.spec.ts`:
  - NgModule `providers` referenced by a const emits `ɵɵdefineInjector({ providers })`, not `ɵɵdefineInjector({})`.
  - Component `providers` referenced by a const emits `ɵɵProvidersFeature` with the referenced identifier.
- [x] Manual verification — a real application that provides all of its services via a const array consumed by `@NgModule({ providers })` threw `NG0201` at bootstrap with `fastCompile: true` before this change, and boots cleanly with no DI errors after it (the emitted injector goes from `ɵɵdefineInjector({})` to `ɵɵdefineInjector({ providers: <const> })`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Only affects `fastCompile`. The default AOT (`ngtsc`) path was already correct because its partial evaluator expands the identifier.
