### PR TITLE
chore: remove leftover @analogjs/trpc references

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -107,16 +107,6 @@ reviews:
       instructions: >-
         Review as the storybook-angular package scope. Prioritize integration correctness,
         example validity, and compatibility with Storybook and Angular tooling.
-    - path: 'packages/trpc/**'
-      instructions: >-
-        Review as the trpc package scope. Focus on runtime integration, API compatibility,
-        and targeted verification for behavior changes.
-    - path: 'apps/trpc-app/**'
-      instructions: >-
-        Treat this app as part of the trpc scope and review changes with the package behavior they validate.
-    - path: 'apps/trpc-app-e2e-playwright/**'
-      instructions: >-
-        Treat this test app as part of the trpc scope. Prioritize reliability and whether the tests validate the intended behavior change.
     - path: 'packages/nx-plugin/**'
       instructions: >-
         Treat as part of the platform package scope. Pay special attention to generators, schemas, migrations,
@@ -195,7 +185,7 @@ reviews:
       requirements: >-
         Prefer Conventional Commit style PR titles. Use type(scope): summary when a supported package scope applies.
         Supported package scopes are vite-plugin-angular, vite-plugin-nitro, vitest-angular, create-analog,
-        astro-angular, router, storybook-angular, platform, content, content-plugin, nx-plugin, and trpc.
+        astro-angular, router, storybook-angular, platform, content, content-plugin, and nx-plugin.
         For repo, docs, or CI-only changes, concise unscoped titles like docs: or ci: are acceptable.
     description:
       mode: warning

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,6 @@ This is the monorepo that contains all the code and infrastructure for AnalogJS.
 | `packages/nx-plugin`           | `@analogjs/nx-plugin`           | `nx-plugin`           |
 | `packages/create-analog`       | `create-analog`                 | `create-analog`       |
 | `packages/storybook-angular`   | `@analogjs/storybook-angular`   | `storybook-angular`   |
-| `packages/trpc`                | `@analogjs/trpc`                | `trpc`                |
 | `packages/astro-angular`       | `@analogjs/astro-angular`       | `astro-angular`       |
 
 ## Agent Skills


### PR DESCRIPTION
## PR Checklist

Removes the remaining non-historical references to the first-party `@analogjs/trpc` package, which was dropped from the workspace as part of the 3.0 major. The package code, the `trpc-app` example, and its e2e app were already removed on `alpha`; this PR completes the cleanup of leftover config/docs references.

Closes #2432

## Affected scope

- Primary scope: repo (config/docs only — `.coderabbit.yaml`, `AGENTS.md`)
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

<!-- Squash merge is highly preferred. -->
<!-- Recommend a non-squash merge only if you can justify why the PR should bypass focused changes per package. -->

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A — single focused cleanup commit.

## What is the new behavior?

- `AGENTS.md`: removed the `packages/trpc` / `@analogjs/trpc` / `trpc` row from the package-scope table.
- `.coderabbit.yaml`: removed the path-review rules for `packages/trpc/**`, `apps/trpc-app/**`, and `apps/trpc-app-e2e-playwright/**`, and dropped `trpc` from the supported PR-title scope list.

## Test plan

<!-- List the commands you ran and any manual verification you performed. -->

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [x] Manual verification — confirmed no `trpc` references remain in `AGENTS.md` or `.coderabbit.yaml`, and that `tsconfig.base.json`, `nx.json`, `release.config.ts`, and `package.json` were already clean.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This PR only removes leftover config/docs references. The breaking removal of the @analogjs/trpc package itself already landed on alpha and is documented in the v2→v3 migration guide. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
<img src="https://static.klipy.com/ii/39f2394ae36df6e199be9eb7c9fa1012/80/e8/dQ5daYHY.gif"/>
