### PR TITLE
test: validate serverFn seeding inside @defer(hydrate) SSR

### DIFF
--- a/apps/streaming-app-e2e-playwright/eslint.config.mjs
+++ b/apps/streaming-app-e2e-playwright/eslint.config.mjs
@@ -1,0 +1,15 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  {
+    ignores: ['**/dist', '**/out-tsc'],
+  },
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+  {
+    ignores: ['**/vite.config.*.timestamp*', '**/vitest.config.*.timestamp*'],
+  },
+];

--- a/apps/streaming-app-e2e-playwright/project.json
+++ b/apps/streaming-app-e2e-playwright/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "streaming-app-e2e-playwright",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/streaming-app-e2e-playwright/src",
+  "projectType": "application",
+  "tags": [],
+  "implicitDependencies": ["streaming-app"],
+  "targets": {
+    "vitest": {
+      "executor": "@nx/vitest:test"
+    },
+    "e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "",
+        "command": "start-server-and-test 'nx serve-nitro streaming-app' http://localhost:3211/fn-buffered 'nx run streaming-app-e2e-playwright:vitest'"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    }
+  }
+}

--- a/apps/streaming-app-e2e-playwright/tests/server-fn-defer-hydrate.spec.ts
+++ b/apps/streaming-app-e2e-playwright/tests/server-fn-defer-hydrate.spec.ts
@@ -1,0 +1,88 @@
+import { Browser, chromium, Page, Request } from 'playwright';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+// Adversarial validation for serverFn resolved inside a `@defer (hydrate on ...)`
+// block. The component holding `injectServerFn` only instantiates when the block
+// resolves on the server, so this exercises whether Angular's SSR stability graph
+// (`whenStable`) awaits that late resource and seeds it into TransferState — and
+// whether the client then hydrates from the seed with zero refetch.
+//
+// The `token` returned by the server function is minted per server call, so it is
+// a witness: identical SSR-vs-client token == hydrated from the seed; a changed
+// token (plus an HTTP call) == refetched on the client.
+
+const baseURL = process.env['E2E_BASE_URL'] ?? 'http://localhost:3211';
+const SERVER_FN_PATH = '/_analog/fn/';
+const SEED_KEY_RE = /__analog_fn_[a-z0-9]+_/;
+const TOKEN_RE = /srv-[0-9a-f-]{8,}/;
+
+let browser: Browser;
+
+beforeAll(async () => {
+  // `PW_EXECUTABLE_PATH` lets a pre-provisioned environment point at its own
+  // Chromium; in CI the default (installed by `playwright install`) is used.
+  const executablePath = process.env['PW_EXECUTABLE_PATH'];
+  browser = await chromium.launch(
+    executablePath ? { executablePath } : undefined,
+  );
+});
+afterAll(async () => {
+  await browser.close();
+});
+
+async function validateRoute(path: string) {
+  // Load in a real browser and watch for any client refetch of the server fn.
+  // Everything is derived from THIS single navigation: the server mints a fresh
+  // token per request, so the SSR token must come from the same response we then
+  // hydrate — not a separate fetch.
+  const page: Page = await browser.newPage();
+  const fnRequests: string[] = [];
+  page.on('request', (req: Request) => {
+    if (req.url().includes(SERVER_FN_PATH)) fnRequests.push(req.url());
+  });
+
+  try {
+    const response = await page.goto(`${baseURL}${path}`, {
+      waitUntil: 'networkidle',
+    });
+    // 1. The server-rendered document for this navigation carries the serverFn
+    //    seed and its value — proof `whenStable` awaited the late resource.
+    const ssrHtml = (await response?.text()) ?? '';
+    expect(ssrHtml, 'ng-state TransferState script present').toContain(
+      'ng-state',
+    );
+    expect(ssrHtml, 'serverFn seed key present in SSR HTML').toMatch(
+      SEED_KEY_RE,
+    );
+    expect(ssrHtml, 'deferred component rendered on the server').toContain(
+      'hello from serverFn',
+    );
+    const ssrToken = ssrHtml.match(TOKEN_RE)?.[0];
+    expect(ssrToken, 'server token embedded in SSR HTML').toBeTruthy();
+
+    // 2. After hydration the block shows the SAME token that was seeded — the
+    //    client read the seed rather than refetching.
+    const token = await page
+      .locator('[data-testid="fn-token"]')
+      .first()
+      .textContent({ timeout: 10000 });
+    expect(token?.trim(), 'client token matches the SSR-seeded token').toBe(
+      ssrToken,
+    );
+
+    // 3. And it got there with no HTTP round-trip to the server function.
+    expect(fnRequests, `no client refetch of ${SERVER_FN_PATH}`).toEqual([]);
+  } finally {
+    await page.close();
+  }
+}
+
+describe('serverFn inside @defer (hydrate on immediate)', () => {
+  test('buffered path: seeds TransferState and hydrates with zero refetch', async () => {
+    await validateRoute('/fn-buffered');
+  });
+
+  test('streaming path: tail carries the seed and hydrates with zero refetch', async () => {
+    await validateRoute('/fn-streaming');
+  });
+});

