### PR TITLE
perf(vite-plugin-angular): reduce redundant parsing, fs work, and blocking reads in fastCompile

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/compile.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/compile.ts
@@ -226,7 +226,7 @@ export function compile(
     fileName,
     sourceCode,
     ts.ScriptTarget.Latest,
-    true,
+    false,
   );
   // OXC parse for metadata extraction (faster than TS for decorator/signal analysis)
   const { program: oxcProgram } = parseSync(fileName, sourceCode);

--- a/packages/vite-plugin-angular/src/lib/compiler/compile.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/compile.ts
@@ -99,6 +99,11 @@ export interface CompileOptions {
    *   Partial output is version-stable and linked at application build time.
    */
   compilationMode?: 'full' | 'partial';
+  /**
+   * Pre-parsed OXC program of `sourceCode`, so callers that already parsed
+   * the identical string can avoid a re-parse. Treated as read-only.
+   */
+  oxcProgram?: ReturnType<typeof parseSync>['program'];
 }
 
 type CompileMetadata = ReturnType<typeof extractMetadata>;
@@ -229,7 +234,7 @@ export function compile(
     false,
   );
   // OXC parse for metadata extraction (faster than TS for decorator/signal analysis)
-  const { program: oxcProgram } = parseSync(fileName, sourceCode);
+  const oxcProgram = opts.oxcProgram ?? parseSync(fileName, sourceCode).program;
   const oxcClassMap = new Map<string, any>();
   for (const stmt of oxcProgram.body) {
     const decl =
@@ -255,7 +260,7 @@ export function compile(
   const parseFile = new ParseSourceFile(sourceCode, fileName);
   const parseLoc = new ParseLocation(parseFile, 0, 0, 0);
   const typeSourceSpan = new ParseSourceSpan(parseLoc, parseLoc);
-  const typeOnlyImports = detectTypeOnlyImportNames(sourceCode);
+  const typeOnlyImports = detectTypeOnlyImportNames(sourceCode, oxcProgram);
   const importSpecifierByName = new Map<string, string>();
   const importedNames = new Set<string>();
 
@@ -1593,7 +1598,7 @@ export function compile(
   //    implements, generics, etc.).  Without this pass, single-file transpilers
   //    like OXC / esbuild cannot tell that `import { SomeType }` is type-only
   //    and will leave the import in the output, causing runtime errors.
-  elideTypeOnlyImportsMagicString(ms);
+  elideTypeOnlyImportsMagicString(ms, oxcProgram);
 
   const map = ms.generateMap({
     source: fileName,

--- a/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
@@ -2196,8 +2196,8 @@ describe('OXC-based resource inlining', () => {
     return haystack.split(needle).length - 1;
   }
 
-  it('inlines templateUrl via AST rewriting', () => {
-    const { code: result } = inlineResourceUrls(
+  it('inlines templateUrl via AST rewriting', async () => {
+    const { code: result } = await inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2213,8 +2213,8 @@ describe('OXC-based resource inlining', () => {
     expect(result).toContain('template:');
   });
 
-  it('inlines styleUrls via AST rewriting', () => {
-    const { code: result } = inlineResourceUrls(
+  it('inlines styleUrls via AST rewriting', async () => {
+    const { code: result } = await inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2231,7 +2231,7 @@ describe('OXC-based resource inlining', () => {
     expect(result).toContain('styles:');
   });
 
-  it('returns original code when no resources to inline', () => {
+  it('returns original code when no resources to inline', async () => {
     const src = `
       import { Component } from '@angular/core';
       @Component({
@@ -2240,12 +2240,12 @@ describe('OXC-based resource inlining', () => {
       })
       export class InlineComponent {}
     `;
-    const { code: result } = inlineResourceUrls(src, 'inline.ts');
+    const { code: result } = await inlineResourceUrls(src, 'inline.ts');
     expect(result).toBe(src);
   });
 
-  it('merges styleUrl into existing inline styles array (no duplicate key)', () => {
-    const { code: result } = inlineResourceUrls(
+  it('merges styleUrl into existing inline styles array (no duplicate key)', async () => {
+    const { code: result } = await inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2268,8 +2268,8 @@ describe('OXC-based resource inlining', () => {
     expect(result).toContain('.wrapper');
   });
 
-  it('merges styleUrls into existing inline styles array (no duplicate key)', () => {
-    const { code: result } = inlineResourceUrls(
+  it('merges styleUrls into existing inline styles array (no duplicate key)', async () => {
+    const { code: result } = await inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2289,8 +2289,8 @@ describe('OXC-based resource inlining', () => {
     expect(result).toContain('.wrapper');
   });
 
-  it('merges styleUrl into an existing styles array with a trailing comma without producing a sparse element', () => {
-    const { code: result } = inlineResourceUrls(
+  it('merges styleUrl into an existing styles array with a trailing comma without producing a sparse element', async () => {
+    const { code: result } = await inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2317,8 +2317,8 @@ describe('OXC-based resource inlining', () => {
     expect(() => rawCompile(result, 'ext.ts')).not.toThrow();
   });
 
-  it('merges styleUrl into an empty styles array without producing a sparse element', () => {
-    const { code: result } = inlineResourceUrls(
+  it('merges styleUrl into an empty styles array without producing a sparse element', async () => {
+    const { code: result } = await inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2366,12 +2366,12 @@ describe('OXC-based resource inlining', () => {
     expect(styles[1]).toBe('p { margin: 0 }');
   });
 
-  it('reports the source extension of an inlined external styleUrl', () => {
+  it('reports the source extension of an inlined external styleUrl', async () => {
     // Regression: fastCompile must preprocess external `styleUrl`s by their own
     // file extension (e.g. `.scss`), independent of `inlineStylesExtension`.
     // `inlineResourceUrls` surfaces each inlined external style's extension at
     // the flat index that `extractInlineStyles`/`resolvedInlineStyles` use.
-    const { styleExtensions } = inlineResourceUrls(
+    const { styleExtensions } = await inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2387,8 +2387,8 @@ describe('OXC-based resource inlining', () => {
     expect(styleExtensions.get(0)).toBe('scss');
   });
 
-  it('reports a css extension for plain external styleUrls', () => {
-    const { styleExtensions } = inlineResourceUrls(
+  it('reports a css extension for plain external styleUrls', async () => {
+    const { styleExtensions } = await inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2404,10 +2404,10 @@ describe('OXC-based resource inlining', () => {
     expect(styleExtensions.get(0)).toBe('css');
   });
 
-  it('indexes an external styleUrl after pre-existing inline styles', () => {
+  it('indexes an external styleUrl after pre-existing inline styles', async () => {
     // Inline `styles: [...]` come first in the flat list; the external scss
     // styleUrl is appended after it, so it must map to index 1 (not 0).
-    const { styleExtensions } = inlineResourceUrls(
+    const { styleExtensions } = await inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({
@@ -2425,12 +2425,12 @@ describe('OXC-based resource inlining', () => {
     expect(styleExtensions.get(1)).toBe('scss');
   });
 
-  it('reports the source extension for each preprocessable styleUrl type', () => {
+  it('reports the source extension for each preprocessable styleUrl type', async () => {
     // The fast-compile path preprocesses each external style by its own
     // extension, so every preprocessable style language must be surfaced
     // distinctly (not collapsed onto a single `inlineStylesExtension`).
     for (const ext of ['css', 'scss', 'less']) {
-      const { styleExtensions } = inlineResourceUrls(
+      const { styleExtensions } = await inlineResourceUrls(
         `
         import { Component } from '@angular/core';
         @Component({
@@ -2447,11 +2447,11 @@ describe('OXC-based resource inlining', () => {
     }
   });
 
-  it('merges a singular `styles` string with an external styleUrl without duplicating the key', () => {
+  it('merges a singular `styles` string with an external styleUrl without duplicating the key', async () => {
     // Regression: a non-array `styles` (single string/template) plus an
     // external `styleUrl` must collapse into one `styles` key, and the external
     // style must be indexed *after* the existing inline style (index 1).
-    const { code, styleExtensions } = inlineResourceUrls(
+    const { code, styleExtensions } = await inlineResourceUrls(
       `
       import { Component } from '@angular/core';
       @Component({

--- a/packages/vite-plugin-angular/src/lib/compiler/dts-reader.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/dts-reader.ts
@@ -331,12 +331,14 @@ export function collectImportedPackages(
 export function collectRelativeReExports(
   code: string,
   fileName: string,
+  program?: ReturnType<typeof parseSync>['program'],
 ): string[] {
-  let program: any;
-  try {
-    program = parseSync(fileName, code).program;
-  } catch {
-    return [];
+  if (!program) {
+    try {
+      program = parseSync(fileName, code).program;
+    } catch {
+      return [];
+    }
   }
   const result: string[] = [];
   for (const stmt of program.body || []) {
@@ -363,12 +365,17 @@ export function collectRelativeReExports(
  * directly listed in tsconfig `files`/`include` (transitively-imported app
  * sources) or behind wildcard `paths` (workspace libraries).
  */
-export function collectAllImports(code: string, fileName: string): string[] {
-  let program: any;
-  try {
-    program = parseSync(fileName, code).program;
-  } catch {
-    return [];
+export function collectAllImports(
+  code: string,
+  fileName: string,
+  program?: ReturnType<typeof parseSync>['program'],
+): string[] {
+  if (!program) {
+    try {
+      program = parseSync(fileName, code).program;
+    } catch {
+      return [];
+    }
   }
   const result: string[] = [];
   for (const stmt of program.body || []) {

--- a/packages/vite-plugin-angular/src/lib/compiler/dts-reader.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/dts-reader.ts
@@ -300,9 +300,10 @@ function subEntryFromFilePath(
 export function collectImportedPackages(
   code: string,
   fileName: string,
+  program?: ReturnType<typeof parseSync>['program'],
 ): Set<string> {
   const packages = new Set<string>();
-  const { program } = parseSync(fileName, code);
+  program ??= parseSync(fileName, code).program;
 
   for (const stmt of program.body) {
     if (stmt.type !== 'ImportDeclaration') continue;

--- a/packages/vite-plugin-angular/src/lib/compiler/jit-transform.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/jit-transform.ts
@@ -64,7 +64,7 @@ export function jitTransform(
 ): JitTransformResult {
   const { program } = parseSync(fileName, sourceCode);
   const ms = new MagicString(sourceCode, { filename: fileName });
-  const typeOnlyImports = detectTypeOnlyImportNames(sourceCode);
+  const typeOnlyImports = detectTypeOnlyImportNames(sourceCode, program);
   let hasAngularClass = false;
 
   const allClasses = findAllClasses(program.body);

--- a/packages/vite-plugin-angular/src/lib/compiler/registry.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/registry.ts
@@ -60,7 +60,11 @@ const DECORATOR_RE = new RegExp(`@(${[...COMPILABLE_DECORATORS].join('|')})`);
  * Lightweight scan of a TypeScript file to extract Angular decorator metadata
  * without performing full compilation. Uses OXC's native Rust parser for speed.
  */
-export function scanFile(code: string, fileName: string): RegistryEntry[] {
+export function scanFile(
+  code: string,
+  fileName: string,
+  program?: ReturnType<typeof parseSync>['program'],
+): RegistryEntry[] {
   const entries: RegistryEntry[] = [];
 
   // Fast regex pre-filter — skip files with neither Angular decorators
@@ -70,7 +74,7 @@ export function scanFile(code: string, fileName: string): RegistryEntry[] {
     return entries;
   }
 
-  const { program } = parseSync(fileName, code);
+  program ??= parseSync(fileName, code).program;
 
   // First pass: collect tuple barrels — top-level `const X = [A, B, C]`
   // (with or without `export`/`as const`) where every element is a bare

--- a/packages/vite-plugin-angular/src/lib/compiler/resource-inliner.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/resource-inliner.ts
@@ -52,10 +52,10 @@ function countInlineStyleLiterals(arrayExpr: any): number {
  * Returns the modified source code plus the per-style-index extension map
  * (see {@link InlineResourceResult}).
  */
-export function inlineResourceUrls(
+export async function inlineResourceUrls(
   code: string,
   fileName: string,
-): InlineResourceResult {
+): Promise<InlineResourceResult> {
   const styleExtensions = new Map<number, string>();
 
   if (!code.includes('templateUrl') && !code.includes('styleUrl')) {
@@ -67,10 +67,21 @@ export function inlineResourceUrls(
   let changed = false;
   const dir = path.dirname(fileName);
 
-  // Running base index into the flat per-file style list (matching the order
-  // `extractInlineStyles` walks classes/decorators/properties) so external
-  // styles can be mapped to the index `resolvedInlineStyles` later keys on.
-  let flatStyleBase = 0;
+  // Phase 1: walk the AST and collect resource descriptors per decorator,
+  // in source order — no I/O during the walk. A plan is recorded for every
+  // `@Component` decorator (even without url props) because the flat style
+  // index bookkeeping below advances per decorator.
+  type ResourceProp =
+    | { kind: 'templateUrl'; prop: any; resolvedPath: string }
+    | { kind: 'styleUrl'; prop: any; resolvedPath: string }
+    | { kind: 'styleUrls'; prop: any; resolvedPaths: string[] };
+  interface DecoratorPlan {
+    existingStylesProp: any;
+    existingStylesArray: any;
+    existingInlineCount: number;
+    resourceProps: ResourceProp[];
+  }
+  const plans: DecoratorPlan[] = [];
 
   for (const node of program.body) {
     const decl =
@@ -114,16 +125,7 @@ export function inlineResourceUrls(
           ? 1
           : 0;
 
-      // Collect the props we want to rewrite. Contents from styleUrl /
-      // styleUrls are accumulated so that multiple url-based props in one
-      // decorator collapse into a single `styles` array write. `extensions`
-      // tracks each content's source extension in the same order.
-      const templateUrlRewrites: Array<{ prop: any; content: string }> = [];
-      const cssProps: Array<{
-        prop: any;
-        contents: string[];
-        extensions: string[];
-      }> = [];
+      const resourceProps: ResourceProp[] = [];
 
       for (const prop of arg.properties) {
         if (prop.type !== 'Property') continue;
@@ -135,13 +137,11 @@ export function inlineResourceUrls(
           val?.type === 'Literal' &&
           typeof val.value === 'string'
         ) {
-          try {
-            const filePath = path.resolve(dir, val.value);
-            const content = fs.readFileSync(filePath, 'utf-8');
-            templateUrlRewrites.push({ prop, content });
-          } catch {
-            // Keep original if file can't be read
-          }
+          resourceProps.push({
+            kind: 'templateUrl',
+            prop,
+            resolvedPath: path.resolve(dir, val.value),
+          });
           continue;
         }
 
@@ -150,127 +150,202 @@ export function inlineResourceUrls(
           val?.type === 'Literal' &&
           typeof val.value === 'string'
         ) {
-          try {
-            const filePath = path.resolve(dir, val.value);
-            const content = fs.readFileSync(filePath, 'utf-8');
-            cssProps.push({
-              prop,
-              contents: [content],
-              extensions: [extensionOf(filePath)],
-            });
-          } catch {
-            // Keep original if file can't be read
-          }
+          resourceProps.push({
+            kind: 'styleUrl',
+            prop,
+            resolvedPath: path.resolve(dir, val.value),
+          });
           continue;
         }
 
         if (key === 'styleUrls' && val?.type === 'ArrayExpression') {
-          const contents: string[] = [];
-          const extensions: string[] = [];
-          let allRead = true;
+          const resolvedPaths: string[] = [];
           for (const el of val.elements) {
             if (el?.type === 'Literal' && typeof el.value === 'string') {
-              try {
-                const filePath = path.resolve(dir, el.value);
-                contents.push(fs.readFileSync(filePath, 'utf-8'));
-                extensions.push(extensionOf(filePath));
-              } catch {
-                allRead = false;
-                break;
-              }
+              resolvedPaths.push(path.resolve(dir, el.value));
             }
           }
-          if (allRead && contents.length > 0) {
-            cssProps.push({ prop, contents, extensions });
-          }
+          resourceProps.push({ kind: 'styleUrls', prop, resolvedPaths });
         }
       }
 
-      for (const { prop, content } of templateUrlRewrites) {
-        ms.overwrite(
-          prop.start,
-          prop.end,
-          `template: ${JSON.stringify(content)}`,
-        );
-        changed = true;
+      plans.push({
+        existingStylesProp,
+        existingStylesArray,
+        existingInlineCount,
+        resourceProps,
+      });
+    }
+  }
+
+  // Phase 2: read every referenced resource without blocking the event
+  // loop. Each read catches its own failure to `undefined` — one missing
+  // file must not abort sibling reads that succeed.
+  const pathsToRead = new Set<string>();
+  for (const plan of plans) {
+    for (const rp of plan.resourceProps) {
+      if (rp.kind === 'styleUrls') {
+        for (const p of rp.resolvedPaths) pathsToRead.add(p);
+      } else {
+        pathsToRead.add(rp.resolvedPath);
       }
+    }
+  }
+  const fileContents = new Map<string, string | undefined>();
+  await Promise.all(
+    [...pathsToRead].map(async (p) => {
+      fileContents.set(
+        p,
+        await fs.promises.readFile(p, 'utf-8').catch(() => undefined),
+      );
+    }),
+  );
 
-      if (cssProps.length > 0) {
-        const allContents = cssProps.flatMap((c) => c.contents);
-        const allExtensions = cssProps.flatMap((c) => c.extensions);
+  // Phase 3: apply MagicString rewrites in the original AST order so the
+  // flat style index bookkeeping matches `extractInlineStyles`.
 
-        if (existingStylesArray) {
-          // Filter out null holes in case the source already has a sparse array.
-          const realElements = (existingStylesArray.elements as any[]).filter(
-            (e) => e != null,
-          );
+  // Running base index into the flat per-file style list (matching the order
+  // `extractInlineStyles` walks classes/decorators/properties) so external
+  // styles can be mapped to the index `resolvedInlineStyles` later keys on.
+  let flatStyleBase = 0;
 
-          if (realElements.length > 0) {
-            // Insert right after the last real element. This preserves any
-            // trailing comma the source may have (e.g. Prettier output) and
-            // avoids producing a sparse `[existing, , "new"]` element, which
-            // would crash downstream decorator metadata extraction.
-            const lastElement = realElements[realElements.length - 1];
-            const insertion = allContents
-              .map((c) => `, ${JSON.stringify(c)}`)
-              .join('');
-            ms.appendRight(lastElement.end, insertion);
-          } else {
-            // Empty array — drop the leading comma.
-            const insertion = allContents
-              .map((c) => JSON.stringify(c))
-              .join(', ');
-            ms.appendLeft(existingStylesArray.end - 1, insertion);
+  for (const plan of plans) {
+    const { existingStylesProp, existingStylesArray, existingInlineCount } =
+      plan;
+
+    // Collect the props we want to rewrite. Contents from styleUrl /
+    // styleUrls are accumulated so that multiple url-based props in one
+    // decorator collapse into a single `styles` array write. `extensions`
+    // tracks each content's source extension in the same order.
+    const templateUrlRewrites: Array<{ prop: any; content: string }> = [];
+    const cssProps: Array<{
+      prop: any;
+      contents: string[];
+      extensions: string[];
+    }> = [];
+
+    for (const rp of plan.resourceProps) {
+      if (rp.kind === 'templateUrl') {
+        // Keep original if file can't be read
+        const content = fileContents.get(rp.resolvedPath);
+        if (content !== undefined) {
+          templateUrlRewrites.push({ prop: rp.prop, content });
+        }
+      } else if (rp.kind === 'styleUrl') {
+        // Keep original if file can't be read
+        const content = fileContents.get(rp.resolvedPath);
+        if (content !== undefined) {
+          cssProps.push({
+            prop: rp.prop,
+            contents: [content],
+            extensions: [extensionOf(rp.resolvedPath)],
+          });
+        }
+      } else {
+        // styleUrls is all-or-nothing: keep the original property if any
+        // entry failed to read.
+        const contents: string[] = [];
+        const extensions: string[] = [];
+        let allRead = true;
+        for (const p of rp.resolvedPaths) {
+          const content = fileContents.get(p);
+          if (content === undefined) {
+            allRead = false;
+            break;
           }
+          contents.push(content);
+          extensions.push(extensionOf(p));
+        }
+        if (allRead && contents.length > 0) {
+          cssProps.push({ prop: rp.prop, contents, extensions });
+        }
+      }
+    }
 
-          for (const { prop } of cssProps) {
-            removePropertyWithSeparator(ms, code, prop.start, prop.end);
-          }
-        } else if (isInlineStyleValue(existingStylesProp?.value)) {
-          // Singular `styles: '...'` / `styles: \`...\`` — wrap the original
-          // value into an array merged with the inlined styles, then drop the
-          // styleUrl props so only one `styles` key remains.
-          const original = code.slice(
-            existingStylesProp.value.start,
-            existingStylesProp.value.end,
-          );
-          const merged = allContents
+    for (const { prop, content } of templateUrlRewrites) {
+      ms.overwrite(
+        prop.start,
+        prop.end,
+        `template: ${JSON.stringify(content)}`,
+      );
+      changed = true;
+    }
+
+    if (cssProps.length > 0) {
+      const allContents = cssProps.flatMap((c) => c.contents);
+      const allExtensions = cssProps.flatMap((c) => c.extensions);
+
+      if (existingStylesArray) {
+        // Filter out null holes in case the source already has a sparse array.
+        const realElements = (existingStylesArray.elements as any[]).filter(
+          (e) => e != null,
+        );
+
+        if (realElements.length > 0) {
+          // Insert right after the last real element. This preserves any
+          // trailing comma the source may have (e.g. Prettier output) and
+          // avoids producing a sparse `[existing, , "new"]` element, which
+          // would crash downstream decorator metadata extraction.
+          const lastElement = realElements[realElements.length - 1];
+          const insertion = allContents
             .map((c) => `, ${JSON.stringify(c)}`)
             .join('');
-          ms.overwrite(
-            existingStylesProp.value.start,
-            existingStylesProp.value.end,
-            `[${original}${merged}]`,
-          );
-          for (const { prop } of cssProps) {
-            removePropertyWithSeparator(ms, code, prop.start, prop.end);
-          }
+          ms.appendRight(lastElement.end, insertion);
         } else {
-          // No existing `styles` array — rewrite the first styleUrl/styleUrls
-          // prop with the merged contents and drop any additional ones so we
-          // don't emit multiple `styles` properties.
-          const [first, ...rest] = cssProps;
-          ms.overwrite(
-            first.prop.start,
-            first.prop.end,
-            `styles: [${allContents.map((c) => JSON.stringify(c)).join(', ')}]`,
-          );
-          for (const { prop } of rest) {
-            removePropertyWithSeparator(ms, code, prop.start, prop.end);
-          }
+          // Empty array — drop the leading comma.
+          const insertion = allContents
+            .map((c) => JSON.stringify(c))
+            .join(', ');
+          ms.appendLeft(existingStylesArray.end - 1, insertion);
         }
-        changed = true;
 
-        // The appended external styles occupy the flat indices after any
-        // pre-existing inline styles for this component.
-        const externalBase = flatStyleBase + existingInlineCount;
-        allExtensions.forEach((ext, k) => {
-          if (ext) styleExtensions.set(externalBase + k, ext);
-        });
-        flatStyleBase = externalBase + allContents.length;
+        for (const { prop } of cssProps) {
+          removePropertyWithSeparator(ms, code, prop.start, prop.end);
+        }
+      } else if (isInlineStyleValue(existingStylesProp?.value)) {
+        // Singular `styles: '...'` / `styles: \`...\`` — wrap the original
+        // value into an array merged with the inlined styles, then drop the
+        // styleUrl props so only one `styles` key remains.
+        const original = code.slice(
+          existingStylesProp.value.start,
+          existingStylesProp.value.end,
+        );
+        const merged = allContents
+          .map((c) => `, ${JSON.stringify(c)}`)
+          .join('');
+        ms.overwrite(
+          existingStylesProp.value.start,
+          existingStylesProp.value.end,
+          `[${original}${merged}]`,
+        );
+        for (const { prop } of cssProps) {
+          removePropertyWithSeparator(ms, code, prop.start, prop.end);
+        }
       } else {
-        flatStyleBase += existingInlineCount;
+        // No existing `styles` array — rewrite the first styleUrl/styleUrls
+        // prop with the merged contents and drop any additional ones so we
+        // don't emit multiple `styles` properties.
+        const [first, ...rest] = cssProps;
+        ms.overwrite(
+          first.prop.start,
+          first.prop.end,
+          `styles: [${allContents.map((c) => JSON.stringify(c)).join(', ')}]`,
+        );
+        for (const { prop } of rest) {
+          removePropertyWithSeparator(ms, code, prop.start, prop.end);
+        }
       }
+      changed = true;
+
+      // The appended external styles occupy the flat indices after any
+      // pre-existing inline styles for this component.
+      const externalBase = flatStyleBase + existingInlineCount;
+      allExtensions.forEach((ext, k) => {
+        if (ext) styleExtensions.set(externalBase + k, ext);
+      });
+      flatStyleBase = externalBase + allContents.length;
+    } else {
+      flatStyleBase += existingInlineCount;
     }
   }
 

--- a/packages/vite-plugin-angular/src/lib/compiler/resource-inliner.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/resource-inliner.ts
@@ -324,7 +324,11 @@ function isWhitespace(ch: string): boolean {
  * Extract inline style strings from Angular @Component decorator using OXC parser.
  * Returns an array of style string values for preprocessing.
  */
-export function extractInlineStyles(code: string, fileName: string): string[] {
+export function extractInlineStyles(
+  code: string,
+  fileName: string,
+  program?: ReturnType<typeof parseSync>['program'],
+): string[] {
   if (!code.includes('styles')) return [];
-  return extractStylesFromAst(code, fileName);
+  return extractStylesFromAst(code, fileName, program);
 }

--- a/packages/vite-plugin-angular/src/lib/compiler/resource-parity.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/resource-parity.spec.ts
@@ -18,16 +18,16 @@ import type { ComponentRegistry } from './registry';
 const FIXTURES = path.join(__dirname, '__fixtures__');
 const ID = path.join(FIXTURES, 'test.component.ts');
 
-function compileSource(src: string): string {
+async function compileSource(src: string): Promise<string> {
   const registry: ComponentRegistry = new Map();
-  return compile(inlineResourceUrls(src, ID).code, ID, {
+  return compile((await inlineResourceUrls(src, ID)).code, ID, {
     registry,
     useDefineForClassFields: true,
   }).code;
 }
 
 describe('resource inlining ↔ inline output parity', () => {
-  it('emits identical Ivy for external templateUrl/styleUrls and their inline form', () => {
+  it('emits identical Ivy for external templateUrl/styleUrls and their inline form', async () => {
     const html = fs.readFileSync(
       path.join(FIXTURES, 'test.component.html'),
       'utf-8',
@@ -55,8 +55,8 @@ export class ParityComponent {}
 export class ParityComponent {}
 `;
 
-    const externalOut = compileSource(external);
-    const inlineOut = compileSource(inline);
+    const externalOut = await compileSource(external);
+    const inlineOut = await compileSource(inline);
 
     // Guard against a vacuous pass: real Ivy must have been emitted for both.
     expect(externalOut).toContain('ɵcmp');

--- a/packages/vite-plugin-angular/src/lib/compiler/style-ast.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/style-ast.ts
@@ -70,9 +70,13 @@ export function extractStyleUrls(code: string, fileName: string): string[] {
 /**
  * Extract inline style strings from Angular @Component decorators.
  */
-export function extractInlineStyles(code: string, fileName: string): string[] {
+export function extractInlineStyles(
+  code: string,
+  fileName: string,
+  program?: ReturnType<typeof parseSync>['program'],
+): string[] {
   const styles: string[] = [];
-  const { program } = parseSync(fileName, code);
+  program ??= parseSync(fileName, code).program;
 
   for (const node of program.body) {
     const decl = getClassDeclaration(node);

--- a/packages/vite-plugin-angular/src/lib/compiler/type-elision.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/type-elision.ts
@@ -48,11 +48,14 @@ const TYPE_NODE_TYPES = new Set([
  * Internal helper: parse code and return both the AST and the set of
  * type-only imported names. Avoids double-parsing when both are needed.
  */
-function analyzeTypeOnlyImports(code: string): {
+function analyzeTypeOnlyImports(
+  code: string,
+  program?: ReturnType<typeof parseSync>['program'],
+): {
   ast: any;
   typeOnlyNames: Set<string>;
 } {
-  const ast = parseSync('file.ts', code).program;
+  const ast = program ?? parseSync('file.ts', code).program;
 
   // Step 1 – collect all value-imported names (skip `import type` / `{ type X }`)
   // Namespace imports (`import * as ns`) are intentionally skipped — they are
@@ -256,8 +259,11 @@ function collectTypeReferenceNames(
  *
  * Uses oxc-parser for fast, Rust-based AST analysis — no type-checker needed.
  */
-export function detectTypeOnlyImportNames(code: string): Set<string> {
-  return analyzeTypeOnlyImports(code).typeOnlyNames;
+export function detectTypeOnlyImportNames(
+  code: string,
+  program?: ReturnType<typeof parseSync>['program'],
+): Set<string> {
+  return analyzeTypeOnlyImports(code, program).typeOnlyNames;
 }
 
 /**
@@ -360,13 +366,17 @@ export function elideTypeOnlyImports(code: string): string {
  *
  * Detects type-only names from `ms.toString()` (the fully-mutated code),
  * but reads import positions from `ms.original` (the coordinate system
- * MagicString expects).
+ * MagicString expects). `originalProgram`, when provided, must be a parse
+ * of `ms.original` — never of the mutated text.
  */
-export function elideTypeOnlyImportsMagicString(ms: MagicString): void {
+export function elideTypeOnlyImportsMagicString(
+  ms: MagicString,
+  originalProgram?: ReturnType<typeof parseSync>['program'],
+): void {
   const typeOnlyNames = detectTypeOnlyImportNames(ms.toString());
   if (typeOnlyNames.size === 0) return;
 
   // Parse the original source to get positions in MagicString's coordinate system
-  const ast = parseSync('file.ts', ms.original).program;
+  const ast = originalProgram ?? parseSync('file.ts', ms.original).program;
   applyElisionEdits(ms, ast, ms.original, typeOnlyNames);
 }

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -526,7 +526,7 @@ export function fastCompilePlugin(
     // `styleExtensions` carries the source extension of each inlined external
     // style so it can be preprocessed by its own file type (e.g. an external
     // `.scss` styleUrl) regardless of the `inlineStylesExtension` option.
-    const inlined = inlineResourceUrls(code, id);
+    const inlined = await inlineResourceUrls(code, id);
     code = inlined.code;
     const { styleExtensions } = inlined;
 

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -95,17 +95,25 @@ export function fastCompilePlugin(
    * The `visited` set prevents infinite recursion within a single
    * top-level call. Each fresh scan should pass an empty set (so HMR
    * re-scans aren't blocked by buildStart's earlier visits).
+   *
+   * `fileContents`/`scanResults` are cold-start dedup caches scoped to a
+   * single `initFastCompile` call. HMR/watcher callers must omit them so
+   * an edited file is always re-read from disk.
    */
   async function scanBarrelExports(
     file: string,
     visited: Set<string> = new Set(),
     overwrite = false,
+    fileContents?: Map<string, string>,
+    scanResults?: Map<string, ReturnType<typeof scanFile>>,
   ): Promise<void> {
     if (visited.has(file)) return;
     visited.add(file);
     let code: string;
     try {
-      code = await fsPromises.readFile(file, 'utf-8');
+      code =
+        fileContents?.get(file) ?? (await fsPromises.readFile(file, 'utf-8'));
+      fileContents?.set(file, code);
     } catch (e) {
       if (debugRegistry.enabled) {
         debugRegistry(
@@ -116,7 +124,21 @@ export function fastCompilePlugin(
       }
       return;
     }
-    const entries = scanFile(code, file);
+    // Single parse shared by scanFile and collectRelativeReExports. On a
+    // parse error each consumer re-parses on its own, preserving their
+    // individual failure semantics (scanFile throws past its pre-filter;
+    // collectRelativeReExports swallows and returns []).
+    let program: ReturnType<typeof parseSync>['program'] | undefined;
+    try {
+      program = parseSync(file, code).program;
+    } catch {
+      program = undefined;
+    }
+    let entries = scanResults?.get(file);
+    if (!entries) {
+      entries = scanFile(code, file, program);
+      scanResults?.set(file, entries);
+    }
     for (const entry of entries) {
       // At buildStart we want stable registry entries (don't overwrite
       // an earlier scan with a barrel re-scan); HMR explicitly asks
@@ -131,7 +153,7 @@ export function fastCompilePlugin(
     // silently skip half of an outer barrel's re-exports, which
     // previously left directives like `HlmRadioGroup` unregistered).
     const dir = dirname(file);
-    for (const rel of collectRelativeReExports(code, file)) {
+    for (const rel of collectRelativeReExports(code, file, program)) {
       // NodeNext-style libraries write `export * from './foo.js'`
       // even though the source is `./foo.ts`. Strip the ESM
       // extension before probing or the candidates would be
@@ -145,7 +167,13 @@ export function fastCompilePlugin(
       for (const candidate of reExportCandidates) {
         try {
           await fsPromises.access(candidate);
-          await scanBarrelExports(candidate, visited, overwrite);
+          await scanBarrelExports(
+            candidate,
+            visited,
+            overwrite,
+            fileContents,
+            scanResults,
+          );
           resolved = true;
           break;
         } catch {
@@ -186,6 +214,11 @@ export function fastCompilePlugin(
     const candidates = new Set<string>(config.rootNames);
     const tsPaths = config.options?.paths;
     const baseUrl = (config.options?.baseUrl ?? projectRoot) as string;
+    // Cold-start dedup caches shared by the three scan phases below
+    // (candidates scan, walkImports, scanBarrelExports). Scoped to this
+    // init call only — HMR/watcher re-scans must hit disk fresh.
+    const fileContents = new Map<string, string>();
+    const scanResults = new Map<string, ReturnType<typeof scanFile>>();
     if (tsPaths) {
       for (const targets of Object.values(tsPaths)) {
         for (const target of targets as string[]) {
@@ -200,7 +233,10 @@ export function fastCompilePlugin(
       Array.from(candidates).map(async (file) => {
         try {
           const code = await fsPromises.readFile(file, 'utf-8');
-          return scanFile(code, file);
+          fileContents.set(file, code);
+          const entries = scanFile(code, file);
+          scanResults.set(file, entries);
+          return entries;
         } catch (e) {
           if (debugRegistry.enabled) {
             debugRegistry(
@@ -251,7 +287,7 @@ export function fastCompilePlugin(
       }
       return [];
     };
-    const resolveToSource = async (base: string): Promise<string | null> => {
+    const probeToSource = async (base: string): Promise<string | null> => {
       const candidates = base.endsWith('.ts')
         ? [base]
         : [base + '.ts', resolve(base, 'index.ts')];
@@ -265,6 +301,18 @@ export function fastCompilePlugin(
       }
       return null;
     };
+    // Memoize fs probes per absolute base path. The cache stores the
+    // Promise (not the settled value) so concurrent walks racing on the
+    // same base collapse into a single probe.
+    const baseResolveCache = new Map<string, Promise<string | null>>();
+    const resolveToSource = (base: string): Promise<string | null> => {
+      let probe = baseResolveCache.get(base);
+      if (!probe) {
+        probe = probeToSource(base);
+        baseResolveCache.set(base, probe);
+      }
+      return probe;
+    };
     // Probe each `paths` target in order; first one that resolves to source wins.
     const resolveFirstSource = async (
       bases: string[],
@@ -276,16 +324,36 @@ export function fastCompilePlugin(
       return null;
     };
     const importWalkVisited = new Set<string>();
+    // Paths-mapped resolution doesn't depend on the importer, so bare
+    // specifiers can be memoized by their raw text. Relative specifiers
+    // must NOT be — the same './foo' resolves differently per directory.
+    const bareSpecResolveCache = new Map<string, Promise<string | null>>();
     const walkImports = async (file: string): Promise<void> => {
       if (importWalkVisited.has(file)) return;
       importWalkVisited.add(file);
       let code: string;
       try {
-        code = await fsPromises.readFile(file, 'utf-8');
+        code =
+          fileContents.get(file) ?? (await fsPromises.readFile(file, 'utf-8'));
+        fileContents.set(file, code);
       } catch {
         return;
       }
-      for (const entry of scanFile(code, file)) {
+      // Single parse shared by scanFile, collectImportedPackages, and
+      // collectAllImports. On a parse error each consumer re-parses on
+      // its own, preserving their individual failure semantics.
+      let program: ReturnType<typeof parseSync>['program'] | undefined;
+      try {
+        program = parseSync(file, code).program;
+      } catch {
+        program = undefined;
+      }
+      let entries = scanResults.get(file);
+      if (!entries) {
+        entries = scanFile(code, file, program);
+        scanResults.set(file, entries);
+      }
+      for (const entry of entries) {
         if (!registry.has(entry.className))
           registry.set(entry.className, entry);
       }
@@ -294,7 +362,7 @@ export function fastCompilePlugin(
       // BrowserModule → CommonModule → NgIf). Doing this at buildStart means the
       // registry is complete before any component transforms, so non-standalone
       // component scope resolves regardless of file transform order.
-      for (const pkg of collectImportedPackages(code, file)) {
+      for (const pkg of collectImportedPackages(code, file, program)) {
         if (scannedDtsPackages.has(pkg)) continue;
         scannedDtsPackages.add(pkg);
         try {
@@ -312,13 +380,18 @@ export function fastCompilePlugin(
       }
       const dir = dirname(file);
       const targets = await Promise.all(
-        collectAllImports(code, file).map((spec) => {
+        collectAllImports(code, file, program).map((spec) => {
           if (spec.startsWith('.')) {
             return resolveToSource(
               resolve(dir, spec.replace(/\.(?:js|mjs)$/u, '')),
             );
           }
-          return resolveFirstSource(resolvePathSpecifier(spec));
+          let resolved = bareSpecResolveCache.get(spec);
+          if (!resolved) {
+            resolved = resolveFirstSource(resolvePathSpecifier(spec));
+            bareSpecResolveCache.set(spec, resolved);
+          }
+          return resolved;
         }),
       );
       await Promise.all(
@@ -344,7 +417,15 @@ export function fastCompilePlugin(
         }
       }
       await Promise.all(
-        barrelCandidates.map((c) => scanBarrelExports(c, buildStartVisited)),
+        barrelCandidates.map((c) =>
+          scanBarrelExports(
+            c,
+            buildStartVisited,
+            false,
+            fileContents,
+            scanResults,
+          ),
+        ),
       );
     }
     debugRegistry(

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -1,5 +1,6 @@
 import { promises as fsPromises } from 'node:fs';
 import { dirname, isAbsolute, resolve } from 'node:path';
+import { parseSync } from 'oxc-parser';
 import * as vite from 'vite';
 
 import * as compilerCli from '@angular/compiler-cli';
@@ -353,8 +354,12 @@ export function fastCompilePlugin(
     );
   }
 
-  function ensureDtsRegistryForSource(code: string, id: string) {
-    for (const pkg of collectImportedPackages(code, id)) {
+  function ensureDtsRegistryForSource(
+    code: string,
+    id: string,
+    program?: ReturnType<typeof parseSync>['program'],
+  ) {
+    for (const pkg of collectImportedPackages(code, id, program)) {
       if (scannedDtsPackages.has(pkg)) continue;
       scannedDtsPackages.add(pkg);
 
@@ -444,6 +449,11 @@ export function fastCompilePlugin(
     code = inlined.code;
     const { styleExtensions } = inlined;
 
+    // Single OXC parse of the post-inline source, shared by every AST
+    // consumer below. `inlineResourceUrls` parsed the PRE-inline string,
+    // so its program can never be reused here.
+    const { program: oxcProgram } = parseSync(id, code);
+
     // Pre-resolve inline styles that need preprocessing (SCSS/Sass/Less). Run
     // whenever a style needs a non-`css` preprocessor — either the configured
     // `inlineStylesExtension` for truly-inline styles, or an external styleUrl's
@@ -455,7 +465,7 @@ export function fastCompilePlugin(
     const styleNeedsPreprocess = (ext: string) => ext !== '' && ext !== 'css';
 
     if (styleNeedsPreprocess(inlineExt) || styleExtensions.size > 0) {
-      const styleStrings = extractInlineStyles(code, id);
+      const styleStrings = extractInlineStyles(code, id, oxcProgram);
 
       if (styleStrings.length > 0) {
         resolvedInlineStyles = new Map();
@@ -488,7 +498,7 @@ export function fastCompilePlugin(
       }
     }
 
-    ensureDtsRegistryForSource(code, id);
+    ensureDtsRegistryForSource(code, id, oxcProgram);
 
     // Merge entries from the shared external-registry global into this
     // compile's lookup view. Convention: out-of-tree compilers populate
@@ -511,6 +521,7 @@ export function fastCompilePlugin(
       resolvedInlineStyles,
       useDefineForClassFields,
       compilationMode: pluginOptions.fastCompileMode,
+      oxcProgram,
     });
 
     // Track resource dependencies for HMR


### PR DESCRIPTION
## PR Checklist

Closes #2401
Closes #2402
Closes #2408
Closes #2409

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: (none)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Four performance fixes to the fastCompile compiler, in one logical commit each. Emitted output is byte-identical — the conformance summary matches a stash-verified baseline exactly (Pass 469 / Fail 59 / Skip 25 / Error 8) with zero snapshot updates.

1. **`setParentNodes: false` in the compile() TS parse.** Nothing in the compiler uses `.parent` or parent-walking accessors (all accessors pass `origSourceFile` explicitly), so TypeScript's post-parse parent-fixup walk was pure overhead on every transform.

2. **One OXC parse per transform instead of 2-4.** `handleFastCompileTransform` now parses the post-inline source once and threads the program through optional parameters on `collectImportedPackages`, `extractInlineStyles`, `compile()` (`CompileOptions.oxcProgram`), `detectTypeOnlyImportNames`, `elideTypeOnlyImportsMagicString` (`originalProgram`, used only for the `ms.original` position lookup), and the JIT path. All params default to the current internal `parseSync`, so string-based public APIs are unchanged. The parses of mutated text (post-edit `ms.toString()`) are deliberately untouched — those see different strings.

3. **Cold-start dedup in `initFastCompile`.** The three registry sweeps (rootNames scan, import walk, barrel scan) now share per-init file-content and scan-result caches and a single parse per file, and `fs.access` specifier probing is promise-memoized (by absolute base path, and by bare specifier for `paths`-mapped resolution only). Caches are scoped strictly to the init call — HMR/watcher rescans still hit disk fresh. Registry overwrite-vs-`!has` semantics are byte-for-byte preserved.

4. **Async resource inlining.** `inlineResourceUrls` no longer calls `fs.readFileSync` inside the transform hook (which blocked all concurrent Vite transforms); it collects descriptors from the AST, reads with `fs.promises.readFile` (per-read catch preserving keep-original-on-failure per property and styleUrls all-or-nothing semantics), and applies edits in source order.

Version-compat: verified clean across the compiler-compat matrix range (17.3.12 → next) — no changed line touches `@angular/compiler` symbols or `ANGULAR_MAJOR` branches; `oxc-parser` is a direct dependency independent of the Angular pin.

## Test plan

- [x] `nx format:check` (prettier via lint-staged on commit)
- [x] `pnpm build` (`nx build vite-plugin-angular` tsc clean; analog-app fastCompile production build succeeds)
- [x] `pnpm test` (`nx test vite-plugin-angular` after every commit: 1211 passed / 26 skipped, conformance summary identical to baseline, zero snapshot updates)
- [x] Manual verification (dev-served analog-app with fastCompile from the built dist, live-edited a page: serves correctly, no errors)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

(`inlineResourceUrls` changed sync → async, but it is not exported from the package's public entry point and has no external callers.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGBu5vifftgU92BmCMyQs5
