### PR TITLE
perf(platform): scope route invalidation to add/unlink and enable router fesm transform cache

### DIFF
--- a/packages/platform/src/lib/router-plugin.spec.ts
+++ b/packages/platform/src/lib/router-plugin.spec.ts
@@ -84,10 +84,41 @@ describe('routerPlugin', () => {
     );
     expect(invalidateModule).toHaveBeenCalledWith(changedRouteModule);
     expect(invalidateModule).toHaveBeenCalledWith(pageImporter);
-    expect(invalidateModule).toHaveBeenCalledWith(analogModule);
-    expect(invalidateModule).toHaveBeenCalledWith(importer);
-    expect(send).toHaveBeenCalledWith({ type: 'full-reload' });
+    expect(invalidateModule).not.toHaveBeenCalledWith(analogModule);
+    expect(invalidateModule).not.toHaveBeenCalledWith(importer);
+    expect(send).not.toHaveBeenCalled();
   });
+
+  it.each(['add', 'unlink'])(
+    'invalidates analog modules and reloads when a route file is %sed',
+    (eventName) => {
+      const {
+        analogModule,
+        changedRouteModule,
+        importer,
+        pageImporter,
+        getModulesByFile,
+        invalidateModule,
+        send,
+        on,
+      } = configureServer();
+
+      const handler = on.mock.calls.find(([event]) => event === eventName)?.[1];
+
+      expect(handler).toBeTypeOf('function');
+
+      handler('/src/app/pages/hot-added.page.ts');
+
+      expect(getModulesByFile).toHaveBeenCalledWith(
+        '/src/app/pages/hot-added.page.ts',
+      );
+      expect(invalidateModule).toHaveBeenCalledWith(changedRouteModule);
+      expect(invalidateModule).toHaveBeenCalledWith(pageImporter);
+      expect(invalidateModule).toHaveBeenCalledWith(analogModule);
+      expect(invalidateModule).toHaveBeenCalledWith(importer);
+      expect(send).toHaveBeenCalledWith({ type: 'full-reload' });
+    },
+  );
 
   it('ignores unrelated file changes', () => {
     const { invalidateModule, send, on } = configureServer();

--- a/packages/platform/src/lib/router-plugin.ts
+++ b/packages/platform/src/lib/router-plugin.ts
@@ -82,8 +82,22 @@ export function routerPlugin(options?: Options): Plugin[] {
           });
         }
 
+        /**
+         * Invalidates only the changed route file's modules so ordinary edits
+         * keep standard HMR instead of triggering a full reload.
+         *
+         * @param path The file path that was changed
+         */
+        function invalidateChangedRoute(path: string) {
+          if (!isRouteLikeFile(path)) {
+            return;
+          }
+
+          invalidateFileModules(server, path);
+        }
+
         server.watcher.on('add', invalidateRoutes);
-        server.watcher.on('change', invalidateRoutes);
+        server.watcher.on('change', invalidateChangedRoute);
         server.watcher.on('unlink', invalidateRoutes);
       },
     },

--- a/packages/vite-plugin-angular/src/lib/router-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/router-plugin.ts
@@ -2,7 +2,13 @@ import type { Plugin } from 'vite';
 import { JavaScriptTransformer } from './utils/devkit.js';
 
 export function routerPlugin(): Plugin {
-  const javascriptTransformer = new JavaScriptTransformer({ jit: true }, 1);
+  const transformCache = new Map<string, Uint8Array>();
+  const javascriptTransformer = new JavaScriptTransformer({ jit: true }, 1, {
+    get: (key: string) => transformCache.get(key),
+    put: (key: string, value: Uint8Array) => {
+      transformCache.set(key, value);
+    },
+  });
 
   /**
    * Transforms Angular packages the didn't get picked up by Vite's pre-optimization.
@@ -11,6 +17,9 @@ export function routerPlugin(): Plugin {
     name: 'analogjs-router-optimization',
     enforce: 'pre',
     apply: 'serve',
+    buildEnd() {
+      return javascriptTransformer.close();
+    },
     transform: {
       filter: {
         id: /fesm(.*?)\.mjs/,


### PR DESCRIPTION
## PR Checklist

Closes #2400
Closes #2406

## Affected scope

- Primary scope: platform
- Secondary scopes: vite-plugin-angular, router

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Two dev-server performance fixes for the router plugin layer (they apply on both the fastCompile and default compilation paths):

1. **`invalidateRoutes` no longer full-reloads on every route-file save.** The heavy path (full `moduleGraph.fileToModulesMap` scan for `@analogjs/*` fesm modules + invalidation of them and their importers + `full-reload`) now runs only on watcher `add`/`unlink` — the events that actually change the route file set. Ordinary `change` events run a light per-file invalidation after the same `isRouteLikeFile` check, preserving the stale-transform fix from b9325af0f while letting HMR/live-reload handle the update. Previously every keystroke-save of a pages/routes/content file discarded all HMR state.

2. **The router fesm `JavaScriptTransformer` gets its content cache enabled.** The third constructor arg (cache) was omitted, so every `@analogjs/*` fesm `.mjs` request re-read the file and round-tripped through the babel/linker worker. A Map-backed `{ get, put }` store (upstream keys by SHA-256 of contents + options, so a plain map is content-safe) turns repeat transforms of unchanged fesm files into cache hits. Also adds `buildEnd` → `close()` to shut down the worker pool, mirroring compiler-plugin.ts.

Verified compatible across `@angular-devkit/build-angular`/`@angular/build` 17.3.12 → 22/next (constructor arity, duck-typed cache interface, and `close()` checked against the published tarballs of each supported major).

## Test plan

- [x] `nx format:check` (prettier via lint-staged on commit)
- [x] `pnpm build` (vite-plugin-angular, platform + analog-app and blog-app built cleanly)
- [x] `pnpm test` (`nx test platform`: 24 passed; `nx test vite-plugin-angular`: 1211 passed, zero snapshot updates)
- [x] Manual verification (dev-served analog-app, edited a page file live: server keeps serving, no full-reload, no errors)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGBu5vifftgU92BmCMyQs5
