### PR TITLE
docs: add copy/open-in-LLM actions to documentation pages

### DIFF
--- a/apps/docs-app/src/components/DocLlmActions/index.tsx
+++ b/apps/docs-app/src/components/DocLlmActions/index.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import Link from '@docusaurus/Link';
+import { useLocation } from '@docusaurus/router';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Translate, { translate } from '@docusaurus/Translate';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+const buttonClass = 'button button--sm button--outline button--primary';
+
+export default function DocLlmActions(): JSX.Element {
+  const { pathname } = useLocation();
+  const {
+    siteConfig: { url },
+  } = useDocusaurusContext();
+  const [copied, setCopied] = useState(false);
+
+  // Each docs page is published as raw Markdown alongside its HTML: index
+  // pages as `<path>/index.md`, leaf pages as `<path>.md`.
+  const markdownPath = pathname.endsWith('/')
+    ? `${pathname}index.md`
+    : `${pathname}.md`;
+  const markdownUrl = `${url}${markdownPath}`;
+
+  const prompt = translate(
+    {
+      id: 'theme.docs.llmActions.prompt',
+      message:
+        'Read {url} so I can ask questions about this AnalogJS documentation page.',
+      description: 'The prompt sent to an assistant when opening a docs page',
+    },
+    { url: markdownUrl },
+  );
+  const encodedPrompt = encodeURIComponent(prompt);
+
+  const copyMarkdown = async () => {
+    try {
+      const response = await fetch(markdownPath);
+      const text = await response.text();
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard/network unavailable; fall back to the "View as Markdown" link.
+    }
+  };
+
+  return (
+    <div className={styles.actions}>
+      <button
+        type="button"
+        className={clsx(buttonClass, styles.action)}
+        onClick={copyMarkdown}
+      >
+        {copied ? (
+          <Translate
+            id="theme.docs.llmActions.copied"
+            description="Confirmation shown after copying the page Markdown"
+          >
+            Copied!
+          </Translate>
+        ) : (
+          <Translate
+            id="theme.docs.llmActions.copy"
+            description="Label for the copy-as-Markdown button"
+          >
+            Copy as Markdown
+          </Translate>
+        )}
+      </button>
+      <Link className={clsx(buttonClass, styles.action)} to={markdownUrl}>
+        <Translate
+          id="theme.docs.llmActions.view"
+          description="Label for the view-as-Markdown link"
+        >
+          View as Markdown
+        </Translate>
+      </Link>
+      <Link
+        className={clsx(buttonClass, styles.action)}
+        to={`https://chatgpt.com/?q=${encodedPrompt}`}
+      >
+        <Translate
+          id="theme.docs.llmActions.chatgpt"
+          description="Label for the open-in-ChatGPT link"
+        >
+          Open in ChatGPT
+        </Translate>
+      </Link>
+      <Link
+        className={clsx(buttonClass, styles.action)}
+        to={`https://claude.ai/new?q=${encodedPrompt}`}
+      >
+        <Translate
+          id="theme.docs.llmActions.claude"
+          description="Label for the open-in-Claude link"
+        >
+          Open in Claude
+        </Translate>
+      </Link>
+    </div>
+  );
+}

--- a/apps/docs-app/src/components/DocLlmActions/styles.module.css
+++ b/apps/docs-app/src/components/DocLlmActions/styles.module.css
@@ -1,0 +1,20 @@
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.action {
+  --ifm-button-border-color: var(--ifm-color-emphasis-300);
+}
+
+@media (max-width: 480px) {
+  .actions {
+    gap: 0.375rem;
+  }
+
+  .action {
+    flex: 1 1 auto;
+  }
+}

--- a/apps/docs-app/src/theme/DocItem/Content/index.tsx
+++ b/apps/docs-app/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Content from '@theme-original/DocItem/Content';
+import type ContentType from '@theme/DocItem/Content';
+import type { WrapperProps } from '@docusaurus/types';
+import DocLlmActions from '@site/src/components/DocLlmActions';
+
+type Props = WrapperProps<typeof ContentType>;
+
+export default function ContentWrapper(props: Props): JSX.Element {
+  return (
+    <>
+      <DocLlmActions />
+      <Content {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
## PR Checklist

Part of #2444
Depends on #2445 (the per-page `.md` files the buttons link to)

## Affected scope

- Primary scope: docs-app (`apps/docs-app`)
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

Each docs page now shows a small actions row at the top, added via a `DocItem/Content` theme wrapper (`src/theme/DocItem/Content/index.tsx`) that renders a new `DocLlmActions` component:

- **Copy as Markdown** — fetches the page's raw `.md` and copies it to the clipboard (with a "Copied!" confirmation)
- **View as Markdown** — opens the raw `.md`
- **Open in ChatGPT** / **Open in Claude** — deep-links the assistant with a prompt pointing at the page's `.md` URL

This surfaces the AI-oriented Markdown output (added in #2445) in the UI instead of leaving it as a hidden file. All labels go through `@docusaurus/Translate` so they can be localized. The `.md` targets are derived from `useLocation()`, so they follow the current locale automatically. The "View as Markdown" link uses the absolute site URL, matching the pattern already used for the `llms.txt` footer links.

## Test plan

- [x] `prettier --check` on changed files — clean
- [x] Built the docs site (`docusaurus build`, en locale) — passes; verified the actions row and all four buttons render on docs pages, with the `.md` targets and ChatGPT/Claude deep links present in the HTML
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Because the buttons target the per-page `.md` files from #2445, that PR should merge first for the Copy/View actions to resolve to real files in production. Part of the tracking issue #2444.

---
_Generated by [Claude Code](https://claude.ai/code/session_01973XfrEjbUZW3Ngj6WZpya)_