### PR TITLE
docs: correct angular-typechecker Nx usage in the Angular Compilation guide

### DIFF
--- a/apps/docs-app/docs/guides/angular-compilation.md
+++ b/apps/docs-app/docs/guides/angular-compilation.md
@@ -112,35 +112,41 @@ This keeps fast builds during development while still failing on template and ty
 
 ### Nx workspaces
 
-In an Nx workspace, [`angular-typechecker`](https://www.npmjs.com/package/angular-typechecker) provides an Nx executor that runs the complete Angular type-check — TypeScript checks plus template type-checking and extended `NG8xxx` diagnostics — with no emit, decoupled from build and test, and cacheable per project.
+In an Nx workspace, [`angular-typechecker`](https://www.npmjs.com/package/angular-typechecker) provides an Nx executor that runs the complete Angular type-check: TypeScript checks, template type-checking, and the extended `NG8xxx` diagnostics. It emits nothing and runs separately from your build and tests. Nx caches the result per project.
 
-Install it:
+Add it with `nx add`, which installs the package and runs its `angular-typechecker:init` generator to seed a cacheable `angular-typechecker:typecheck` entry in `nx.json` under `targetDefaults`:
 
 ```bash
-npm install --save-dev angular-typechecker
+nx add angular-typechecker
 ```
 
-Then add an `angular-typecheck` target to the project you want to check:
+Then wire a `typecheck` target into the project you want to check:
 
-```jsonc
-// apps/my-app/project.json
-{
-  "targets": {
-    "angular-typecheck": {
-      "executor": "angular-typechecker:angular-typecheck",
-      "options": {
-        "tsConfig": "apps/my-app/tsconfig.app.json",
-        "includeDeps": true,
-      },
-    },
-  },
-}
+```bash
+nx g angular-typechecker:configuration my-app
 ```
 
 Run it:
 
 ```bash
-nx run my-app:angular-typecheck
+nx typecheck my-app
+```
+
+The generator writes this target. Add `includeDeps: true` to also report diagnostics from dependencies:
+
+```jsonc
+// apps/my-app/project.json
+{
+  "targets": {
+    "typecheck": {
+      "executor": "angular-typechecker:typecheck",
+      "options": {
+        "tsConfig": "apps/my-app/tsconfig.json",
+        "includeDeps": true,
+      },
+    },
+  },
+}
 ```
 
 ## Compatibility


### PR DESCRIPTION
## PR Checklist

Closes # N/A (documentation fix)

The "Nx workspaces" subsection of the Angular Compilation guide documented `angular-typechecker` against its pre-0.1.0 API. Following it today produces an executor id that no longer exists and skips the cacheable `nx.json` setup the package now ships. This updates the subsection to match `angular-typechecker@0.1.x`.

## Affected scope

- Primary scope: docs-app
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

The "Nx workspaces" subsection now:

- Installs with `nx add angular-typechecker`, which runs the package's `angular-typechecker:init` generator to seed a cacheable `angular-typechecker:typecheck` entry in `nx.json` `targetDefaults`. The old `npm install --save-dev` line did neither.
- Uses the correct executor id `angular-typechecker:typecheck`. It was `angular-typechecker:angular-typecheck`, which the package renamed in 0.1.0.
- Adds `nx g angular-typechecker:configuration my-app` to wire the `typecheck` target, and `nx typecheck my-app` to run it.
- Keeps the existing `includeDeps: true` example from the initial version.

## Test plan

- [x] `nx format:check` (ran Prettier 3.8.1 over the file with the repo config; passes)
- [x] `pnpm build` (the `docs-app` Docusaurus build validates the guide; it ran green on this PR through the `analog-docs` deploy preview, and `build-windows` passed)
- [ ] `pnpm test` (not applicable; documentation-only markdown change with no test surface)
- [x] Manual verification: cross-checked every command and the executor and generator names against the published `angular-typechecker@0.1.1` (`executors.json`, `generators.json`, and README)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Guide: https://analogjs.org/docs/guides/angular-compilation
