### PR TITLE
perf(vite-plugin-angular): persist dependency transform output across dep-optimizer runs

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler-plugin.ts
@@ -13,6 +13,7 @@ import {
   CompilerPluginOptions,
   JavaScriptTransformer,
 } from './utils/devkit.js';
+import type { TransformCacheStore } from './utils/transform-cache.js';
 
 type EsbuildOptions = NonNullable<DepOptimizationConfig['esbuildOptions']>;
 type EsbuildPlugin = NonNullable<EsbuildOptions['plugins']>[number];
@@ -21,10 +22,12 @@ export function createCompilerPlugin(
   pluginOptions: CompilerPluginOptions,
   isTest: boolean,
   closeTransformer: boolean,
+  cache?: TransformCacheStore,
 ): EsbuildPlugin {
   const javascriptTransformer = new JavaScriptTransformer(
     { ...pluginOptions, jit: true },
     1,
+    cache,
   );
 
   return {
@@ -52,10 +55,12 @@ export function createRolldownCompilerPlugin(
   pluginOptions: CompilerPluginOptions,
   isTest: boolean,
   closeTransformer: boolean,
+  cache?: TransformCacheStore,
 ): Rolldown.Plugin {
   const javascriptTransformer = new JavaScriptTransformer(
     { ...pluginOptions, jit: true },
     1,
+    cache,
   );
 
   const plugin: Rolldown.Plugin = {

--- a/packages/vite-plugin-angular/src/lib/router-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/router-plugin.ts
@@ -1,14 +1,28 @@
 import type { Plugin } from 'vite';
 import { JavaScriptTransformer } from './utils/devkit.js';
+import {
+  createPersistentTransformCache,
+  resolveTransformCacheDir,
+  withMemoryLayer,
+  type TransformCacheStore,
+} from './utils/transform-cache.js';
 
 export function routerPlugin(): Plugin {
-  const transformCache = new Map<string, Uint8Array>();
-  const javascriptTransformer = new JavaScriptTransformer({ jit: true }, 1, {
-    get: (key: string) => transformCache.get(key),
+  const memoryCache = new Map<string, Uint8Array>();
+  const memoryOnly: TransformCacheStore = {
+    get: (key: string) => memoryCache.get(key),
     put: (key: string, value: Uint8Array) => {
-      transformCache.set(key, value);
+      memoryCache.set(key, value);
     },
-  });
+  };
+  const persistentDir = resolveTransformCacheDir(process.cwd());
+  const javascriptTransformer = new JavaScriptTransformer(
+    { jit: true },
+    1,
+    persistentDir
+      ? withMemoryLayer(createPersistentTransformCache(persistentDir))
+      : memoryOnly,
+  );
 
   /**
    * Transforms Angular packages the didn't get picked up by Vite's pre-optimization.

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { isAbsolute, resolve } from 'node:path';
+import { dirname, isAbsolute, resolve } from 'node:path';
 import * as vite from 'vite';
 import { defaultClientConditions } from 'vite';
 
@@ -7,6 +7,10 @@ import {
   createCompilerPlugin,
   createRolldownCompilerPlugin,
 } from '../compiler-plugin.js';
+import {
+  createPersistentTransformCache,
+  resolveTransformCacheDir,
+} from './transform-cache.js';
 
 /**
  * TypeScript file extension regex
@@ -98,6 +102,14 @@ export function createDepOptimizerConfig(opts: DepOptimizerOptions) {
     ...(opts.watchMode ? {} : { ngDevMode: 'false' }),
   };
 
+  // Persist linked dependency output across dep-optimizer runs. The
+  // transformer's own key covers file bytes + options, and the directory
+  // is namespaced by Angular version, so entries never go stale.
+  const transformCacheDir = resolveTransformCacheDir(dirname(opts.tsconfig));
+  const transformCache = transformCacheDir
+    ? createPersistentTransformCache(transformCacheDir)
+    : undefined;
+
   const rolldownOptions: vite.DepOptimizationOptions['rolldownOptions'] = {
     plugins: [
       createRolldownCompilerPlugin(
@@ -110,6 +122,7 @@ export function createDepOptimizerConfig(opts: DepOptimizerOptions) {
         },
         opts.isTest,
         !opts.isAstroIntegration,
+        transformCache,
       ),
     ],
   };
@@ -126,6 +139,7 @@ export function createDepOptimizerConfig(opts: DepOptimizerOptions) {
         },
         opts.isTest,
         !opts.isAstroIntegration,
+        transformCache,
       ),
     ],
     define: defineOptions,

--- a/packages/vite-plugin-angular/src/lib/utils/transform-cache.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/transform-cache.ts
@@ -1,0 +1,141 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import { VERSION } from '@angular/compiler';
+import { createDebug } from 'obug';
+
+const debugCache = createDebug('analog-transform-cache');
+
+/**
+ * The `{ get, put }` shape `@angular/build`'s `JavaScriptTransformer`
+ * accepts as its third constructor argument. Keys are SHA-256 digests the
+ * transformer derives from the file bytes plus every option that affects
+ * output, so entries are immutable and never need invalidation — but the
+ * digest does NOT cover the linker version, so stores must be namespaced
+ * by Angular version (see {@link resolveTransformCacheDir}).
+ */
+export interface TransformCacheStore {
+  get(key: string): Promise<Uint8Array | undefined> | Uint8Array | undefined;
+  put(key: string, value: Uint8Array): Promise<void> | void;
+}
+
+interface TransformCacheStats {
+  hits: number;
+  misses: number;
+  writes: number;
+  /** Approximate total ms spent in the linker worker for cache misses. */
+  workerMs: number;
+}
+
+/**
+ * Disk-backed content-addressed store for linked/transformed dependency
+ * output. Entries are written atomically (temp + rename) so concurrent
+ * dev servers can share a directory; all failures degrade to a miss.
+ */
+export function createPersistentTransformCache(
+  baseDir: string,
+): TransformCacheStore & { stats: TransformCacheStats } {
+  const stats: TransformCacheStats = {
+    hits: 0,
+    misses: 0,
+    writes: 0,
+    workerMs: 0,
+  };
+  // Miss timestamps by key: with the transformer's serialized worker, the
+  // gap between a missed get and its put approximates linker time per file.
+  const missedAt = new Map<string, number>();
+
+  const entryPath = (key: string) => path.join(baseDir, key.slice(0, 2), key);
+
+  return {
+    stats,
+    async get(key: string): Promise<Uint8Array | undefined> {
+      try {
+        const value = await fs.promises.readFile(entryPath(key));
+        stats.hits++;
+        debugCache('hit %s (hits=%d misses=%d)', key, stats.hits, stats.misses);
+        return value;
+      } catch {
+        stats.misses++;
+        missedAt.set(key, performance.now());
+        debugCache(
+          'miss %s (hits=%d misses=%d)',
+          key,
+          stats.hits,
+          stats.misses,
+        );
+        return undefined;
+      }
+    },
+    async put(key: string, value: Uint8Array): Promise<void> {
+      const startedAt = missedAt.get(key);
+      if (startedAt !== undefined) {
+        missedAt.delete(key);
+        stats.workerMs += performance.now() - startedAt;
+      }
+      try {
+        const file = entryPath(key);
+        await fs.promises.mkdir(path.dirname(file), { recursive: true });
+        const tmp = `${file}.${process.pid}.${crypto.randomBytes(4).toString('hex')}`;
+        await fs.promises.writeFile(tmp, value);
+        await fs.promises.rename(tmp, file);
+        stats.writes++;
+        debugCache(
+          'put %s (writes=%d workerMs=%d)',
+          key,
+          stats.writes,
+          Math.round(stats.workerMs),
+        );
+      } catch (e) {
+        debugCache('put failed %s: %s', key, (e as Error)?.message);
+      }
+    },
+  };
+}
+
+/**
+ * Layer an unbounded in-memory map over a persistent store so repeat
+ * transforms in the same session never touch the disk.
+ */
+export function withMemoryLayer(
+  store: TransformCacheStore,
+): TransformCacheStore {
+  const memory = new Map<string, Uint8Array>();
+  return {
+    async get(key: string): Promise<Uint8Array | undefined> {
+      const cached = memory.get(key) ?? (await store.get(key));
+      if (cached) memory.set(key, cached);
+      return cached;
+    },
+    async put(key: string, value: Uint8Array): Promise<void> {
+      memory.set(key, value);
+      await store.put(key, value);
+    },
+  };
+}
+
+/**
+ * Resolve the shared on-disk cache directory: the nearest `node_modules`
+ * at or above `startDir`, namespaced by the installed Angular version
+ * because the transformer's cache key does not cover the linker version.
+ * Returns `null` (caching disabled) when no `node_modules` exists or the
+ * `ANALOG_TRANSFORM_CACHE=0` kill switch is set.
+ */
+export function resolveTransformCacheDir(startDir: string): string | null {
+  if (process.env['ANALOG_TRANSFORM_CACHE'] === '0') return null;
+  let dir = path.resolve(startDir);
+  for (;;) {
+    if (fs.existsSync(path.join(dir, 'node_modules'))) {
+      return path.join(
+        dir,
+        'node_modules',
+        '.analog',
+        'transform-cache',
+        VERSION.full,
+      );
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}

--- a/packages/vite-plugin-angular/src/lib/utils/transform-cache.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/transform-cache.ts
@@ -115,8 +115,10 @@ export function withMemoryLayer(
 }
 
 /**
- * Resolve the shared on-disk cache directory: the nearest `node_modules`
- * at or above `startDir`, namespaced by the installed Angular version
+ * Resolve the shared on-disk cache directory: `node_modules/.cache` at the
+ * nearest `node_modules` above `startDir` — the conventional tool-cache
+ * location, so installs and `node_modules` cleans evict it without a
+ * separate eviction pass. Namespaced by the installed Angular version
  * because the transformer's cache key does not cover the linker version.
  * Returns `null` (caching disabled) when no `node_modules` exists or the
  * `ANALOG_TRANSFORM_CACHE=0` kill switch is set.
@@ -129,7 +131,8 @@ export function resolveTransformCacheDir(startDir: string): string | null {
       return path.join(
         dir,
         'node_modules',
-        '.analog',
+        '.cache',
+        'analog',
         'transform-cache',
         VERSION.full,
       );


### PR DESCRIPTION
## PR Checklist

Closes #2415

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: (none)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Linked/transformed dependency output persists across dep-optimizer runs. A content-addressed disk store is passed as the `JavaScriptTransformer` cache in the dep-optimizer plugins (esbuild + rolldown variants — previously uncached) and layered under the router fesm transformer's in-memory cache.

Safety model: upstream keys entries by SHA-256 of file bytes + every output-affecting option, so entries are immutable — no invalidation logic exists to get wrong. The key does not cover the linker version, so the store is namespaced by the installed Angular version. It lives under `node_modules/.cache/analog/transform-cache/<version>`: the conventional tool-cache location, evicted naturally by installs and `node_modules` cleans, so no separate eviction pass is needed. Writes are atomic (temp + rename) so concurrent dev servers can share it; every failure degrades to a cache miss. Kill switch: `ANALOG_TRANSFORM_CACHE=0`.

Measured on analog-app dev cold starts with the Vite dep cache wiped (the event this targets — first start, lockfile bump, `--force`, fresh worktree, CI): ~720 dependency files round-trip the babel/linker worker (~815 with a Material-heavy page). Warm cache serves 100% from disk with zero measurable cold-write overhead; wall-clock savings ~0.3–0.5s on analog-app as-is and ~1.5–2s of ~17.5s with 20 Material modules. Savings scale with the app's Angular dependency surface.

## Test plan

- [x] `nx format:check` (prettier via lint-staged on commit)
- [x] `pnpm build` (`nx build vite-plugin-angular` clean)
- [x] `pnpm test` (`nx test vite-plugin-angular`: 38 files, 1224 passed / 26 skipped, zero snapshot updates)
- [x] Manual verification (8× benchmarked dev cold starts baseline vs cold vs warm via `DEBUG=analog-transform-cache` counters; verified store populates at `node_modules/.cache/analog/transform-cache/22.0.0` and serves 100% hits on restart)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGBu5vifftgU92BmCMyQs5
