### PR TITLE
fix(vite-plugin-angular): skip vmThreads pool default in browser mode

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.spec.ts
@@ -30,4 +30,25 @@ describe(angularVitestPlugin.name, () => {
     );
     expect(config.test?.pool).toBe('threads');
   });
+
+  /* In browser mode a Node pool is a no-op for execution but disables
+   * per-file isolation (`isolate` has no effect under VM pools, and browser
+   * isolation inherits it since Vitest 4.0.7), leaking global state such as
+   * fake timers across spec files. The plugin must not force a pool then.
+   * Cf. https://github.com/analogjs/analog/issues/2222 */
+  it('should not force a pool when browser mode is enabled', async () => {
+    const config = await resolveConfig(
+      defineConfig({
+        plugins: [angularVitestPlugin()],
+        test: {
+          browser: {
+            enabled: true,
+            instances: [{ browser: 'chromium' }],
+          },
+        },
+      }),
+      'serve',
+    );
+    expect(config.test?.pool).toBeUndefined();
+  });
 });

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -13,6 +13,15 @@ export function angularVitestPlugin(): Plugin {
     apply: 'serve',
     enforce: 'post',
     config(userConfig) {
+      // The `vmThreads` pool default only applies to the Node/JSDOM runner.
+      // In Vitest browser mode a Node pool is a no-op for execution, but it
+      // still poisons isolation: `isolate` has no effect under VM pools
+      // (https://vitest.dev/config/isolate), and since Vitest 4.0.7 browser
+      // isolation inherits that resolution — so forcing `vmThreads` disables
+      // per-file isolation and leaks global state (e.g. fake timers) between
+      // spec files. Leave the pool untouched when browser mode is enabled.
+      const browserEnabled = (userConfig as any).test?.browser?.enabled;
+
       return {
         optimizeDeps: {
           include: ['tslib'],
@@ -24,9 +33,13 @@ export function angularVitestPlugin(): Plugin {
             /fesm2015/,
           ],
         },
-        test: {
-          pool: (userConfig as any).test?.pool ?? 'vmThreads',
-        },
+        ...(browserEnabled
+          ? {}
+          : {
+              test: {
+                pool: (userConfig as any).test?.pool ?? 'vmThreads',
+              },
+            }),
       };
     },
     async transform(_code, id) {


### PR DESCRIPTION
## PR Checklist

Closes #2222

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: —

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

The Vitest plugin defaulted `test.pool` to `vmThreads` unconditionally — including in browser mode. In browser mode a Node pool is a no-op for execution, but it silently breaks isolation: `isolate` [has no effect under VM pools](https://vitest.dev/config/isolate), and since Vitest 4.0.7 browser isolation inherits that resolution. Forcing `vmThreads` therefore disabled per-file isolation in the browser, so spec files shared one page/context and global state (e.g. fake timers) leaked across files.

The `vmThreads` default is now only applied when browser mode is **not** enabled. Node/JSDOM runs are unchanged; a user-set `pool` is still respected.

This only affected the top-level `test.browser` config; `test.projects`-based browser setups already isolate correctly and are unaffected.

## Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [x] `pnpm test` — ran the plugin config spec (`angular-vitest-plugin.spec.ts`, 3 passing), including a new regression asserting no pool is forced in browser mode
- [x] Manual verification

Manual verification (Vitest 4.0.18, real Chromium browser mode, order-independent fake-timer leak probe across two spec files):

| Config | pool | Result |
|---|---|---|
| top-level `test.browser` | default | isolated ✅ |
| top-level `test.browser` | `vmThreads` (old behavior) | leaks ❌ |
| top-level `test.browser` | fixed (skip in browser mode) | isolated ✅ |
| `test.projects[].browser` | `vmThreads` | isolated ✅ (unaffected) |

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Supersedes the approach in #2244, which targeted a different failure mode (later `setupTestBed()` calls being ignored) that does not address this isolation leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHgJLoCZsd9hq7rW8RLN3P)_