### PR TITLE
fix(vite-plugin-angular): link Angular packages for Astro + Cloudflare (`workerd`) builds

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import type { Plugin, UserConfig } from 'vite';
 import { buildOptimizerPlugin } from './angular-build-optimizer-plugin';
 
@@ -8,6 +8,39 @@ function createPlugin(): Plugin {
     jit: false,
   });
 }
+
+describe('buildOptimizerPlugin apply()', () => {
+  const originalNodeEnv = process.env['NODE_ENV'];
+  afterEach(() => {
+    process.env['NODE_ENV'] = originalNodeEnv;
+  });
+
+  function apply(command: 'build' | 'serve'): boolean {
+    const fn = createPlugin().apply as (
+      c: UserConfig,
+      env: { command: 'build' | 'serve' },
+    ) => boolean;
+    return fn({}, { command });
+  }
+
+  it('applies during build', () => {
+    process.env['NODE_ENV'] = 'development';
+    expect(apply('build')).toBe(true);
+  });
+
+  it('applies in a serve-style pipeline under production NODE_ENV (#2438)', () => {
+    // Astro's Cloudflare integration transforms SSR modules through a
+    // serve-style `workerd` runner during `astro build` (which sets a
+    // production NODE_ENV). The linker must run there.
+    process.env['NODE_ENV'] = 'production';
+    expect(apply('serve')).toBe(true);
+  });
+
+  it('stays off for a regular development serve (unchanged behavior)', () => {
+    process.env['NODE_ENV'] = 'development';
+    expect(apply('serve')).toBe(false);
+  });
+});
 
 describe('buildOptimizerPlugin config()', () => {
   it('should set ngServerMode to true for production SSR builds', () => {

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
@@ -52,3 +52,33 @@ describe('buildOptimizerPlugin config()', () => {
     expect(config.define).toEqual({});
   });
 });
+
+describe('buildOptimizerPlugin transform filter', () => {
+  function filterId(): RegExp {
+    return (createPlugin().transform as any).filter.id as RegExp;
+  }
+
+  it('matches Angular fesm modules carrying a `?v=<hash>` query (#2438)', () => {
+    // Regression: Cloudflare's `workerd` runner (Astro's Cloudflare
+    // integration) references optimized deps with a query suffix. A
+    // `$`-anchored extension match skipped these, so the linker never ran and
+    // the partially-compiled package fell back to the JIT compiler at runtime.
+    const re = filterId();
+    expect(re.test('/x/fesm2022/_platform_location-chunk.mjs?v=a786a9ff')).toBe(
+      true,
+    );
+    expect(re.test('/x/fesm2022/common.mjs?v=abc123')).toBe(true);
+    expect(re.test('/x/foo.js?v=1')).toBe(true);
+    expect(re.test('/x/foo.cjs?v=1')).toBe(true);
+  });
+
+  it('still matches plain .js/.cjs/.mjs and rejects non-JS ids', () => {
+    const re = filterId();
+    expect(re.test('/x/foo.js')).toBe(true);
+    expect(re.test('/x/foo.cjs')).toBe(true);
+    expect(re.test('/x/foo.mjs')).toBe(true);
+    expect(re.test('/x/foo.json')).toBe(false);
+    expect(re.test('/x/foo.ts')).toBe(false);
+    expect(re.test('/x/foo.css?v=1')).toBe(false);
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -21,7 +21,19 @@ export function buildOptimizerPlugin({
 
   return {
     name: '@analogjs/vite-plugin-angular-optimizer',
-    apply: 'build',
+    // Normally build-only. Astro's Cloudflare integration (`@astrojs/cloudflare`)
+    // transforms SSR modules through a serve-style `workerd` runner *during*
+    // `astro build`; an `apply: 'build'` plugin is excluded from that pipeline,
+    // so the Angular linker never runs on the worker's partially-compiled
+    // packages and they fall back to the JIT compiler. Also apply under a
+    // production `NODE_ENV` (which `astro build` sets) so the linker runs in
+    // that runner too. Regular Analog dev servers run with a development
+    // `NODE_ENV`, so their behavior is unchanged.
+    apply(_config, env) {
+      return (
+        env.command === 'build' || process.env['NODE_ENV'] === 'production'
+      );
+    },
     config(userConfig) {
       isProd =
         userConfig.mode === 'production' ||

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -50,10 +50,19 @@ export function buildOptimizerPlugin({
     },
     transform: {
       filter: {
-        id: /\.[cm]?js$/,
+        // Allow an optional `?query` after the extension. Some environments
+        // (e.g. Cloudflare's `workerd`, used by Astro's Cloudflare integration)
+        // reference optimized deps with a `?v=<hash>` suffix, e.g.
+        // `.../fesm2022/_platform_location-chunk.mjs?v=a786a9ff`. A `$`-anchored
+        // extension match skips those, so the Angular linker never runs and the
+        // partially-compiled package falls back to the JIT compiler at runtime.
+        id: /\.[cm]?js(?:\?|$)/,
       },
       async handler(code, id) {
-        const angularPackage = /fesm20/.test(id);
+        // Strip the `?query` so the fesm check and the transformer see a real
+        // filename rather than `foo.mjs?v=<hash>`.
+        const cleanId = id.split('?')[0];
+        const angularPackage = /fesm20/.test(cleanId);
 
         if (!angularPackage) {
           return {
@@ -67,9 +76,9 @@ export function buildOptimizerPlugin({
         }
 
         const sideEffects =
-          jit && id.includes('@angular/compiler') ? true : false;
+          jit && cleanId.includes('@angular/compiler') ? true : false;
         const result: Uint8Array = await javascriptTransformer.transformData(
-          id,
+          cleanId,
           code,
           false,
           sideEffects,


### PR DESCRIPTION
## PR Checklist

Closes #2438

Follow-up to #2439. That PR fixed `astro dev`; this PR fixes the remaining `astro build` failure reported in the same issue, reproduced and validated end-to-end (see Test plan).

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none (astro-angular consumes this at build time)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Reproduced against the reporter's stack (Astro 6.4.8 + `@astrojs/cloudflare` 13.7.0 + Angular 22), `astro build` fails with:

```
JIT compilation failed for injectable [class PlatformLocation]
...'@angular/compiler' is not available.
  at runInRunnerObject (workers/runner-worker/index.js:107:3)
```

Two related causes, both in `buildOptimizerPlugin` (the plugin that runs the Angular linker over partially-compiled `fesm` packages):

1. **`apply: 'build'` excludes the plugin from Cloudflare's build-time runner (primary fix).** `@astrojs/cloudflare` transforms SSR modules through a serve-style `workerd` runner *during* `astro build`, and `apply: 'build'` plugins are excluded from that pipeline. So the linker never ran on the worker's Angular packages; they reached the runtime partially compiled and fell back to JIT. Fixed by applying the plugin during build **or** under a production `NODE_ENV` (which `astro build` sets), so the linker also runs in that runner. Regular Analog dev servers run with a development `NODE_ENV`, so their behavior is unchanged.

2. **The transform filter skipped query-suffixed ids (defensive fix).** The filter `/\.[cm]?js$/` misses ids such as `.../fesm2022/_platform_location-chunk.mjs?v=a786a9ff` that the `workerd` runner can reference. Broadened to `/\.[cm]?js(?:\?|$)/` and the query is stripped before the `fesm` check and the transformer call. This complements the fix above so the linker isn't skipped once it runs.

## Test plan

- [x] `nx format:check` (changed files)
- [x] `pnpm build` (`nx build vite-plugin-angular`)
- [x] `pnpm test` (`nx test vite-plugin-angular` — 665 passed; added `apply()` gating + filter regression tests)
- [x] Manual verification — built an isolated **Astro 6.4.8 + `@astrojs/cloudflare` 13.7.0 + Angular 22** project (an Angular component rendered on a page) against a locally-packed build of this package:
  - On `beta`: `astro build` fails with the `PlatformLocation` JIT error above.
  - With this fix: `astro build` completes (exit 0), client + server bundles emitted.
  - Traced the build runner to confirm the linker now processes the worker's Angular `fesm` modules (`_platform_location-chunk.mjs`, `_server-chunk.mjs`, …) — partial before, linked (`ɵɵdefineInjectable`) after.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The `apply` gate is intentionally scoped to `command === 'build' || NODE_ENV === 'production'` so only production/build pipelines (including the Cloudflare build-time runner) activate the linker; development servers are untouched. Whether this belongs here or should instead be expressed per-environment (à la #2439) is a judgment call worth a maintainer's eye.