--- a/apps/streaming-app-e2e-playwright/tsconfig.json
+++ b/apps/streaming-app-e2e-playwright/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "outDir": "../../dist/out-tsc",
+    "allowJs": true,
+    "types": ["node", "vitest/globals"],
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["tests/**/*.ts", "src/**/*.js"]
+}

--- a/apps/streaming-app-e2e-playwright/vite.config.ts
+++ b/apps/streaming-app-e2e-playwright/vite.config.ts
@@ -1,0 +1,24 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => {
+  return {
+    root: 'tests',
+    test: {
+      reporters: ['default'],
+      globals: true,
+      environment: 'node',
+      include: ['**/*.spec.ts'],
+      testTimeout: 30000,
+      hookTimeout: 30000,
+      cache: {
+        dir: `../../node_modules/.vitest`,
+      },
+    },
+    define: {
+      'import.meta.vitest': mode !== 'production',
+    },
+  };
+});

--- a/apps/streaming-app/project.json
+++ b/apps/streaming-app/project.json
@@ -51,7 +51,10 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "",
-        "command": "PORT=3211 node dist/apps/streaming-app/analog/server/index.mjs"
+        "env": {
+          "PORT": "3211"
+        },
+        "command": "node dist/apps/streaming-app/analog/server/index.mjs"
       },
       "dependsOn": ["build"]
     }

--- a/apps/streaming-app/project.json
+++ b/apps/streaming-app/project.json
@@ -46,6 +46,14 @@
           "buildTarget": "streaming-app:build:production"
         }
       }
+    },
+    "serve-nitro": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "",
+        "command": "PORT=3211 node dist/apps/streaming-app/analog/server/index.mjs"
+      },
+      "dependsOn": ["build"]
     }
   }
 }

--- a/apps/streaming-app/src/app/blocks/greeting-fn.component.ts
+++ b/apps/streaming-app/src/app/blocks/greeting-fn.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { injectServerFn } from '@analogjs/router';
+
+import { getGreeting } from '../server-fns/greeting.server';
+
+// Lives inside a `@defer (hydrate on ...)` block, so this component only
+// instantiates once the block resolves on the server. It reads a server
+// function as a `resource()`; the open question is whether SSR `whenStable`
+// awaits that late-instantiated resource so its value is seeded into
+// TransferState (and hydrates on the client with no refetch).
+@Component({
+  selector: 'app-greeting-fn',
+  standalone: true,
+  template: `<aside class="block-fn" data-testid="greeting-fn">
+    @if (greeting.value(); as g) {
+      <span class="fn-message">{{ g.message }}</span>
+      <span class="fn-token" data-testid="fn-token">{{ g.token }}</span>
+    } @else {
+      <span class="fn-loading" data-testid="fn-loading">loading…</span>
+    }
+  </aside>`,
+})
+export class GreetingFn {
+  protected readonly greeting = injectServerFn(getGreeting);
+}

--- a/apps/streaming-app/src/app/pages/fn-buffered.page.ts
+++ b/apps/streaming-app/src/app/pages/fn-buffered.page.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+
+import { GreetingFn } from '../blocks/greeting-fn.component';
+
+// Buffered path (this route opts out of streaming via a `streaming: false`
+// route rule in vite.config.ts). A serverFn-backed resource inside a
+// `@defer (hydrate on immediate)` block — the adversarial case: the block only
+// instantiates the component server-side, so its serverFn read must still be
+// awaited by `whenStable` and seeded into TransferState.
+@Component({
+  selector: 'fn-buffered-page',
+  standalone: true,
+  imports: [GreetingFn],
+  template: `
+    <h1 class="fn-buffered-heading">
+      serverFn in &#64;defer(hydrate) — buffered
+    </h1>
+    @defer (hydrate on immediate) {
+      <app-greeting-fn />
+    } @placeholder {
+      <p class="ph-fn">Loading…</p>
+    }
+  `,
+})
+export default class FnBufferedPage {}

--- a/apps/streaming-app/src/app/pages/fn-streaming.page.ts
+++ b/apps/streaming-app/src/app/pages/fn-streaming.page.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+
+import { GreetingFn } from '../blocks/greeting-fn.component';
+
+// Streaming path (default — no `streaming: false` rule). Confirmatory case: the
+// streaming tail reuses the same `whenStable`, so if the buffered route seeds
+// correctly, the streamed tail must carry the same seed and hydrate with no
+// refetch.
+@Component({
+  selector: 'fn-streaming-page',
+  standalone: true,
+  imports: [GreetingFn],
+  template: `
+    <h1 class="fn-streaming-heading">
+      serverFn in &#64;defer(hydrate) — streaming
+    </h1>
+    @defer (hydrate on immediate) {
+      <app-greeting-fn />
+    } @placeholder {
+      <p class="ph-fn">Loading…</p>
+    }
+  `,
+})
+export default class FnStreamingPage {}

