### PR TITLE
fix(vite-plugin-nitro): enforce path boundary in generated API middleware

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/utils/renderers.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/renderers.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { apiMiddleware } from './renderers';
+
+// Compiles the apiMiddleware string template into an executable handler with
+// mocked h3/#imports dependencies so its URL-boundary logic can be exercised.
+function createApiMiddleware(apiPrefix: string) {
+  const fetchMock = vi.fn(async () => 'fetched');
+  const proxyMock = vi.fn(async () => 'proxied');
+
+  const body = apiMiddleware
+    .replace(/import[^;]+;/g, '')
+    .replace(
+      'export default eventHandler(async (event) => {',
+      'return (async (event) => {',
+    )
+    .replace(/}\);$/, '});');
+
+  const factory = new Function(
+    'eventHandler',
+    'proxyRequest',
+    'createError',
+    'useRuntimeConfig',
+    '$fetch',
+    body,
+  );
+
+  const handler = factory(
+    (fn: unknown) => fn,
+    proxyMock,
+    ({ statusCode }: { statusCode: number }) => {
+      const error = new Error('createError') as Error & { statusCode: number };
+      error.statusCode = statusCode;
+      return error;
+    },
+    () => ({ prefix: '', apiPrefix }),
+    Object.assign(fetchMock, { native: fetchMock }),
+  );
+
+  const run = (url: string, method = 'GET') =>
+    handler({ node: { req: { url, method, headers: {} } } });
+
+  return { run, fetchMock, proxyMock };
+}
+
+describe('apiMiddleware', () => {
+  it('forwards a legitimate API request with the prefix stripped', async () => {
+    const { run, fetchMock } = createApiMiddleware('api');
+    await run('/api/hello');
+    expect(fetchMock).toHaveBeenCalledWith('/hello', expect.anything());
+  });
+
+  it('does not match when the prefix is not on a path boundary', async () => {
+    const { run, fetchMock, proxyMock } = createApiMiddleware('api');
+    const result = await run('/apihttp://127.0.0.1:9911/secret.txt');
+    expect(result).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(proxyMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects protocol-relative targets to prevent SSRF', async () => {
+    const { run, fetchMock } = createApiMiddleware('api');
+    await expect(run('/api//127.0.0.1:9911/secret.txt')).rejects.toMatchObject({
+      statusCode: 400,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not proxy an absolute URL on non-GET methods', async () => {
+    const { run, proxyMock } = createApiMiddleware('api');
+    const result = await run('/apihttp://127.0.0.1:9911/admin', 'POST');
+    expect(result).toBeUndefined();
+    expect(proxyMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vite-plugin-nitro/src/lib/utils/renderers.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/renderers.ts
@@ -32,15 +32,31 @@ export default eventHandler(async () => {
 `;
 
 export const apiMiddleware = `
-import { eventHandler, proxyRequest } from 'h3';
+import { createError, eventHandler, proxyRequest } from 'h3';
 import { useRuntimeConfig } from '#imports';
 
 export default eventHandler(async (event) => {
   const prefix = useRuntimeConfig().prefix;
   const apiPrefix = \`\${prefix}/\${useRuntimeConfig().apiPrefix}\`;
 
-  if (event.node.req.url?.startsWith(apiPrefix)) {
-    const reqUrl = event.node.req.url?.replace(apiPrefix, '');
+  const url = event.node.req.url || '';
+
+  // only match the prefix on a path boundary, otherwise a URL such as
+  // '/apihttp://internal-host' would pass startsWith() and be forwarded verbatim
+  if (
+    url === apiPrefix ||
+    url.startsWith(\`\${apiPrefix}/\`) ||
+    url.startsWith(\`\${apiPrefix}?\`)
+  ) {
+    let reqUrl = url.slice(apiPrefix.length);
+    if (reqUrl === '' || reqUrl.startsWith('?')) {
+      reqUrl = \`/\${reqUrl}\`;
+    }
+
+    // reject absolute and protocol-relative targets to prevent SSRF
+    if (!reqUrl.startsWith('/') || reqUrl.startsWith('//')) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid API route' });
+    }
 
     if (
       event.node.req.method === 'GET' &&


### PR DESCRIPTION
## PR Checklist

Hardens the URL matching in the generated Nitro API middleware. The middleware matched the configured prefix with `startsWith(apiPrefix)` and stripped it with a first-match `replace()`, neither of which enforced a path boundary. As a result a request path that merely began with the prefix characters could be reduced to an absolute or protocol-relative URL and forwarded verbatim to `$fetch`/`proxyRequest`.

Closes #

## Affected scope

- Primary scope: `vite-plugin-nitro`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

The middleware now matches the API prefix only on a path boundary — the URL must equal the prefix, or be followed by `/` or `?`. The prefix is stripped with a length-based `slice` instead of a first-match `replace`, and any resolved target that is not a single-slash-rooted path (i.e. absolute or `//` protocol-relative URLs) is rejected with a `400`. Legitimate `/api/*` routing and the existing `.xml` proxy behavior are unchanged. Adds targeted regression tests for the middleware.

## Test plan

- [x] `nx format:check`
- [x] `pnpm build` (`nx build vite-plugin-nitro`)
- [x] `pnpm test` (`nx test vite-plugin-nitro` — 40 passed)
- [x] Manual verification against a standalone Nitro build

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Input hardening for the API middleware; no public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)