### PR TITLE
fix(astro-angular): keep Angular server deps out of the optimizer per environment

### DIFF
--- a/packages/astro-angular/src/index.spec.ts
+++ b/packages/astro-angular/src/index.spec.ts
@@ -63,4 +63,42 @@ describe('angularVitePlugin', () => {
       expect(plugin.configEnvironment('ssr')).toBeUndefined();
     });
   });
+
+  describe('analogjs-astro-server-optimize-deps plugin', () => {
+    function getPlugin() {
+      return getVitePlugins().find(
+        (p) => (p as Plugin).name === 'analogjs-astro-server-optimize-deps',
+      ) as Plugin & {
+        configEnvironment: (
+          name: string,
+        ) => { optimizeDeps: { exclude: string[] } } | undefined;
+      };
+    }
+
+    // Regression for analogjs/analog#2438: top-level `optimizeDeps` only seeds
+    // the client environment, so adapters that run SSR in their own
+    // environment (`@astrojs/cloudflare` on `workerd`) pre-bundled Angular's
+    // server entrypoints and the renderer failed.
+    it('should exclude the server entrypoints for server environments', () => {
+      const exclude =
+        getPlugin().configEnvironment('ssr')?.optimizeDeps.exclude;
+
+      expect(exclude).toEqual([
+        '@angular/platform-server',
+        '@analogjs/astro-angular/server.js',
+        '@analogjs/astro-angular/server-ngh.js',
+        '@angular/core',
+      ]);
+    });
+
+    // Pre-bundling `@angular/core` on the server yields a second Angular
+    // runtime, so components render against a different runtime than the one
+    // they registered in — empty SSR output plus NG0912 ID collisions.
+    it('should exclude @angular/core on the server but keep it optimized on the client', () => {
+      expect(
+        getPlugin().configEnvironment('ssr')?.optimizeDeps.exclude,
+      ).toContain('@angular/core');
+      expect(getPlugin().configEnvironment('client')).toBeUndefined();
+    });
+  });
 });

--- a/packages/astro-angular/src/index.ts
+++ b/packages/astro-angular/src/index.ts
@@ -30,6 +30,21 @@ function getRenderer(ngHydration: boolean | undefined): AstroRenderer {
   };
 }
 
+const SERVER_ENTRYPOINTS = [
+  '@angular/platform-server',
+  '@analogjs/astro-angular/server.js',
+  '@analogjs/astro-angular/server-ngh.js',
+];
+
+/**
+ * Modules the dependency optimizer must leave alone on the server.
+ * `@angular/core` is excluded on top of the server entrypoints because
+ * pre-bundling it produces a second copy of the Angular runtime, so components
+ * render against a different runtime than the one they were registered in —
+ * surfacing as empty SSR output plus `NG0912` component ID collisions.
+ */
+const SERVER_OPTIMIZE_DEPS_EXCLUDE = [...SERVER_ENTRYPOINTS, '@angular/core'];
+
 function getViteConfiguration(options?: AngularOptions): ViteUserConfig {
   return {
     esbuild: {
@@ -43,11 +58,7 @@ function getViteConfiguration(options?: AngularOptions): ViteUserConfig {
           ? '@analogjs/astro-angular/client-ngh.js'
           : '@analogjs/astro-angular/client.js',
       ],
-      exclude: [
-        '@angular/platform-server',
-        '@analogjs/astro-angular/server.js',
-        '@analogjs/astro-angular/server-ngh.js',
-      ],
+      exclude: SERVER_ENTRYPOINTS,
     },
 
     plugins: [
@@ -81,6 +92,25 @@ function getViteConfiguration(options?: AngularOptions): ViteUserConfig {
           }
 
           return undefined;
+        },
+      },
+      {
+        // Top-level `optimizeDeps` only seeds the client environment. Adapters
+        // that run SSR in their own environment — `@astrojs/cloudflare`, which
+        // serves the `ssr` environment on `workerd` — get none of the excludes
+        // above, so Angular's server entrypoints are pre-bundled there and the
+        // renderer breaks. Re-declare them per server environment.
+        name: 'analogjs-astro-server-optimize-deps',
+        configEnvironment(name: string) {
+          if (name === 'client') {
+            return undefined;
+          }
+
+          return {
+            optimizeDeps: {
+              exclude: SERVER_OPTIMIZE_DEPS_EXCLUDE,
+            },
+          };
         },
       },
     ],


