### PR TITLE
perf(vite-plugin-angular): dedupe emits, filter watcher invalidation, and memoize HMR metadata

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -506,7 +506,6 @@ describe('createFsWatcherCacheInvalidator', () => {
     } = setup();
 
     invalidate('/project/src/assets/logo.png');
-    invalidate('/project/src/app/app.component.spec.ts');
     invalidate('/project/src/app/types.d.ts');
     invalidate('/project/src/app/data.json');
     await vi.runAllTimersAsync();
@@ -514,6 +513,22 @@ describe('createFsWatcherCacheInvalidator', () => {
     expect(invalidateFsCaches).not.toHaveBeenCalled();
     expect(invalidateTsconfigCaches).not.toHaveBeenCalled();
     expect(performCompilation).not.toHaveBeenCalled();
+  });
+
+  it('recompiles when a spec file is added so it joins the program', async () => {
+    const {
+      invalidateFsCaches,
+      invalidateTsconfigCaches,
+      performCompilation,
+      invalidate,
+    } = setup();
+
+    invalidate('/project/src/app/app.component.spec.ts');
+    await vi.runAllTimersAsync();
+
+    expect(invalidateFsCaches).toHaveBeenCalledOnce();
+    expect(invalidateTsconfigCaches).toHaveBeenCalledOnce();
+    expect(performCompilation).toHaveBeenCalledOnce();
   });
 
   it('coalesces bursts of events into a single recompilation', async () => {

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -13,11 +13,13 @@ vi.mock('vite', async () => {
 });
 
 import type ts from 'typescript';
+import * as tsModule from 'typescript';
 import {
   angular,
   collectEmittedDiagnostics,
   createFsWatcherCacheInvalidator,
   formatDiagnosticWithLocation,
+  getFileMetadata,
   groupDiagnosticsByFile,
   mapTemplateUpdatesToFiles,
   toAngularCompilationFileReplacements,
@@ -818,6 +820,83 @@ describe('collectEmittedDiagnostics', () => {
       errors: [],
       warnings: [],
     });
+  });
+});
+
+describe('getFileMetadata HMR memoization', () => {
+  const createProgram = (sourceFile: ts.SourceFile) =>
+    ({
+      getSourceFile: () => sourceFile,
+      getSyntacticDiagnostics: () => [],
+    }) as unknown as ts.BuilderProgram;
+
+  const createSourceFile = () =>
+    tsModule.createSourceFile(
+      '/src/app/foo.component.ts',
+      'export class FooComponent {}',
+      tsModule.ScriptTarget.Latest,
+      true,
+    );
+
+  it('emits the HMR update module once per source file identity', () => {
+    const sourceFile = createSourceFile();
+    const angularCompiler = {
+      emitHmrUpdateModule: vi.fn(() => 'hmr-update-code'),
+    };
+    const metadata = getFileMetadata(
+      createProgram(sourceFile),
+      angularCompiler as any,
+      true,
+      true,
+    );
+
+    const first = metadata('/src/app/foo.component.ts');
+    const second = metadata('/src/app/foo.component.ts');
+
+    expect(angularCompiler.emitHmrUpdateModule).toHaveBeenCalledOnce();
+    expect(first.hmrUpdateCode).toBe('hmr-update-code');
+    expect(first.hmrEligible).toBe(true);
+    expect(second.hmrUpdateCode).toBe('hmr-update-code');
+    expect(second.hmrEligible).toBe(true);
+  });
+
+  it('recomputes for a new source file identity', () => {
+    const angularCompiler = {
+      emitHmrUpdateModule: vi.fn(() => 'hmr-update-code'),
+    };
+
+    getFileMetadata(
+      createProgram(createSourceFile()),
+      angularCompiler as any,
+      true,
+      true,
+    )('/src/app/foo.component.ts');
+    getFileMetadata(
+      createProgram(createSourceFile()),
+      angularCompiler as any,
+      true,
+      true,
+    )('/src/app/foo.component.ts');
+
+    expect(angularCompiler.emitHmrUpdateModule).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not emit HMR update modules without liveReload', () => {
+    const angularCompiler = {
+      emitHmrUpdateModule: vi.fn(() => 'hmr-update-code'),
+    };
+    const metadata = getFileMetadata(
+      createProgram(createSourceFile()),
+      angularCompiler as any,
+      false,
+      true,
+    );
+
+    const result = metadata('/src/app/foo.component.ts');
+
+    expect(angularCompiler.emitHmrUpdateModule).not.toHaveBeenCalled();
+    expect(result.hmrUpdateCode).toBeUndefined();
+    expect(result.hmrEligible).toBe(false);
   });
 });
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as realFs from 'node:fs';
 import { tmpdir } from 'node:os';
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { normalizePath, preprocessCSS } from 'vite';
 
 vi.mock('vite', async () => {
@@ -425,7 +425,7 @@ describe('load virtual raw template imports', () => {
 });
 
 describe('createFsWatcherCacheInvalidator', () => {
-  it('clears fs and tsconfig caches before recompiling', async () => {
+  function setup(includeGlobs: string[] = []) {
     const invalidateFsCaches = vi.fn();
     const invalidateTsconfigCaches = vi.fn();
     const performCompilation = vi.fn().mockResolvedValue(undefined);
@@ -433,12 +433,95 @@ describe('createFsWatcherCacheInvalidator', () => {
       invalidateFsCaches,
       invalidateTsconfigCaches,
       performCompilation,
+      includeGlobs,
     );
 
-    await invalidate();
+    return {
+      invalidateFsCaches,
+      invalidateTsconfigCaches,
+      performCompilation,
+      invalidate,
+    };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears fs and tsconfig caches before recompiling', async () => {
+    const {
+      invalidateFsCaches,
+      invalidateTsconfigCaches,
+      performCompilation,
+      invalidate,
+    } = setup();
+
+    invalidate('/project/src/app/new.component.ts');
 
     expect(invalidateFsCaches).toHaveBeenCalledOnce();
     expect(invalidateTsconfigCaches).toHaveBeenCalledOnce();
+    expect(performCompilation).not.toHaveBeenCalled();
+
+    await vi.runAllTimersAsync();
+
+    expect(performCompilation).toHaveBeenCalledOnce();
+  });
+
+  it('recompiles for component resources and tsconfig files', async () => {
+    const { performCompilation, invalidate } = setup();
+
+    invalidate('/project/src/app/app.component.html');
+    await vi.runAllTimersAsync();
+    invalidate('/project/src/app/app.component.scss');
+    await vi.runAllTimersAsync();
+    invalidate('/project/tsconfig.app.json');
+    await vi.runAllTimersAsync();
+
+    expect(performCompilation).toHaveBeenCalledTimes(3);
+  });
+
+  it('recompiles for files matched by include globs', async () => {
+    const { performCompilation, invalidate } = setup([
+      '/project/src/content/**/*.md',
+    ]);
+
+    invalidate('/project/src/content/post.md');
+    await vi.runAllTimersAsync();
+
+    expect(performCompilation).toHaveBeenCalledOnce();
+  });
+
+  it('ignores files that cannot affect the program', async () => {
+    const {
+      invalidateFsCaches,
+      invalidateTsconfigCaches,
+      performCompilation,
+      invalidate,
+    } = setup();
+
+    invalidate('/project/src/assets/logo.png');
+    invalidate('/project/src/app/app.component.spec.ts');
+    invalidate('/project/src/app/types.d.ts');
+    invalidate('/project/src/app/data.json');
+    await vi.runAllTimersAsync();
+
+    expect(invalidateFsCaches).not.toHaveBeenCalled();
+    expect(invalidateTsconfigCaches).not.toHaveBeenCalled();
+    expect(performCompilation).not.toHaveBeenCalled();
+  });
+
+  it('coalesces bursts of events into a single recompilation', async () => {
+    const { performCompilation, invalidate } = setup();
+
+    invalidate('/project/src/app/a.component.ts');
+    invalidate('/project/src/app/a.component.ts');
+    invalidate('/project/src/app/b.component.ts');
+    await vi.runAllTimersAsync();
+
     expect(performCompilation).toHaveBeenCalledOnce();
   });
 });

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -18,6 +18,7 @@ import { type createAngularCompilation as createAngularCompilationType } from '@
 import * as ngCompiler from '@angular/compiler';
 import { globSync } from 'tinyglobby';
 import {
+  createFilter,
   defaultClientConditions,
   ModuleNode,
   normalizePath,
@@ -343,6 +344,10 @@ export function angular(options?: PluginOptions): Plugin[] {
           invalidateFsCaches,
           invalidateTsconfigCaches,
           () => performCompilation(resolvedConfig),
+          pluginOptions.include.map(
+            (glob) =>
+              `${normalizePath(resolve(pluginOptions.workspaceRoot))}${glob}`,
+          ),
         );
         server.watcher.on('add', invalidateCompilationOnFsChange);
         server.watcher.on('unlink', invalidateCompilationOnFsChange);
@@ -1504,15 +1509,44 @@ export function angular(options?: PluginOptions): Plugin[] {
   }
 }
 
+const COMPONENT_RESOURCE_EXT_REGEX = /\.(html|htm|css|scss|sass|less)$/;
+const EXCLUDED_TS_EXT_REGEX = /\.(spec|d)\.[cm]?ts$/;
+
 export function createFsWatcherCacheInvalidator(
   invalidateFsCaches: () => void,
   invalidateTsconfigCaches: () => void,
   performCompilation: () => Promise<void>,
+  includeGlobs: string[] = [],
+  debounceMs = 100,
 ) {
-  return async () => {
+  const includeFilter = includeGlobs.length
+    ? createFilter(includeGlobs)
+    : undefined;
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  return (file: string) => {
+    const affectsProgram =
+      (TS_EXT_REGEX.test(file) && !EXCLUDED_TS_EXT_REGEX.test(file)) ||
+      COMPONENT_RESOURCE_EXT_REGEX.test(file) ||
+      basename(file).includes('tsconfig') ||
+      !!includeFilter?.(file);
+
+    if (!affectsProgram) {
+      return;
+    }
+
     invalidateFsCaches();
     invalidateTsconfigCaches();
-    await performCompilation();
+
+    // Coalesce event bursts (atomic-save add+unlink pairs, git branch
+    // switches) into a single recompilation.
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined;
+      void performCompilation();
+    }, debounceMs);
   };
 }
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1751,6 +1751,17 @@ export function formatDiagnosticWithLocation(
   }: ${text}`;
 }
 
+// Keyed by SourceFile identity — invalidation recreates source files, so a
+// reused object is guaranteed to produce the same HMR update module.
+const hmrMetadataCache = new WeakMap<
+  ts.SourceFile,
+  {
+    hmrUpdateCode: string | null | undefined;
+    hmrEligible: boolean;
+    className?: string;
+  }
+>();
+
 export function getFileMetadata(
   program: ts.BuilderProgram,
   angularCompiler?: NgtscProgram['compiler'],
@@ -1783,14 +1794,28 @@ export function getFileMetadata(
 
     let hmrEligible = false;
     if (liveReload) {
-      for (const node of sourceFile.statements) {
-        if (ts.isClassDeclaration(node) && (node as any).name != null) {
-          hmrUpdateCode = angularCompiler?.emitHmrUpdateModule(node as any);
-          if (!!hmrUpdateCode) {
-            classNames.set(file, (node as any).name.getText());
-            hmrEligible = true;
+      let cached = hmrMetadataCache.get(sourceFile);
+
+      if (!cached) {
+        cached = { hmrUpdateCode: undefined, hmrEligible: false };
+        for (const node of sourceFile.statements) {
+          if (ts.isClassDeclaration(node) && (node as any).name != null) {
+            cached.hmrUpdateCode = angularCompiler?.emitHmrUpdateModule(
+              node as any,
+            );
+            if (!!cached.hmrUpdateCode) {
+              cached.className = (node as any).name.getText();
+              cached.hmrEligible = true;
+            }
           }
         }
+        hmrMetadataCache.set(sourceFile, cached);
+      }
+
+      hmrUpdateCode = cached.hmrUpdateCode;
+      hmrEligible = cached.hmrEligible;
+      if (cached.className != null) {
+        classNames.set(file, cached.className);
       }
     }
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -217,6 +217,7 @@ export function angular(options?: PluginOptions): Plugin[] {
   const templateUrlsResolver = new TemplateUrlsResolver();
   let outputFile: ((file: string) => void) | undefined;
   const outputFiles = new Map<string, EmitFileResult>();
+  let emittedIds = new Set<string>();
   const fileEmitter = (file: string) => {
     outputFile?.(file);
     return outputFiles.get(normalizePath(file));
@@ -1089,6 +1090,10 @@ export function angular(options?: PluginOptions): Plugin[] {
    * It should not be called concurrently. Use `performCompilation` which wraps this method in a lock to ensure only one compilation runs at a time.
    */
   async function _doPerformCompilation(config: ResolvedConfig, ids?: string[]) {
+    // Each pass creates a new builder/program, so previously emitted output
+    // can go stale — only dedupe emits within a single pass.
+    emittedIds = new Set<string>();
+
     // Forward `ids` (modified files) so the Compilation API path can do
     // incremental re-analysis instead of a full recompile on every change.
     if (pluginOptions.useAngularCompilationAPI) {
@@ -1381,6 +1386,14 @@ export function angular(options?: PluginOptions): Plugin[] {
     };
 
     const writeOutputFile = (id: string) => {
+      const normalizedId = normalizePath(id);
+      if (
+        emittedIds.has(normalizedId) &&
+        outputFiles.get(normalizedId)?.content != null
+      ) {
+        return;
+      }
+
       const sourceFile = builder.getSourceFile(id);
       if (!sourceFile) {
         return;
@@ -1451,6 +1464,8 @@ export function angular(options?: PluginOptions): Plugin[] {
       if (angularCompiler) {
         angularCompiler.incrementalCompilation.recordSuccessfulEmit(sourceFile);
       }
+
+      emittedIds.add(normalizedId);
     };
 
     if (watchMode) {

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1513,7 +1513,9 @@ export function angular(options?: PluginOptions): Plugin[] {
 }
 
 const COMPONENT_RESOURCE_EXT_REGEX = /\.(html|htm|css|scss|sass|less)$/;
-const EXCLUDED_TS_EXT_REGEX = /\.(spec|d)\.[cm]?ts$/;
+// Spec files stay included — a newly added spec must join the program's
+// root names in Vitest watch mode.
+const EXCLUDED_TS_EXT_REGEX = /\.d\.[cm]?ts$/;
 
 export function createFsWatcherCacheInvalidator(
   invalidateFsCaches: () => void,

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -691,15 +691,18 @@ export function angular(options?: PluginOptions): Plugin[] {
             }
           }
 
-          const hasComponent = code.includes('@Component');
-          const templateUrls = hasComponent
+          // Resource URLs are only consumed for watch-file registration and
+          // JIT rewrites, so skip resolution entirely in prod AOT builds.
+          const resolveResourceUrls =
+            code.includes('@Component') && (watchMode || jit);
+          const templateUrls = resolveResourceUrls
             ? templateUrlsResolver.resolve(code, id)
             : [];
-          const styleUrls = hasComponent
+          const styleUrls = resolveResourceUrls
             ? styleUrlsResolver.resolve(code, id)
             : [];
 
-          if (hasComponent && watchMode) {
+          if (resolveResourceUrls && watchMode) {
             for (const urlSet of [...templateUrls, ...styleUrls]) {
               // `urlSet` is a string where a relative path is joined with an
               // absolute path using the `|` symbol.

--- a/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
@@ -252,6 +252,87 @@ describe('component-resolvers', () => {
     });
   });
 
+  describe('caching', () => {
+    it('should return the cached style urls for identical code', () => {
+      const code = `
+        @Component({
+          styleUrls: ['./app.component.css']
+        })
+        export class MyComponent {}
+      `;
+
+      const styleUrlsResolver = new StyleUrlsResolver();
+      const first = styleUrlsResolver.resolve(code, id);
+      const second = styleUrlsResolver.resolve(code, id);
+
+      expect(second).toBe(first);
+    });
+
+    it('should re-resolve style urls when the code changes', () => {
+      const styleUrlsResolver = new StyleUrlsResolver();
+      const first = styleUrlsResolver.resolve(
+        `
+        @Component({
+          styleUrls: ['./app.component.css']
+        })
+        export class MyComponent {}
+      `,
+        id,
+      );
+      const second = styleUrlsResolver.resolve(
+        `
+        @Component({
+          styleUrls: ['./other.component.css']
+        })
+        export class MyComponent {}
+      `,
+        id,
+      );
+
+      expect(first).toMatchNormalizedPaths([
+        './app.component.css|/path/to/src/app.component.css',
+      ]);
+      expect(second).toMatchNormalizedPaths([
+        './other.component.css|/path/to/src/other.component.css',
+      ]);
+    });
+
+    it('should return the cached template urls for identical code', () => {
+      const code = `
+        @Component({
+          templateUrl: './app.component.html'
+        })
+        export class MyComponent {}
+      `;
+
+      const templateUrlsResolver = new TemplateUrlsResolver();
+      const first = templateUrlsResolver.resolve(code, id);
+      const second = templateUrlsResolver.resolve(code, id);
+
+      expect(second).toBe(first);
+    });
+
+    it('should resolve template and style urls from the same code', () => {
+      const code = `
+        @Component({
+          templateUrl: './app.component.html',
+          styleUrls: ['./app.component.css']
+        })
+        export class MyComponent {}
+      `;
+
+      const templateUrls = new TemplateUrlsResolver().resolve(code, id);
+      const styleUrls = new StyleUrlsResolver().resolve(code, id);
+
+      expect(templateUrls).toMatchNormalizedPaths([
+        './app.component.html|/path/to/src/app.component.html',
+      ]);
+      expect(styleUrls).toMatchNormalizedPaths([
+        './app.component.css|/path/to/src/app.component.css',
+      ]);
+    });
+  });
+
   describe('component-resolvers templateUrl', () => {
     const id = '/path/to/src/app.component.ts';
 

--- a/packages/vite-plugin-angular/src/lib/component-resolvers.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.ts
@@ -8,7 +8,7 @@ import {
 import { normalizePath } from 'vite';
 
 interface StyleUrlsCacheEntry {
-  matchedStyleUrls: string[];
+  code: string;
   styleUrls: string[];
 }
 
@@ -20,32 +20,42 @@ export class StyleUrlsResolver {
   private readonly styleUrlsCache = new Map<string, StyleUrlsCacheEntry>();
 
   resolve(code: string, id: string): string[] {
-    // Given the code is the following:
-    // @Component({
-    //   styleUrls: [
-    //     './app.component.scss'
-    //   ]
-    // })
-    // The `matchedStyleUrls` would result in: `styleUrls: [\n    './app.component.scss'\n  ]`.
-    const matchedStyleUrls = getStyleUrls(code);
     const entry = this.styleUrlsCache.get(id);
-    // We're using `matchedStyleUrls` as a key because the code may be changing continuously,
-    // resulting in the resolver being called multiple times. While the code changes, the
-    // `styleUrls` may remain constant, which means we should always return the previously
-    // resolved style URLs.
-    if (entry && entry.matchedStyleUrls === matchedStyleUrls) {
+    if (entry?.code === code) {
       return entry.styleUrls;
     }
 
-    const styleUrls = matchedStyleUrls.map((styleUrlPath) => {
+    const styleUrls = getStyleUrls(code).map((styleUrlPath) => {
       return `${styleUrlPath}|${normalizePath(
         resolve(dirname(id), styleUrlPath),
       )}`;
     });
 
-    this.styleUrlsCache.set(id, { styleUrls, matchedStyleUrls });
+    this.styleUrlsCache.set(id, { code, styleUrls });
     return styleUrls;
   }
+}
+
+// Shared project so template and style extraction for the same code reuse a
+// single parse. `resolve()` is synchronous, so the last-parse memo cannot be
+// interleaved by another file's code.
+const project = new Project({ useInMemoryFileSystem: true });
+let lastParsedCode: string | undefined;
+let lastParsedProperties: PropertyAssignment[] = [];
+
+function getPropertyAssignments(code: string): PropertyAssignment[] {
+  if (code === lastParsedCode) {
+    return lastParsedProperties;
+  }
+
+  const sourceFile = project.createSourceFile('cmp.ts', code, {
+    overwrite: true,
+  });
+  lastParsedCode = code;
+  lastParsedProperties = sourceFile.getDescendantsOfKind(
+    SyntaxKind.PropertyAssignment,
+  );
+  return lastParsedProperties;
 }
 
 function getTextByProperty(name: string, properties: PropertyAssignment[]) {
@@ -58,11 +68,7 @@ function getTextByProperty(name: string, properties: PropertyAssignment[]) {
 }
 
 export function getStyleUrls(code: string) {
-  const project = new Project({ useInMemoryFileSystem: true });
-  const sourceFile = project.createSourceFile('cmp.ts', code);
-  const properties = sourceFile.getDescendantsOfKind(
-    SyntaxKind.PropertyAssignment,
-  );
+  const properties = getPropertyAssignments(code);
   const styleUrl = getTextByProperty('styleUrl', properties);
   const styleUrls = properties
     .filter((property) => property.getName() === 'styleUrls')
@@ -75,12 +81,7 @@ export function getStyleUrls(code: string) {
 }
 
 export function getTemplateUrls(code: string) {
-  const project = new Project({ useInMemoryFileSystem: true });
-  const sourceFile = project.createSourceFile('cmp.ts', code);
-  const properties = sourceFile.getDescendantsOfKind(
-    SyntaxKind.PropertyAssignment,
-  );
-  return getTextByProperty('templateUrl', properties);
+  return getTextByProperty('templateUrl', getPropertyAssignments(code));
 }
 
 interface TemplateUrlsCacheEntry {


### PR DESCRIPTION
## PR Checklist

Closes #2403
Closes #2404
Closes #2405
Closes #2407

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: (none)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Four performance fixes to the main (NgtscProgram) plugin's dev/HMR path, one logical commit each, plus a follow-up fix from adversarial review:

1. **Each file emits once per compilation pass.** An `emittedIds` set (reset at the top of `_doPerformCompilation`, so nothing can be served across builder/program recreations) deduplicates the 2-3 redundant `builder.emit` + Ivy-transformer runs per HMR update (eager emit in `performCompilation`, `fileEmitter` from `handleHotUpdate` with liveReload, and the transform-hook re-fetch). The eager emit is kept — it is the only emit in Vitest watch mode.

2. **Watcher invalidation is filtered and coalesced.** Previously any file add/unlink (including images, editor temp files — and atomic saves fire add+unlink pairs) cleared the tsconfig/host caches and forced a full `readConfiguration` + NgtscProgram rebuild + `analyzeAsync`. The invalidator now early-returns unless the path is a TS file (excluding `.d.ts`), a component resource, a tsconfig, or matches the plugin `include` globs, and the recompile is debounced (100ms) so bursts collapse into one compilation. Cache invalidation itself stays immediate per matching event.

3. **Component resource-url resolution is skipped and deduped.** Resolvers only run when their output is consumed (`watchMode || jit`) — eliminating two fresh ts-morph Projects per `@Component` transform in prod AOT builds. `StyleUrlsResolver`'s dead cache (parse-before-lookup + reference-compared array key) now checks before parsing keyed on the code string, and template+style extraction shares one parse via a reused module-level Project.

4. **HMR update-module emission memoized per `ts.SourceFile`.** `emitHmrUpdateModule` (uncached upstream: printNode + `ts.transpileModule` per class) ran for every class of every file on every emit, including cold-start emits whose payload is never consumed. A WeakMap keyed on SourceFile identity (recreated on invalidation, so identity-keying is automatically correct) eliminates the recomputation; diagnostics are deliberately not memoized.

The adversarial scope review caught one regression in the initial watcher filter (excluding `.spec.ts` broke rootNames pickup of newly created spec files in Vitest watch) — fixed in the final commit with a locking test.

Notes for the maintainer from the version-compat review (pre-existing, not changed by this PR): `emitHmrUpdateModule` does not exist on `@angular/compiler-cli` 17/18, and the unguarded call predates this PR; also `compiler-compat.yml`'s path filter does not cover `angular-vite-plugin.ts`.

## Test plan

- [x] `nx format:check` (prettier via lint-staged on commit)
- [x] `pnpm build` (`nx build vite-plugin-angular` tsc clean; blog-app production build on the default path succeeds)
- [x] `pnpm test` (`nx test vite-plugin-angular` after every commit: 1223 passed / 26 skipped including 12 new tests, zero snapshot updates)
- [x] Manual verification (dev-served apps from the built dist; live page edit serves correctly with no errors)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGBu5vifftgU92BmCMyQs5
