### PR TITLE
test(vite-plugin-angular): triage r3_view_compiler_dom_only conformance category

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/conformance.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/conformance.spec.ts
@@ -311,6 +311,7 @@ const CATEGORIES = [
   'r3_view_compiler_di',
   'r3_view_compiler_arrow_functions',
   'r3_view_compiler_providers',
+  'r3_view_compiler_dom_only', // v22+ DOM-only instruction set fast path
   'r3_view_compiler',
   'r3_compiler_compliance',
   'signal_inputs', // v17-v18 category name


### PR DESCRIPTION
Angular v22.0.x added the `r3_view_compiler_dom_only` compliance fixture
category, which the drift detector flagged as untriaged, failing the
"Angular latest" conformance job. The category tests the DOM-only
instruction-set fast path (`ɵɵdomElementStart`/`ɵɵdomElementEnd`) for
directive-free standalone components.

Add it to CATEGORIES alongside the other `r3_view_compiler_*` entries.
Its single case is filtered to full/local compilation and is skipped by
the existing local-compile guard, so no new assertions run, but the
category is now consciously covered and the drift detector passes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0155PW5VZRX4eTf4eeQHrW6w