### PR DESCRIPTION
## PR Checklist

`astro dev` fails for any Astro project using both `@analogjs/astro-angular` and `@astrojs/cloudflare` v13 (Astro v6), with:

```
[ERROR] [vite] JIT compilation failed for injectable [class _PlatformLocation]
The injectable '_PlatformLocation' needs to be compiled using the JIT compiler, but '@angular/compiler' is not available.
```

Closes #2438

## Affected scope

- Primary scope: `astro-angular`
- Secondary scopes: none — no other package is touched

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A — single focused commit in one package.

## What is the new behavior?

Vite's top-level `optimizeDeps` only seeds the **client** environment. Adapters that run SSR in their own environment — `@astrojs/cloudflare` v13 serves the `ssr` environment on `workerd` — therefore received **none** of the integration's `optimizeDeps.exclude` entries. Angular's server entrypoints were pre-bundled there, so the partially-compiled declarations reached the runtime unlinked and fell back to the JIT compiler, which isn't available under AOT.

This adds an `analogjs-astro-server-optimize-deps` plugin that re-declares the excludes per server environment via `configEnvironment`, leaving the client path untouched.

`@angular/core` is excluded on the server in addition to the server entrypoints. Pre-bundling it produces a **second copy of the Angular runtime**, so components render against a different runtime than the one they registered in. That surfaced only after the first error was resolved, as empty SSR output plus `NG0912` component ID collisions.

## Test plan

- [x] `nx format:check` (full workspace, clean)
- [ ] `pnpm build` — ran the affected package only: `nx build astro-angular` ✅
- [ ] `pnpm test` — ran the affected package only: `nx test astro-angular` ✅ 12 passed (2 new regression tests)
- [x] Manual verification

Manual verification used a standalone project matching the reporter's exact stack (astro `6.4.8`, `@astrojs/cloudflare` `13.7.0`, Angular `22.0.8`, wrangler `4.114.0`), with the local build linked in, running real `astro dev` on `workerd`:

| Variant | HTTP | Component renders | Errors |
| --- | --- | --- | --- |
| Before fix | server exits, `000` | no | `_PlatformLocation` JIT ×2 (matches the report) |
| After fix | `200` | yes — `<app-hello ng-version="22.0.8" ng-server-context="analog">` | none |
| Non-Cloudflare `astro dev` (regression check) | `200` | yes | none |
| Non-Cloudflare `astro build` (regression check) | exit `0` | — | none |

Nothing is pre-bundled in the worker SSR environment after the fix (previously `@analogjs/astro-angular/server.js` and `@angular/core` were).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The new hook returns `undefined` for the `client` environment, so existing client behavior is byte-for-byte unchanged. Non-Cloudflare projects already had these excludes applied through the top-level config; re-declaring them per server environment is a no-op there (verified above).

## Other information

Two pre-existing problems were found while verifying this. Both reproduce **without** this change, so neither is a regression from it, and both are out of scope here:

1. **`astro build` with the Cloudflare adapter still fails** with `JIT compilation failed for injectable [class PlatformLocation]`. A/B-tested against unpatched code — it fails identically, so it is pre-existing. It is a different mechanism (build-time linking rather than the dev dependency optimizer). Note this contradicts the issue's "astro build works", so the reporter's build may differ from the repro used here. Probably deserves its own issue.
2. **`tsconfig.app.json` has no fallback to `tsconfig.json`.** The plugin defaults to `./tsconfig.app.json` and only logs an error when it's missing. Without it, the Node path still compiles but the Cloudflare path fails to AOT-compile app components. This repo's own `apps/astro-app` has the file so it's the expected convention, but a fresh `astro add @analogjs/astro-angular` scaffold won't create one.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BjcJV3LmmwH6dg9MwDNDG
