### PR TITLE
ci: distribute PR pipeline across Nx Agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   NODE_OPTIONS: --max-old-space-size=16384
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_VERBOSE_LOGGING: ${{ vars.NX_VERBOSE_LOGGING }}
   # Lets the coordinator keep handing tasks to already-running agents across the
   # sequential nx commands below instead of re-provisioning between them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   NODE_OPTIONS: --max-old-space-size=16384
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_VERBOSE_LOGGING: ${{ vars.NX_VERBOSE_LOGGING }}
   # Lets the coordinator keep handing tasks to already-running agents across the
   # sequential nx commands below instead of re-provisioning between them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,20 @@ env:
   NODE_OPTIONS: --max-old-space-size=16384
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_VERBOSE_LOGGING: ${{ vars.NX_VERBOSE_LOGGING }}
+  # Lets the coordinator keep handing tasks to already-running agents across the
+  # sequential nx commands below instead of re-provisioning between them.
+  NX_CLOUD_CONTINUOUS_ASSIGNMENT: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  prettier:
+  # Coordinator. Checkout / install / orchestration only — all cacheable Nx work
+  # (lint, build, test, e2e) is distributed to Nx Agents defined in
+  # .nx/workflows/agents.yaml. Prettier stays local (non-Nx) but is recorded so
+  # it shows up in the Nx Cloud run.
+  main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -33,47 +40,47 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Validate
-        run: pnpm run prettier:check
+      # Start the distributed run. Agents are stopped once the last distributed
+      # target (e2e) finishes; the run itself is finalized explicitly so a
+      # failure in any step still records and shuts the run down cleanly.
+      - name: Start CI run
+        run: >
+          pnpm exec nx-cloud start-ci-run
+          --distribute-on="3 analog-linux"
+          --with-env-vars="NX_VERBOSE_LOGGING"
+          --require-explicit-completion
+          --stop-agents-after="e2e"
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: .node-version
-      - run: npm install --global corepack@0.31.0
-      - run: corepack enable
-      - run: pnpm --version
-      - uses: actions/setup-node@v3
-        with:
-          cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
-      - name: Install
-        run: pnpm install --frozen-lockfile --prefer-offline
+      # Non-Nx check: runs on the coordinator, recorded into the Nx Cloud run.
+      - name: Prettier
+        run: pnpm exec nx-cloud record -- pnpm prettier:check
+
+      # Distributed across agents. Kept as separate commands because each target
+      # has a distinct project filter (lint excludes content/platform/router;
+      # build excludes astro-app; e2e is limited to analog-app-e2e/blog-app-e2e),
+      # which a single run-many cannot express. Ordering (test/e2e depend on
+      # build) is modeled by the Nx task graph, so no coordinator-level gating is
+      # needed. --parallel values are preserved as per-agent task concurrency.
       - name: Lint
         run: pnpm exec nx run-many --target lint --all --exclude=content,platform,router
 
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: .node-version
-      - run: npm install --global corepack@0.31.0
-      - run: corepack enable
-      - run: pnpm --version
-      - uses: actions/setup-node@v3
-        with:
-          cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
-      - name: Install
-        run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build
-        run: pnpm build
+        run: pnpm exec nx run-many --target build --all --parallel=1 --exclude=astro-app
 
+      - name: Test
+        run: pnpm exec nx run-many --target test
+
+      - name: E2E
+        run: pnpm exec nx run-many --target e2e --projects=analog-app-e2e,blog-app-e2e --parallel=1
+
+      # Finalize the distributed run regardless of earlier step outcome.
+      - name: Complete CI run
+        if: always()
+        run: pnpm exec nx-cloud complete-ci-run
+
+  # Windows smoke build of the produced output. Left as a native runner job:
+  # it requires a Windows OS plane (not the linux agents) and verifies the
+  # built artifact, so it is genuinely coordinator/provider-local work.
   build-windows:
     runs-on: windows-latest
     steps:
@@ -88,49 +95,3 @@ jobs:
         run: pnpm build
       - name: Verify
         run: more dist\apps\blog-app\analog\public\index.html