--- a/apps/streaming-app/src/app/server-fns/greeting.server.ts
+++ b/apps/streaming-app/src/app/server-fns/greeting.server.ts
@@ -1,0 +1,14 @@
+import { serverFn } from '@analogjs/router/server';
+
+// GET (input-less) server function. The `token` is minted per server call, so
+// it is a witness for how the value was resolved on the client: if the client
+// hydrates from the SSR TransferState seed it renders the SAME token that was
+// serialized; if the client refetches over HTTP it renders a DIFFERENT token.
+export const getGreeting = serverFn(
+  async (): Promise<{ message: string; token: string }> => {
+    return {
+      message: 'hello from serverFn',
+      token: `srv-${globalThis.crypto.randomUUID()}`,
+    };
+  },
+);

--- a/apps/streaming-app/vite.config.ts
+++ b/apps/streaming-app/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig(() => {
         nitro: {
           routeRules: {
             '/buffered': { streaming: false },
+            '/fn-buffered': { streaming: false },
           },
         },
       }),


### PR DESCRIPTION
## PR Checklist

Adds an adversarial end-to-end test that pins down an open question about the newly-landed Server Functions (#2433) and Streaming SSR (#2419): **does Angular's SSR stability graph (`whenStable`) await a server function resolved inside a `@defer (hydrate on …)` block** — a `resource()` on a component that only instantiates once the block resolves on the server — and seed it into `TransferState` so the client hydrates with **zero refetch**?

The answer, now pinned by a test, is **yes** — on both the buffered and streaming paths.

Closes #

## Affected scope

Test-only; no package source changes. Exercises the `router` server-function client/dispatch + `platform`/`vite-plugin-nitro` streaming paths through the `streaming-app` example.

- Primary scope: `router`
- Secondary scopes: `platform`, `vite-plugin-nitro`

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

The decomposition: the uncertain half lives in the **buffered** path, where it can be settled before streaming is in the picture — buffered SSR also renders `hydrate`-triggered defer blocks server-side and also calls `whenStable` before serializing `TransferState`; streaming's tail reuses that same `whenStable` and is byte-identical, so it only changes *when* bytes flush, not *what* the tail awaits.

- **`streaming-app`** — a new input-less `serverFn` (`greeting.server.ts`) read via `injectServerFn` inside a `@defer (hydrate on immediate)` block (`greeting-fn.component.ts`), on a buffered route (`/fn-buffered`, `streaming: false`) and a streaming route (`/fn-streaming`). The server function mints a per-request `token` that acts as a witness: identical SSR-vs-client token ⇒ hydrated from the seed; a changed token (plus an HTTP call) ⇒ refetched. Adds a `serve-nitro` target so the e2e can run against the production Nitro server over HTTP.
- **`streaming-app-e2e-playwright`** — a new Playwright e2e project (mirrors `trpc-app-e2e-playwright`) asserting, on **both** paths, that (a) the `__analog_fn_<id>` seed key is present in the server-rendered `ng-state` document, (b) the deferred component rendered server-side, (c) the post-hydration DOM token equals the seeded token, and (d) **zero** requests hit `/_analog/fn/` during hydration.

## Test plan

- [x] `nx format:check`
- [x] `nx build streaming-app --configuration=production` (serverFn discovery + client scrub + streaming build all succeed; new chunks emitted)
- [x] Manual verification — served the production Nitro build and confirmed the `__analog_fn_<id>__` seed and its value appear in both the buffered (`/fn-buffered`) and streaming (`/fn-streaming`) SSR documents, with the deferred block rendered server-side (not a placeholder)
- [x] `streaming-app-e2e-playwright` e2e — both specs pass (buffered + streaming): seed present in SSR HTML, DOM token equals the seeded token, and zero `/_analog/fn/` refetches on hydrate

Note: the Playwright spec accepts an optional `PW_EXECUTABLE_PATH` for pre-provisioned environments; in CI the browser installed by `playwright install` is used with no override.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Additive, test-only.

## Other information

This closes the validation gate that the Server Functions and Streaming SSR PRs landed through without an explicit test: a serverFn triggered by a `hydrate`-instantiated defer block is correctly awaited by `whenStable`, seeded into `TransferState`, and hydrated refetch-free — buffered path settles it, streaming path confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016fLjJaroni8PufTmAakBLJ)_