### PR TITLE
fix(platform): keep library routes opt-in

### DIFF
--- a/packages/platform/src/lib/options.ts
+++ b/packages/platform/src/lib/options.ts
@@ -120,12 +120,12 @@ export interface Options {
    */
   additionalAPIDirs?: string[];
   /**
-   * Automatically discover route directories (pages, content, API) in
-   * workspace libraries by scanning `libs/**` directories directly.
+   * Generate routes from the app's route directories.
    *
-   * Discovered directories are merged with any explicit
-   * `additionalPagesDirs`, `additionalContentDirs`, and
-   * `additionalAPIDirs` values.
+   * Workspace library route directories are opt-in. Use
+   * `discoverLibraryRoutes()` and pass its result to `additionalPagesDirs`,
+   * `additionalContentDirs`, and `additionalAPIDirs` when an app should
+   * include routes from shared libraries.
    *
    * @default false
    */

--- a/packages/platform/src/lib/platform-plugin.spec.ts
+++ b/packages/platform/src/lib/platform-plugin.spec.ts
@@ -10,7 +10,6 @@ const {
   contentPluginSpy,
   serverModePluginSpy,
   clearClientPageEndpointsPluginSpy,
-  discoverLibraryRoutesSpy,
   resolveStylePipelinePluginsSpy,
   stylePipelineFactorySpy,
   stylePipelinePluginSpy,
@@ -24,11 +23,6 @@ const {
   contentPluginSpy: vi.fn(() => []),
   serverModePluginSpy: vi.fn(() => []),
   clearClientPageEndpointsPluginSpy: vi.fn(() => []),
-  discoverLibraryRoutesSpy: vi.fn(() => ({
-    additionalPagesDirs: [],
-    additionalContentDirs: [],
-    additionalAPIDirs: [],
-  })),
   resolveStylePipelinePluginsSpy: vi.fn(() => []),
   stylePipelineFactorySpy: vi.fn(),
   stylePipelinePluginSpy: { name: 'community-style-pipeline' },
@@ -60,9 +54,6 @@ vi.mock('../server-mode-plugin.js', () => ({
 }));
 vi.mock('./clear-client-page-endpoint.js', () => ({
   clearClientPageEndpointsPlugin: clearClientPageEndpointsPluginSpy,
-}));
-vi.mock('./discover-library-routes.js', () => ({
-  discoverLibraryRoutes: discoverLibraryRoutesSpy,
 }));
 vi.mock('./style-pipeline.js', () => ({
   resolveStylePipelinePlugins:
@@ -118,16 +109,14 @@ describe('platformPlugin', () => {
     expect(injectHTMLPluginSpy).not.toHaveBeenCalled();
   });
 
-  it('merges discovered library routes when discoverRoutes is true', () => {
-    discoverLibraryRoutesSpy.mockReturnValue({
+  it('passes through explicit additional route dirs when discoverRoutes is true', () => {
+    platformPlugin({
+      discoverRoutes: true,
       additionalPagesDirs: ['/libs/shared/feature'],
       additionalContentDirs: ['/libs/shared/feature/src/content'],
       additionalAPIDirs: ['/libs/shared/feature/src/api'],
     });
 
-    platformPlugin({ discoverRoutes: true });
-
-    expect(discoverLibraryRoutesSpy).toHaveBeenCalled();
     expect(routerPluginSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         additionalPagesDirs: ['/libs/shared/feature'],
@@ -144,31 +133,6 @@ describe('platformPlugin', () => {
         additionalContentDirs: ['/libs/shared/feature/src/content'],
       }),
     );
-  });
-
-  it('deduplicates explicit and discovered dirs', () => {
-    discoverLibraryRoutesSpy.mockReturnValue({
-      additionalPagesDirs: ['/libs/shared/feature', '/libs/other'],
-      additionalContentDirs: [],
-      additionalAPIDirs: [],
-    });
-
-    platformPlugin({
-      discoverRoutes: true,
-      additionalPagesDirs: ['/libs/shared/feature'],
-    });
-
-    expect(routerPluginSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        additionalPagesDirs: ['/libs/shared/feature', '/libs/other'],
-      }),
-    );
-  });
-
-  it('does not call discoverLibraryRoutes when discoverRoutes is not set', () => {
-    platformPlugin();
-
-    expect(discoverLibraryRoutesSpy).not.toHaveBeenCalled();
   });
 
   it('wires experimental style-pipeline plugins when configured', () => {

--- a/packages/platform/src/lib/platform-plugin.ts
+++ b/packages/platform/src/lib/platform-plugin.ts
@@ -1,5 +1,4 @@
 import { Plugin } from 'vite';
-import { union } from 'es-toolkit';
 
 import { Options } from './options.js';
 import {
@@ -7,7 +6,6 @@ import {
   applyDebugOption,
   debugPlatform,
 } from './utils/debug.js';
-import { discoverLibraryRoutes } from './discover-library-routes.js';
 import { routerPlugin } from './router-plugin.js';
 import { ssrBuildPlugin } from './ssr/ssr-build-plugin.js';
 import { contentPlugin } from './content-plugin.js';
@@ -28,25 +26,6 @@ export function platformPlugin(opts: Options = {}): Plugin[] {
     ssr: true,
     ...opts,
   };
-  if (platformOptions.discoverRoutes) {
-    const workspaceRoot =
-      platformOptions.workspaceRoot ??
-      process.env['NX_WORKSPACE_ROOT'] ??
-      process.cwd();
-    const discovered = discoverLibraryRoutes(workspaceRoot);
-    platformOptions.additionalPagesDirs = union(
-      platformOptions.additionalPagesDirs ?? [],
-      discovered.additionalPagesDirs,
-    );
-    platformOptions.additionalContentDirs = union(
-      platformOptions.additionalContentDirs ?? [],
-      discovered.additionalContentDirs,
-    );
-    platformOptions.additionalAPIDirs = union(
-      platformOptions.additionalAPIDirs ?? [],
-      discovered.additionalAPIDirs,
-    );
-  }
 
   debugPlatform('experimental options resolved', {
     typedRouter: platformOptions.experimental?.typedRouter,


### PR DESCRIPTION
## PR Checklist

Closes #2294

## Affected scope

- Primary scope: platform
- Secondary scopes: routing

## Recommended merge strategy for maintainer [optional]

- [ ] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

`analog({ discoverRoutes: true })` no longer scans every `libs/**/src/{pages,content,api}` directory and merges those routes into the current app.

Apps that want routes from workspace libraries can still opt in explicitly by calling `discoverLibraryRoutes()` and passing the returned directories through `additionalPagesDirs`, `additionalContentDirs`, and `additionalAPIDirs`. That keeps shared library routes available without making unrelated apps inherit each other's pages, content, or API routes just because they live in the same workspace.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [x] Manual verification

Ran:

```shell
vitest run -c packages/platform/vite.config.ts src/lib/platform-plugin.spec.ts src/lib/discover-library-routes.spec.ts src/lib/route-file-discovery.spec.ts
git diff --check
```

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

For apps that relied on `discoverRoutes: true` to implicitly pull in workspace library routes, pass the library route dirs explicitly instead:

```ts
const libs = discoverLibraryRoutes(workspaceRoot);

analog({
  additionalPagesDirs: libs.additionalPagesDirs,
  additionalContentDirs: libs.additionalContentDirs,
  additionalAPIDirs: libs.additionalAPIDirs,
});
```

## Other information

This matches the v3 migration docs, which already show `discoverLibraryRoutes()` as the explicit path for workspace library routes.