-
-  unit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: .node-version
-      - run: npm install --global corepack@0.31.0
-      - run: corepack enable
-      - run: pnpm --version
-      - uses: actions/setup-node@v3
-        with:
-          cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
-      - name: Install
-        run: pnpm install --frozen-lockfile --prefer-offline
-      - name: Install Playwright
-        run: pnpm playwright install --with-deps chromium --only-shell
-      - name: Test
-        run: pnpm test
-
-  e2e:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: .node-version
-      - run: npm install --global corepack@0.31.0
-      - run: corepack enable
-      - run: pnpm --version
-      - uses: actions/setup-node@v3
-        with:
-          cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
-      - name: Install
-        run: pnpm install --frozen-lockfile --prefer-offline
-      - name: Install Playwright
-        run: npx playwright install --with-deps
-      - name: Install Cypress
-        run: npx cypress install
-      - name: End-to-end test
-        run: pnpm e2e

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -1,0 +1,62 @@
+# Nx Agents launch template for the `ci` workflow.
+#
+# A single template is used because every distributed target family (lint,
+# build, test, e2e) can land on any agent, and `test`/`e2e` both need browsers.
+# Each agent is sized to mirror the old single GitHub-hosted `ubuntu-latest`
+# runner (16 GB) so the existing `--max-old-space-size=16384` heap and the
+# per-command `--parallel` values keep the same machine-local semantics.
+launch-templates:
+  analog-linux:
+    # `large` is chosen to match the ~16 GB memory of the old ubuntu-latest
+    # runner that the 16 GB Node heap was tuned for. Verify the exact memory of
+    # this resource class in your Nx Cloud account and adjust if it differs.
+    resource-class: 'docker_linux_amd64/large'
+    image: 'ubuntu22.04-node24.14-v1'
+    env:
+      # The old jobs ran with a 16 GB heap; agents now execute that work, so the
+      # same heap must be set here (the coordinator env does not reach agents).
+      NODE_OPTIONS: '--max-old-space-size=16384'
+    init-steps:
+      - name: Checkout
+        # Checks out the exact commit recorded by `start-ci-run`, keeping agents
+        # and the coordinator on the same SHA.
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+
+      - name: Install Node
+        # Reads `.node-version` (24.11.0). The base image ships Node 24.14, so we
+        # install the pinned version to preserve the old `node-version-file`
+        # behavior. Verify this reusable step picks up `.node-version`; if not,
+        # pass the version explicitly via its inputs.
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node/main.yaml'
+
+      - name: Enable Corepack and pnpm
+        # Mirrors the old jobs' `npm i -g corepack@0.31.0 && corepack enable`.
+        # The pinned corepack version is intentional and must not be bumped here.
+        script: |
+          npm install --global corepack@0.31.0
+          corepack enable
+          pnpm --version
+
+      - name: Restore node_modules cache
+        # Best-effort dependency cache; the install step below is still
+        # authoritative. Verify the key/paths inputs against your Nx Cloud
+        # cache step version before relying on it.
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
+        inputs:
+          key: 'pnpm-lock.yaml'
+          paths: |
+            node_modules
+          base-branch: 'beta'
+
+      - name: Install dependencies
+        script: |
+          pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Install browsers
+        # Agents run both `test` (Vitest + Chromium shell) and `e2e` (Playwright
+        # + Cypress) tasks, so the full browser superset is installed once. This
+        # is heavier than either old job alone but is required because any agent
+        # may receive either task family.
+        script: |
+          pnpm playwright install --with-deps
+          pnpm cypress install


### PR DESCRIPTION
## PR Checklist

Migrates the PR `ci` workflow from manually sharded GitHub-hosted jobs to a single coordinator job that distributes cacheable Nx work across Nx Agents.

Closes #

## Affected scope

- Primary scope: ci
- Secondary scopes: repo (`.nx/workflows/` agent launch template)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

The five Linux PR jobs (`prettier`, `lint`, `build`, `unit`, `e2e`) collapse into one coordinator job that starts an Nx Cloud distributed run and hands the cacheable Nx targets to Nx Agents.

- **New `.nx/workflows/agents.yaml`** — one `analog-linux` launch template (`docker_linux_amd64/large`, `ubuntu22.04-node24.14-v1`, 16 GB Node heap, corepack@0.31.0 + pnpm, Playwright + Cypress browser superset since any agent may run a `test` or `e2e` task).
- **`nx-cloud start-ci-run`** with `--distribute-on="3 analog-linux"`, `--require-explicit-completion`, and `--stop-agents-after="e2e"`; finalized by a guarded `complete-ci-run` (`if: always()`).
- **Dropped the `e2e: needs build` gate** — the Nx task graph already models `test`/`e2e → build` (verified via `nx run-many --graph`), so Nx schedules the ordering.
- **Kept `lint`/`build`/`test`/`e2e` as separate commands** — each has a distinct project filter (lint excludes `content,platform,router`; build excludes `astro-app`; e2e is limited to `analog-app-e2e,blog-app-e2e`) that a single `run-many` cannot express. Per-target `--parallel` values are preserved as per-agent task concurrency.
- **Prettier** (non-Nx) stays on the coordinator, recorded into the run via `nx-cloud record`.
- **`build-windows`** is unchanged — it needs a separate OS plane and verifies the built artifact.

### Maintainer setup required
- Confirm the CI `NX_CLOUD_ACCESS_TOKEN` secret is **read-write** (the token committed in `nx.json` is read-only; agents/DTE need write access to populate the cache).
- Verify the `install-node` reusable step honors `.node-version` (24.11.0) and the `cache` step input signature for your Nx Cloud version.
- Tune agent count (3) / resource class (`large`) after the first run.

## Test plan

- [x] `nx format:check` (prettier passed on changed files)
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

Locally verified: Nx task graph edges (`test`/`e2e → build`), distinct per-target project filters, both YAML files parse, `--stop-agents-after="e2e"` matches a real target. The distributed run itself (agents start, receive tasks, restore cache, shut down) can only be validated by a live CI run — left for CI/maintainer.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

CI-infra only; no package or runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)