### PR TITLE
ci: speed up the Windows build

### DIFF
--- a/.github/workflows/ci-windows-full.yml
+++ b/.github/workflows/ci-windows-full.yml
@@ -1,0 +1,42 @@
+name: ci-windows-full
+
+# Comprehensive Windows build of every project. Kept off the per-PR path: PRs
+# get the fast, scoped blog-app smoke build in ci.yml, while this broad `--all`
+# build runs nightly (and on demand), where latency matters less and the extra
+# Windows coverage is worth it.
+on:
+  schedule:
+    - cron: '0 8 * * *' # nightly, 08:00 UTC
+  workflow_dispatch: {}
+
+env:
+  NODE_OPTIONS: --max-old-space-size=16384
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_VERBOSE_LOGGING: ${{ vars.NX_VERBOSE_LOGGING }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-windows-full:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .node-version
+      - run: corepack enable
+      - uses: actions/setup-node@v3
+        with:
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
+      - name: Install
+        run: pnpm install --frozen-lockfile --prefer-offline
+      # `--skip-nx-cache` forces an actual Windows compile rather than restoring
+      # the OS-independent cache the linux agents populated, so this genuinely
+      # exercises the build on Windows. Mirrors the old `pnpm build` filters.
+      - name: Build
+        run: pnpm exec nx run-many --target build --all --parallel=1 --exclude=astro-app --skip-nx-cache
+      - name: Verify
+        run: more dist\apps\blog-app\analog\public\index.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
   # serially on the slowest runner was wasted time. `--skip-nx-cache` is
   # deliberate: Nx's cache hash is OS-independent, so without it Windows could
   # restore the linux agents' artifacts and never actually compile here,
-  # defeating the smoke test. The broad `--all` Windows build runs nightly and
-  # in the merge queue via ci-windows-full.yml.
+  # defeating the smoke test. The broad `--all` Windows build runs nightly via
+  # ci-windows-full.yml.
   build-windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,16 @@ jobs:
         if: always()
         run: pnpm exec nx-cloud complete-ci-run
 
-  # Windows smoke build of the produced output. Left as a native runner job:
-  # it requires a Windows OS plane (not the linux agents) and verifies the
-  # built artifact, so it is genuinely coordinator/provider-local work.
+  # Windows smoke build. Native runner job (separate OS plane from the linux
+  # agents) that verifies an Analog app actually builds on Windows.
+  #
+  # Scoped to `blog-app` and its deps (6 build tasks) instead of every project
+  # (20) — the Verify step only checks blog-app's output, so building the rest
+  # serially on the slowest runner was wasted time. `--skip-nx-cache` is
+  # deliberate: Nx's cache hash is OS-independent, so without it Windows could
+  # restore the linux agents' artifacts and never actually compile here,
+  # defeating the smoke test. The broad `--all` Windows build runs nightly and
+  # in the merge queue via ci-windows-full.yml.
   build-windows:
     runs-on: windows-latest
     steps:
@@ -89,9 +96,13 @@ jobs:
         with:
           node-version-file: .node-version
       - run: corepack enable
+      - uses: actions/setup-node@v3
+        with:
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build
-        run: pnpm build
+        run: pnpm exec nx build blog-app --skip-nx-cache
       - name: Verify
         run: more dist\apps\blog-app\analog\public\index.html


### PR DESCRIPTION
## PR Checklist

The `build-windows` job is the long pole of the PR pipeline (~12m). This scopes it to what it actually verifies and moves comprehensive Windows coverage to a nightly run.

Closes #

## Affected scope

- Primary scope: ci
- Secondary scopes: —

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Measured on a recent run, `build-windows` spent **9m33s** of its ~12m building **20 projects serially** (`run-many --target build --all --parallel=1`), even though the Verify step only checks `blog-app`'s output.

**On every PR (`ci.yml`):**

- **Scoped** the build to `pnpm exec nx build blog-app` — 6 build tasks (`blog-app` + `content`/`platform`/`router`/`vite-plugin-angular`/`vite-plugin-nitro`) instead of 20, and no longer forced serial.
- **Added the pnpm cache** step (`actions/setup-node` `cache: 'pnpm'`) that the coordinator job already uses, to trim the ~1m52s install.
- **`--skip-nx-cache`** so the job genuinely compiles on Windows. Nx's cache hash is OS-independent, so without it Windows could restore the linux agents' artifacts and never exercise the Windows build path — defeating the smoke test.

**Nightly (`ci-windows-full.yml`, new):**

- The broad `--all` Windows build now runs on a nightly schedule (plus `workflow_dispatch`), off the per-PR hot path, where the extra coverage is worth the latency.

Net: PRs get a fast, real Windows smoke build of a representative app; "does everything compile on Windows" runs nightly.

## Test plan

- [x] `nx format:check` (workflow YAML formatted, both files parse)
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

Validated the task-count reduction locally (`nx build blog-app` = 6 build tasks vs `run-many --all` = 20) and that both workflow files parse. The actual Windows wall-clock improvement will be confirmed by this PR's `build-windows` run.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

CI-infra only; no package or runtime code changes. The nightly workflow can also be triggered manually via the Actions "Run workflow" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)