### PR TITLE
fix(vite-plugin-angular): cover legacy compliance fixtures + fix surfaced DI emit bugs

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/compile.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/compile.ts
@@ -976,6 +976,9 @@ export function compile(
           if (meta.useFactory) injectableMeta.useFactory = meta.useFactory;
           if (meta.useExisting) injectableMeta.useExisting = meta.useExisting;
           if (meta.useValue) injectableMeta.useValue = meta.useValue;
+          // Dependency list for `useFactory` / `useClass`; without it the
+          // emitted factory is invoked with no arguments.
+          if (meta.deps) injectableMeta.deps = meta.deps;
           if (isPartial) {
             const inj = compileDeclareInjectableFromMetadata(injectableMeta);
             ivyCode.push(

--- a/packages/vite-plugin-angular/src/lib/compiler/conformance.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/conformance.spec.ts
@@ -27,6 +27,13 @@ function expectEmit(
 
   // Normalize both sides
   let normalizedExpected = expected.replace(/\$r3\$/g, 'i0');
+  // Legacy `r3_compiler_compliance` fixtures use a comment-style ellipsis
+  // (`// ...` / inline `/* ... */`) as "match any content here", whereas
+  // newer categories use `…` (U+2026). Fold the legacy form into `…` so the
+  // ellipsis/structural matchers apply to both.
+  normalizedExpected = normalizedExpected
+    .replace(/\/\/\s*\.\.\.[^\n]*/g, ' … ')
+    .replace(/\/\*\s*\.\.\.\s*\*\//g, ' … ');
   const actualNorm = normalizeWs(actual);
   const expectedNorm = normalizeWs(normalizedExpected);
 
@@ -111,6 +118,54 @@ function expectEmit(
       pass: true,
       message: `OK (ellipsis fragments matched in order)`,
     };
+  }
+
+  // Placeholder-aware structural match. Angular's fixtures use `$ident$`
+  // placeholders (e.g. `$ctx$`, `$index$`) to mean "some generated
+  // identifier here" — they are wildcards, not literal text. The looser
+  // per-call heuristics below *delete* them (`$\w+$` → ''), turning
+  // `ɵɵclassMap($ctx$.expr)` into `ɵɵclassMap(.expr)` which then fails to
+  // match the real emit `ɵɵclassMap(ctx.expr)`. Build a regex from the
+  // expected snippet instead: `…` → any run, `$ident$` → an identifier,
+  // everything else literal. A symmetric pre-pass folds away emit-style
+  // differences (arrow vs named render/factory functions, `static ɵcmp =`
+  // vs `Cmp.ɵcmp =`, version-dependent `dom`-prefixed instruction aliases)
+  // so the match is about semantics, not style. Only engages when the
+  // expected actually contains a wildcard, so it cannot loosen exact cases.
+  const structuralMatch = (() => {
+    const canon = (s: string) =>
+      s
+        .replace(/\/\*\s*@__PURE__\s*\*\//g, '')
+        .replace(/\bstatic\s+(ɵ)/g, '$1')
+        .replace(/[A-Za-z_$][\w$]*\.(ɵ[\w$]*\s*=)/g, '$1')
+        .replace(/\bfunction\s+[A-Za-z_$][\w$]*\s*\(/g, '(')
+        .replace(/\bfunction\s*\(/g, '(')
+        .replace(/=>/g, '')
+        .replace(/ɵɵdom([A-Z])/g, (_m, c: string) => 'ɵɵ' + c.toLowerCase());
+    const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const haystack = canon(actualNorm).replace(/\s+/g, '');
+    const e = canon(normalizedExpected);
+    const tokenRe = /…|\$[A-Za-z_][\w$]*\$/g;
+    let pattern = '';
+    let last = 0;
+    let sawWildcard = false;
+    let m: RegExpExecArray | null;
+    while ((m = tokenRe.exec(e)) !== null) {
+      pattern += escapeRe(e.slice(last, m.index).replace(/\s+/g, ''));
+      pattern += m[0] === '…' ? '[\\s\\S]*?' : '[A-Za-z_$][\\w$]*';
+      sawWildcard = true;
+      last = m.index + m[0].length;
+    }
+    if (!sawWildcard) return null; // no wildcards — defer to other paths
+    pattern += escapeRe(e.slice(last).replace(/\s+/g, ''));
+    try {
+      return new RegExp(pattern).test(haystack);
+    } catch {
+      return null;
+    }
+  })();
+  if (structuralMatch) {
+    return { pass: true, message: 'OK (structural placeholder match)' };
   }
 
   const actualAggressive = aggressiveNorm(actualNorm);
@@ -402,8 +457,17 @@ describe.skipIf(!angularAvailable)('Angular Compliance Tests', () => {
                 if (!expectation.files || !Array.isArray(expectation.files))
                   continue;
                 for (const file of expectation.files) {
-                  if (!file?.expected) continue;
-                  const expectedCode = loadFile(group.dir, file.expected);
+                  // Angular expresses the expected-output file two ways: newer
+                  // categories use an object (`{ expected: 'x.js', generated:
+                  // 'x.ts' }`), the older `r3_compiler_compliance` fixtures use
+                  // a bare string (`'x.js'`). Normalize so the legacy string
+                  // form is actually compared instead of silently skipped — it
+                  // was the bare-string shape that hid the `variable_providers`
+                  // (providers-by-const) regression.
+                  const expectedName =
+                    typeof file === 'string' ? file : file?.expected;
+                  if (!expectedName) continue;
+                  const expectedCode = loadFile(group.dir, expectedName);
                   if (!expectedCode) continue;
 
                   const result = expectEmit(compiled, expectedCode);

--- a/packages/vite-plugin-angular/src/lib/compiler/constructor-di.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/constructor-di.spec.ts
@@ -164,4 +164,58 @@ describe('Constructor DI', () => {
     // util is a runtime value, should still be preserved
     expect(result).toContain('util');
   });
+
+  it('injects the attribute name for @Attribute with a string literal', () => {
+    const result = compile(
+      `
+      import { Directive, Attribute } from '@angular/core';
+      @Directive({ selector: '[x]' })
+      export class X { constructor(@Attribute('name') n: string) {} }
+    `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    // The attribute name must reach the factory, not be dropped to null.
+    expect(result).toMatch(/ɵɵinjectAttribute\(\s*["']name["']\s*\)/);
+    expect(result).not.toContain('ɵɵinjectAttribute(null)');
+  });
+
+  it('passes a computed @Attribute name through instead of failing', () => {
+    const result = compile(
+      `
+      import { Directive, Attribute } from '@angular/core';
+      function attrName() { return 'name'; }
+      @Directive({ selector: '[x]' })
+      export class X { constructor(@Attribute(attrName()) n: string) {} }
+    `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    // A non-literal name must not poison the whole factory.
+    expect(result).not.toContain('ɵɵinvalidFactory');
+    expect(result).toMatch(/ɵɵinjectAttribute\(\s*attrName\(\)\s*\)/);
+  });
+
+  it('reads the implementation, not an overload signature, for ctor deps', () => {
+    const result = compile(
+      `
+      import { Injectable, Optional } from '@angular/core';
+      class Dep {}
+      class OptDep {}
+      @Injectable({ providedIn: 'root' })
+      export class X {
+        constructor(dep: Dep);
+        constructor(dep: Dep, @Optional() opt?: OptDep) {}
+      }
+    `,
+      'test.ts',
+    );
+
+    expectCompiles(result);
+    // Both deps must appear — the overload signature only has one.
+    expect(result).toContain('Dep');
+    expect(result).toMatch(/ɵɵinject\(\s*OptDep\s*,\s*8\s*\)/);
+  });
 });

--- a/packages/vite-plugin-angular/src/lib/compiler/injectable.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/injectable.spec.ts
@@ -65,6 +65,29 @@ describe('@Injectable provider configuration', () => {
     expect(result).toMatch(/useFactory|factory:\s*\(\)/);
   });
 
+  it('wires useFactory deps (incl. flag arrays) into the factory', () => {
+    const result = compile(
+      `
+      import { Injectable, Optional } from '@angular/core';
+      class SomeDep {}
+      @Injectable({
+        providedIn: 'root',
+        useFactory: (dep, optional) => new Alt(dep, optional),
+        deps: [SomeDep, [new Optional(), SomeDep]],
+      })
+      export class Alt { constructor(public a: SomeDep, public b: SomeDep | null) {} }
+    `,
+      's.ts',
+    );
+    expectCompiles(result);
+    // Both deps must be injected, the second flagged Optional (8)...
+    expect(result).toMatch(/ɵɵinject\(\s*SomeDep\s*\)/);
+    expect(result).toMatch(/ɵɵinject\(\s*SomeDep\s*,\s*8\s*\)/);
+    // ...and the useFactory arrow must be parenthesized before it is invoked,
+    // so the deps bind to the arrow and not to its body.
+    expect(result).toMatch(/\(\([^)]*\)\s*=>[\s\S]*?\)\(/);
+  });
+
   it('emits useValue in ɵprov', () => {
     const result = compile(
       `

--- a/packages/vite-plugin-angular/src/lib/compiler/injectable.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/injectable.spec.ts
@@ -88,6 +88,51 @@ describe('@Injectable provider configuration', () => {
     expect(result).toMatch(/\(\([^)]*\)\s*=>[\s\S]*?\)\(/);
   });
 
+  it('wires useClass deps into ɵprov', () => {
+    const result = compile(
+      `
+      import { Injectable, Optional } from '@angular/core';
+      class SomeDep {}
+      class Impl { constructor(public dep: SomeDep | null) {} }
+      @Injectable({
+        providedIn: 'root',
+        useClass: Impl,
+        deps: [[new Optional(), SomeDep]],
+      })
+      export class Alt {}
+    `,
+      's.ts',
+    );
+    expectCompiles(result);
+    expect(result).toContain('Impl');
+    expect(result).toMatch(/ɵɵinject\(\s*SomeDep\s*,\s*8\s*\)/);
+  });
+
+  it('unwraps forwardRef tokens in useFactory deps', () => {
+    const result = compile(
+      `
+      import { Injectable, Inject, Optional, forwardRef } from '@angular/core';
+      class TOKEN {}
+      @Injectable({
+        providedIn: 'root',
+        useFactory: (a, b) => new Alt(a, b),
+        deps: [
+          forwardRef(() => TOKEN),
+          [new Optional(), new Inject(forwardRef(() => TOKEN))],
+        ],
+      })
+      export class Alt { constructor(a: unknown, b: unknown) {} }
+    `,
+      's.ts',
+    );
+    expectCompiles(result);
+    // forwardRef must be unwrapped to the bare token, matching constructor DI;
+    // the raw forwardRef(...) call must not reach the factory.
+    expect(result).toMatch(/ɵɵinject\(\s*TOKEN\s*\)/);
+    expect(result).toMatch(/ɵɵinject\(\s*TOKEN\s*,\s*8\s*\)/);
+    expect(result).not.toMatch(/ɵɵinject\(\s*forwardRef/);
+  });
+
   it('emits useValue in ɵprov', () => {
     const result = compile(
       `

--- a/packages/vite-plugin-angular/src/lib/compiler/js-emitter.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/js-emitter.ts
@@ -272,10 +272,16 @@ class JSEmitter implements o.ExpressionVisitor, o.StatementVisitor {
   visitInvokeFunctionExpr(ast: o.InvokeFunctionExpr) {
     const fn = ast.fn.visitExpression(this, null);
     const args = ast.args.map((a: any) => this.emitExpr(a)).join(', ');
-    // Wrap arrow/function expressions in parens for valid IIFE syntax
+    // Wrap arrow/function expressions in parens for valid IIFE syntax. A
+    // `WrappedNodeExpr` callee is a raw user expression (e.g. an
+    // `@Injectable({ useFactory: (a, b) => … })` arrow); without parens the
+    // argument list binds to the arrow's *body* (`… => new X(a, b)(args)`)
+    // instead of invoking the arrow. Parenthesizing any wrapped callee is
+    // always semantically safe.
     if (
       ast.fn instanceof o.ArrowFunctionExpr ||
-      ast.fn instanceof o.FunctionExpr
+      ast.fn instanceof o.FunctionExpr ||
+      ast.fn instanceof o.WrappedNodeExpr
     ) {
       return '(' + fn + ')(' + args + ')';
     }

--- a/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
@@ -907,8 +907,13 @@ function extractInjectableDeps(depsNode: any, sourceCode: string): any[] {
       }
     }
 
-    const tokenStr = tokenNode
-      ? sourceCode.slice(tokenNode.start, tokenNode.end)
+    // Unwrap `forwardRef(() => TOKEN)` to TOKEN so the emitted factory
+    // references the token directly — matching `extractConstructorDeps` and
+    // covering every form (`deps: [forwardRef(...)]`,
+    // `[new Inject(forwardRef(...))]`, `[[new Optional(), forwardRef(...)]]`).
+    const resolvedToken = tokenNode ? unwrapForwardRefOxc(tokenNode) : null;
+    const tokenStr = resolvedToken
+      ? sourceCode.slice(resolvedToken.start, resolvedToken.end)
       : null;
     deps.push({
       token: tokenStr

--- a/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/metadata.ts
@@ -337,6 +337,16 @@ export function extractMetadata(
       case 'useFactory':
         meta[key] = new o.WrappedNodeExpr(valNode);
         break;
+      // `@Injectable({ deps: [...] })` — the dependency list for `useFactory`
+      // / `useClass`. Each entry is either a bare token or a flag array such
+      // as `[new Optional(), new SkipSelf(), Token]`. Without parsing this the
+      // emitted factory ignores the deps and calls the factory/ctor with no
+      // arguments.
+      case 'deps':
+        if (valNode.type === 'ArrayExpression') {
+          meta.deps = extractInjectableDeps(valNode, sourceCode);
+        }
+        break;
       // `@Service` configuration. `autoProvided` defaults to `true`, so only
       // an explicit `false` is meaningful; `factory` is a bare expression
       // forwarded to compileService.
@@ -852,6 +862,68 @@ export function detectFieldDecorators(classNode: any, sourceCode: string) {
  *
  * Accepts an OXC ClassDeclaration node and the original source string.
  */
+/**
+ * Parse an `@Injectable({ deps: [...] })` dependency list into
+ * R3DependencyMetadata. Each element is either a bare token expression or a
+ * flag array combining DI modifiers with the token, e.g.
+ * `[new Optional(), new SkipSelf(), Token]` or `[new Inject(TOKEN)]`.
+ */
+function extractInjectableDeps(depsNode: any, sourceCode: string): any[] {
+  const deps: any[] = [];
+  for (const el of depsNode.elements || []) {
+    if (!el) continue;
+    let tokenNode: any = el;
+    let optional = false,
+      self = false,
+      skipSelf = false,
+      host = false;
+
+    if (el.type === 'ArrayExpression') {
+      // Flag array: zero or more `new <Modifier>()` instances plus the token.
+      tokenNode = null;
+      for (const item of el.elements || []) {
+        if (!item) continue;
+        if (item.type === 'NewExpression') {
+          switch (item.callee?.name) {
+            case 'Optional':
+              optional = true;
+              continue;
+            case 'Self':
+              self = true;
+              continue;
+            case 'SkipSelf':
+              skipSelf = true;
+              continue;
+            case 'Host':
+              host = true;
+              continue;
+            case 'Inject':
+              tokenNode = item.arguments?.[0] ?? null;
+              continue;
+          }
+        }
+        // Bare token (identifier, member expression, `new InjectionToken()`…)
+        tokenNode = item;
+      }
+    }
+
+    const tokenStr = tokenNode
+      ? sourceCode.slice(tokenNode.start, tokenNode.end)
+      : null;
+    deps.push({
+      token: tokenStr
+        ? new o.WrappedNodeExpr(tokenStr)
+        : new o.LiteralExpr(null),
+      attributeNameType: null,
+      host,
+      optional,
+      self,
+      skipSelf,
+    });
+  }
+  return deps;
+}
+
 export function extractConstructorDeps(
   classNode: any,
   sourceCode: string,
@@ -861,9 +933,14 @@ export function extractConstructorDeps(
   const hasSuper = heritage.length > 0;
 
   const members: any[] = classNode.body?.body || [];
-  const ctor = members.find(
+  const ctors = members.filter(
     (m: any) => m.type === 'MethodDefinition' && m.kind === 'constructor',
   );
+  // With overloaded constructors, only the implementation carries the real
+  // parameter list and parameter decorators; the overload *signatures* have
+  // `value.body === null`. Picking the first constructor would read an
+  // overload signature and emit a factory missing the remaining deps.
+  const ctor = ctors.find((m: any) => m.value?.body != null) ?? ctors[0];
 
   if (!ctor) {
     return hasSuper ? null : [];
@@ -875,6 +952,13 @@ export function extractConstructorDeps(
 
   for (const param of params) {
     let token: string | null = null;
+    // For `@Attribute(...)` the injected value is the attribute name itself,
+    // not a type token. `attributeToken` holds that name expression (a string
+    // literal for `@Attribute('name')`, or the raw expression for a computed
+    // name like `@Attribute(dynamicAttrName())`); `attributeNameType` being
+    // non-null flags the dep as an attribute injection so the factory emits
+    // `ɵɵinjectAttribute(<name>)` instead of `ɵɵdirectiveInject(...)`.
+    let attributeToken: any = null;
     let attributeNameType: any = null;
     let host = false,
       optional = false,
@@ -983,15 +1067,23 @@ export function extractConstructorDeps(
           if (args.length > 0) {
             const sv = stringValue(args[0]);
             if (sv !== null) {
+              attributeToken = new o.LiteralExpr(sv);
               attributeNameType = new o.LiteralExpr(sv);
-              token = '';
+            } else {
+              // Computed attribute name, e.g. `@Attribute(dynamicAttrName())`.
+              // ngtsc emits `ɵɵinjectAttribute(<expr>)`; pass the expression
+              // through by value. `attributeNameType` only feeds the (unused)
+              // `.d.ts` type, so a placeholder is sufficient to flag the dep.
+              attributeToken = new o.WrappedNodeExpr(args[0]);
+              attributeNameType = new o.LiteralExpr('unknown');
             }
+            token = '';
           }
           break;
       }
     }
 
-    if (!token && !attributeNameType) {
+    if (!token && !attributeToken) {
       invalid = true;
       continue;
     }
@@ -1002,7 +1094,9 @@ export function extractConstructorDeps(
     }
 
     deps.push({
-      token: token ? new o.WrappedNodeExpr(token) : new o.LiteralExpr(null),
+      token:
+        attributeToken ??
+        (token ? new o.WrappedNodeExpr(token) : new o.LiteralExpr(null)),
       attributeNameType,
       host,
       optional,


### PR DESCRIPTION
## PR Checklist

Broadens fastCompile conformance coverage to the legacy compliance fixtures that were silently skipped, and fixes the real constructor/injectable DI emit bugs that coverage then surfaced.

Closes #

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: —

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

### 1. Conformance: compare the legacy fixtures that were being skipped

The conformance runner only compared expectation files written in the newer object form (`"files": [{ "expected": "x.js" }]`). The older `r3_compiler_compliance` fixtures use a bare-string form (`"files": ["x.js"]`), and the runner's `if (!file?.expected) continue;` silently skipped them — ~80 expectation entries, including `variable_providers`, the fixture that pins the providers-by-const behaviour. Normalizing the two forms re-enables those comparisons.

The legacy fixtures also use a different convention than the matcher assumed, so two matcher improvements come with the un-skip:

- Fold the legacy `// ...` comment-ellipsis into `…`.
- A placeholder-aware structural match: Angular's `$ident$` placeholders (`$ctx$`, `$index$`, …) are identifier wildcards, not literal text — the previous heuristic *deleted* them (`ɵɵclassMap($ctx$.x)` → `ɵɵclassMap(.x)`), which then failed to match the real emit `ɵɵclassMap(ctx.x)`. The new path treats `…` as "skip" and `$ident$` as an identifier, with a symmetric pre-pass that folds away emit-style differences (arrow vs named render/factory functions, `static ɵcmp =` vs `Cmp.ɵcmp =`, version-dependent `dom`-prefixed instruction aliases) so the comparison is about semantics, not style.

A faithful port of Angular's strict `expectEmit` was tried and rejected: because fastCompile's emit legitimately differs from ngtsc's *textually*, an exact ordered-token match floods false failures. A cross-compiler textual comparison is inherently fuzzy, so the suite stays a (non-gating) pass-rate tracker and the real regression guard for each bug below is a focused unit test.

### 2. Fix the DI emit bugs the coverage surfaced

- **Overloaded constructors** — `extractConstructorDeps` read the first constructor, which for an overloaded constructor is a body-less *signature*, dropping every dependency past the first. Pick the implementation (the one with a body).
- **`@Attribute`** — the attribute name was lost: `@Attribute('name')` emitted `ɵɵinjectAttribute(null)`, and a computed name like `@Attribute(fn())` poisoned the entire factory into `ɵɵinvalidFactory()`. Carry the name expression (literal or computed) through as the injected token.
- **`@Injectable({ useFactory, deps })`** — the `deps` list (including flag arrays such as `[new Optional(), Token]`) was never parsed, so the factory ran with no arguments. Parse it into R3 dependency metadata, and parenthesize a `WrappedNodeExpr` call target in the emitter so an inline `useFactory` arrow is actually invoked instead of the argument list binding to its body.

Each fix has unit-test coverage in `constructor-di.spec.ts` / `injectable.spec.ts`.

## Test plan

- [x] `nx format:check` (changed files)
- [x] `pnpm test` — `vite-plugin-angular` green (1206 passing); new specs assert each DI fix
- [x] `pnpm build` — `nx build-package vite-plugin-angular` (tsc) clean
- [x] Manual verification — confirmed the offending fixtures now emit correct Ivy (`ɵɵinjectAttribute("name")`, both overload deps with the `Optional` flag, and a parenthesized `useFactory` arrow invoked with `ɵɵinject(...)` deps)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Conformance pass-rate moves up (no false passes; the deliberately-unsupported `deferred` cases stay red). The remaining surfaced soft-failures were triaged as matcher artifacts (e.g. sanitizers *are* emitted correctly; multi-file query fixtures) or niche unsupported features (`ɵɵregisterNgModuleType`, `ɵɵExternalStylesFeature`), not correctness bugs.
