### PR TITLE
fix(vite-plugin-angular): track inlined resources for HMR invalidation in fast compile

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/resource-inliner.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/resource-inliner.ts
@@ -16,6 +16,13 @@ export interface InlineResourceResult {
    * truly-inline `styles: [...]` template strings).
    */
   styleExtensions: Map<number, string>;
+  /**
+   * Absolute paths of every external resource file successfully read and
+   * inlined. Callers record these so a later edit to the resource file can
+   * invalidate the owning source module — the inlined copy is otherwise
+   * invisible to the module graph.
+   */
+  resourceDependencies: string[];
 }
 
 /** Whether a node is an inline style value (string literal or single-quasi template). */
@@ -59,7 +66,7 @@ export async function inlineResourceUrls(
   const styleExtensions = new Map<number, string>();
 
   if (!code.includes('templateUrl') && !code.includes('styleUrl')) {
-    return { code, styleExtensions };
+    return { code, styleExtensions, resourceDependencies: [] };
   }
 
   const { program } = parseSync(fileName, code);
@@ -349,7 +356,13 @@ export async function inlineResourceUrls(
     }
   }
 
-  return { code: changed ? ms.toString() : code, styleExtensions };
+  return {
+    code: changed ? ms.toString() : code,
+    styleExtensions,
+    resourceDependencies: [...pathsToRead].filter(
+      (p) => fileContents.get(p) !== undefined,
+    ),
+  };
 }
 
 /** Lower-cased file extension without the leading dot (e.g. `scss`), or `''`. */

--- a/packages/vite-plugin-angular/src/lib/compiler/resource-parity.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/resource-parity.spec.ts
@@ -64,4 +64,31 @@ export class ParityComponent {}
 
     expect(externalOut).toBe(inlineOut);
   });
+
+  it('reports every inlined resource path so HMR can invalidate the owning module', async () => {
+    const external = `import { Component } from '@angular/core';
+@Component({
+  selector: 'app-parity',
+  templateUrl: './test.component.html',
+  styleUrls: ['./test.component.css'],
+})
+export class ParityComponent {}
+`;
+
+    const result = await inlineResourceUrls(external, ID);
+
+    expect(result.resourceDependencies.sort()).toEqual([
+      path.join(FIXTURES, 'test.component.css'),
+      path.join(FIXTURES, 'test.component.html'),
+    ]);
+
+    // Unreadable resources are not reported (nothing was inlined for them).
+    const missing = await inlineResourceUrls(
+      external.replace('./test.component.html', './does-not-exist.html'),
+      ID,
+    );
+    expect(missing.resourceDependencies).toEqual([
+      path.join(FIXTURES, 'test.component.css'),
+    ]);
+  });
 });

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -530,6 +530,14 @@ export function fastCompilePlugin(
     code = inlined.code;
     const { styleExtensions } = inlined;
 
+    // Track inlined resources for HMR. `compile()` only reports resources it
+    // reads through its own fallback (a templateUrl/styleUrl the inliner did
+    // NOT already inline), so files inlined here must be recorded here or a
+    // later edit to them never invalidates the owning module.
+    for (const dep of inlined.resourceDependencies) {
+      resourceToSource.set(dep, id);
+    }
+
     // Single OXC parse of the post-inline source, shared by every AST
     // consumer below. `inlineResourceUrls` parsed the PRE-inline string,
     // so its program can never be reused here.


### PR DESCRIPTION
## PR Checklist

Closes #2413

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: (none)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Editing an external `templateUrl`/`styleUrl` file updates the owning component in the dev server again on the fastCompile path.

`resourceToSource` was only fed from `compile()`'s `resourceDependencies`, which are recorded solely by its read fallback for resources the inliner did **not** already inline — successfully inlined resources were never tracked. The gap predates the perf PRs but was masked by the platform router-plugin's heavy `change`-event invalidation, which #2410 intentionally removed. `inlineResourceUrls` now reports every resource path it successfully read, and the fast-compile plugin records them so a resource edit invalidates its parent module — targeted invalidation instead of the old full-reload side effect.

## Test plan

- [x] `nx format:check` (prettier via lint-staged on commit)
- [x] `pnpm build` (`nx build vite-plugin-angular` clean)
- [x] `pnpm test` (`nx test vite-plugin-angular`: 1224 passed / 26 skipped, incl. new resource-dependency test; zero snapshot updates)
- [x] Manual verification (dev-served analog-app: `shipping.html` and `shipping.scss` edits now reach SSR within ~4s, reverts propagate; regression reproduced on merged beta and absence confirmed on pre-merge baseline first)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGBu5vifftgU92BmCMyQs5
