### PR TITLE
feat: ship agent context for create-analog and the Nx preset

### DIFF
--- a/packages/create-analog/__tests__/cli.spec.ts
+++ b/packages/create-analog/__tests__/cli.spec.ts
@@ -3,6 +3,7 @@ import { execaCommandSync as commandSync } from 'execa';
 import {
   mkdirpSync,
   readdirSync,
+  readFileSync,
   readJsonSync,
   remove,
   writeFileSync,
@@ -131,4 +132,36 @@ test('strips the vite/vitest overrides with --skipViteOverrides', () => {
   );
   const pkg = readJsonSync(join(genPath, 'package.json'));
   expect(pkg.overrides).toBeUndefined();
+});
+
+test('templates wire up the agent context chain', () => {
+  // CLAUDE.md -> @AGENTS.md -> node_modules/@analogjs/platform/AGENTS.md
+  for (const template of ['latest', 'blog', 'minimal']) {
+    const dir = join(CLI_PATH, `template-${template}`);
+    expect(readFileSync(join(dir, 'CLAUDE.md'), 'utf-8')).toContain(
+      '@AGENTS.md',
+    );
+    expect(readFileSync(join(dir, 'AGENTS.md'), 'utf-8')).toContain(
+      'node_modules/@analogjs/platform/AGENTS.md',
+    );
+  }
+});
+
+test('platform AGENTS.md documents current Analog APIs', () => {
+  const agents = readFileSync(
+    join(CLI_PATH, '..', 'platform', 'AGENTS.md'),
+    'utf-8',
+  );
+  for (const api of [
+    'RouteMeta',
+    'inject(ActivatedRoute)',
+    'defineEventHandler',
+    'injectLoad',
+    'injectContent',
+  ]) {
+    expect(agents).toContain(api);
+  }
+  // deprecated APIs must not be reintroduced
+  expect(agents).not.toContain('defineRouteMeta');
+  expect(agents).not.toContain('injectActivatedRoute');
 });

--- a/packages/create-analog/template-blog/AGENTS.md
+++ b/packages/create-analog/template-blog/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+This is an [AnalogJS](https://analogjs.org) app — an Angular meta-framework powered by Vite.
+
+Framework conventions for AI assistants — file-based routing, server/API routes, data fetching, content routes, and modern Angular usage — ship with the framework and are installed alongside your dependencies. Read them here:
+
+- `node_modules/@analogjs/platform/AGENTS.md`
+
+Reading from `@analogjs/platform` keeps the guidance in sync with the installed version instead of drifting from a copy checked into the project.
+
+Full documentation: https://analogjs.org/docs · LLM-friendly index: https://analogjs.org/llms.txt

--- a/packages/create-analog/template-blog/CLAUDE.md
+++ b/packages/create-analog/template-blog/CLAUDE.md
@@ -1,0 +1,1 @@
+Strictly follow the rules in @AGENTS.md

--- a/packages/create-analog/template-latest/AGENTS.md
+++ b/packages/create-analog/template-latest/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+This is an [AnalogJS](https://analogjs.org) app — an Angular meta-framework powered by Vite.
+
+Framework conventions for AI assistants — file-based routing, server/API routes, data fetching, content routes, and modern Angular usage — ship with the framework and are installed alongside your dependencies. Read them here:
+
+- `node_modules/@analogjs/platform/AGENTS.md`
+
+Reading from `@analogjs/platform` keeps the guidance in sync with the installed version instead of drifting from a copy checked into the project.
+
+Full documentation: https://analogjs.org/docs · LLM-friendly index: https://analogjs.org/llms.txt

--- a/packages/create-analog/template-latest/CLAUDE.md
+++ b/packages/create-analog/template-latest/CLAUDE.md
@@ -1,0 +1,1 @@
+Strictly follow the rules in @AGENTS.md

--- a/packages/create-analog/template-minimal/AGENTS.md
+++ b/packages/create-analog/template-minimal/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+This is an [AnalogJS](https://analogjs.org) app — an Angular meta-framework powered by Vite.
+
+Framework conventions for AI assistants — file-based routing, server/API routes, data fetching, content routes, and modern Angular usage — ship with the framework and are installed alongside your dependencies. Read them here:
+
+- `node_modules/@analogjs/platform/AGENTS.md`
+
+Reading from `@analogjs/platform` keeps the guidance in sync with the installed version instead of drifting from a copy checked into the project.
+
+Full documentation: https://analogjs.org/docs · LLM-friendly index: https://analogjs.org/llms.txt

--- a/packages/create-analog/template-minimal/CLAUDE.md
+++ b/packages/create-analog/template-minimal/CLAUDE.md
@@ -1,0 +1,1 @@
+Strictly follow the rules in @AGENTS.md

--- a/packages/nx-plugin/src/generators/preset/files/AGENTS.md
+++ b/packages/nx-plugin/src/generators/preset/files/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+This is an [AnalogJS](https://analogjs.org) app — an Angular meta-framework powered by Vite.
+
+Framework conventions for AI assistants — file-based routing, server/API routes, data fetching, content routes, and modern Angular usage — ship with the framework and are installed alongside your dependencies. Read them here:
+
+- `node_modules/@analogjs/platform/AGENTS.md`
+
+Reading from `@analogjs/platform` keeps the guidance in sync with the installed version instead of drifting from a copy checked into the project.
+
+Full documentation: https://analogjs.org/docs · LLM-friendly index: https://analogjs.org/llms.txt

--- a/packages/nx-plugin/src/generators/preset/files/CLAUDE.md
+++ b/packages/nx-plugin/src/generators/preset/files/CLAUDE.md
@@ -1,0 +1,1 @@
+Strictly follow the rules in @AGENTS.md

--- a/packages/nx-plugin/src/generators/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.spec.ts
@@ -57,6 +57,15 @@ describe('preset generator', () => {
     expect(packageJson['devDependencies']['@nx/vite']).toBeDefined();
   });
 
+  it('should generate agent context wired to @analogjs/platform', async () => {
+    const { tree } = await setup({ analogAppName: 'my-app' });
+
+    expect(tree.read('/AGENTS.md').toString()).toContain(
+      'node_modules/@analogjs/platform/AGENTS.md',
+    );
+    expect(tree.read('/CLAUDE.md').toString()).toContain('@AGENTS.md');
+  });
+
   it('should use vitest 3 for Nx < 22.3.0', async () => {
     const { tree } = await setup({ analogAppName: 'my-app' });
 

--- a/packages/nx-plugin/src/generators/preset/generator.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.ts
@@ -1,4 +1,5 @@
-import { ensurePackage, NX_VERSION, Tree } from '@nx/devkit';
+import { ensurePackage, generateFiles, NX_VERSION, Tree } from '@nx/devkit';
+import { join } from 'node:path';
 import { PresetGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: PresetGeneratorSchema) {
@@ -8,7 +9,13 @@ export default async function (tree: Tree, options: PresetGeneratorSchema) {
   ensurePackage('@angular-devkit/core', 'latest');
   ensurePackage('rxjs', 'latest');
 
-  return await import('../app/generator').then(({ appGenerator }) =>
+  const appTask = await import('../app/generator').then(({ appGenerator }) =>
     appGenerator(tree, options),
   );
+
+  // Seed agent context at the workspace root so AI coding assistants pick up
+  // Analog conventions (see node_modules/@analogjs/platform/AGENTS.md).
+  generateFiles(tree, join(__dirname, 'files'), '.', options);
+
+  return appTask;
 }

--- a/packages/platform/AGENTS.md
+++ b/packages/platform/AGENTS.md
@@ -1,0 +1,74 @@
+# AnalogJS — conventions for AI coding assistants
+
+This file ships with `@analogjs/platform` and documents how to work in an [AnalogJS](https://analogjs.org) app (an Angular meta-framework, powered by Vite). A generated app's root `AGENTS.md` points here so the guidance stays in sync with the installed version.
+
+## Commands
+
+- `npm start` / `npm run dev` — start the dev server (Vite)
+- `npm run build` — production build
+- `npm test` — run unit tests (Vitest)
+- `npm run preview` — run the built server locally
+
+## Project structure
+
+- `src/app/pages/` — file-based routes (see Routing below)
+- `src/app/` — components and app config (`app.config.ts`, `app.config.server.ts`)
+- `src/server/routes/` — server and API routes (Nitro + h3)
+- `src/main.ts` / `src/main.server.ts` — client and server bootstrap
+- `vite.config.ts` — Vite + Analog plugin and Vitest config
+
+## Routing
+
+Routes are file-based. A file in `src/app/pages/` ending in `.page.ts` becomes a route, and it must `export default` a standalone Angular component.
+
+- `index.page.ts` → `/`
+- `about.page.ts` → `/about`
+- `products/index.page.ts` → `/products`
+- `products/[productId].page.ts` → `/products/:productId` (dynamic segment)
+- `(auth).page.ts` + `(auth)/*.page.ts` → pathless layout: `(auth).page.ts` renders a `<router-outlet />` and wraps its child routes (e.g. `(auth)/login.page.ts` → `/login`, `(auth)/signup.page.ts` → `/signup`) without adding a path segment
+- `[...not-found].page.ts` → catch-all / 404
+
+Read route params with `inject(ActivatedRoute)` from `@angular/router`.
+
+Define per-route metadata (title, meta tags, guards, resolvers) by exporting a `RouteMeta`:
+
+```ts
+import { RouteMeta } from '@analogjs/router';
+
+export const routeMeta: RouteMeta = {
+  title: 'Products',
+};
+```
+
+## Server & API routes
+
+Server routes live in `src/server/routes/` and use [h3](https://h3.dev). API routes are conventionally under `src/server/routes/api/`.
+
+```ts
+import { defineEventHandler } from 'h3';
+
+export default defineEventHandler(() => ({ message: 'Hello World' }));
+```
+
+Filenames encode the HTTP method and params: `hello.get.ts`, `users.post.ts`, `users/[id].get.ts`.
+
+## Data fetching
+
+- **Page load functions:** add a sibling `.server.ts` `load` function and read its result in the page with `injectLoad` from `@analogjs/router`.
+- **Server functions:** define functions in `.server.ts` files and call them from the client with `injectServerFn`.
+
+## Content routes
+
+Markdown content is supported via `@analogjs/content`: `injectContent` / `injectContentFiles` to load content, and `MarkdownComponent` (`analog-markdown`) to render it. Content files live in `src/content/`.
+
+## Conventions
+
+- Use modern Angular: standalone components, `inject()`, signals, and the built-in control flow (`@if`, `@for`, `@switch`).
+- Page components are **default-exported**.
+- Tests are colocated as `*.spec.ts` and run under Vitest (jsdom environment).
+- Prefer existing Angular and Analog APIs over hand-rolled equivalents.
+
+## More
+
+Full documentation: https://analogjs.org/docs
+LLM-friendly docs index: https://analogjs.org/llms.txt


### PR DESCRIPTION
## PR Checklist

Part of #2444

## Affected scope

- Primary scope: create-analog
- Secondary scopes: platform, nx-plugin

## Recommended merge strategy for maintainer [optional]

- [ ] Squash merge
- [x] Rebase merge
- [ ] Other

## Commit preservation note [optional]

Three commits, split by package so each gets its own changelog entry:

1. `feat(platform)` — adds the canonical context file that ships in `@analogjs/platform`
2. `feat(create-analog)` — makes the templates reference it (with tests)
3. `feat(nx-plugin)` — makes the Nx preset reference it (with a test)

A squash would collapse them into one scope and drop the platform/nx-plugin changelog entries, so a rebase merge is preferred here.

## What is the new behavior?

The Analog guidance is shipped **through the package** and referenced from thin per-project files, so there's one source of truth that tracks the installed version:

- **`packages/platform/AGENTS.md`** — the canonical guidance (routing, server/API routes, data fetching, content routes, modern Angular). Picked up by `@analogjs/platform`'s existing `assets` glob, so it publishes to `node_modules/@analogjs/platform/AGENTS.md` the same way the package's `README.md` already ships. Scoped to core authoring conventions with links out to `analogjs.org/docs` + `llms.txt`.
- **create-analog** (`template-{latest,blog,minimal}`) — a thin `AGENTS.md` pointing at `node_modules/@analogjs/platform/AGENTS.md`, plus a `CLAUDE.md` (`Strictly follow the rules in @AGENTS.md`, mirroring this repo's own root `CLAUDE.md`).
- **Nx preset** (`@analogjs/platform` preset) — now emits the same `AGENTS.md` + `CLAUDE.md` at the workspace root, so an Analog workspace created via `create-nx-workspace --preset @analogjs/platform` gets the same context. Scoped to the preset (a fresh Analog workspace); the `app` generator does not write root files into an existing workspace.

## Test plan

- [x] `prettier --check` on changed files — clean
- [x] `nx test create-analog` (Vitest) — 11 passed, 1 skipped, incl. regression tests for the reference chain and that the canonical guidance uses current APIs (`RouteMeta`, `inject(ActivatedRoute)`, `defineEventHandler`, `injectLoad`, `injectContent`) with none of the deprecated ones (`defineRouteMeta`, `injectActivatedRoute`)
- [x] Added a preset generator test asserting the preset emits `/AGENTS.md` (referencing the platform file) and `/CLAUDE.md`. Validated the preset's `generateFiles` emission in isolation (both files written with correct content); the full `nx test nx-plugin` runs in CI (the local sandbox can't compute the Nx project graph)
- [x] Scaffolded a create-analog app and validated the full chain resolves end-to-end: `CLAUDE.md` → `@AGENTS.md` → `node_modules/@analogjs/platform/AGENTS.md` → real content
- [x] Behavioral eval: an agent implemented a routed + server-loaded page and an API route in a scaffolded app using only the shipped context and produced correct, current-API Analog code
- [x] Verified the publish mechanism against the real npm tarball: `@analogjs/platform@2.7.0-beta.3` ships `README.md` at its package root via the same `*.md` assets glob, so `AGENTS.md` publishes the same way
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

`@analogjs/platform` is a devDependency in every template, so `node_modules/@analogjs/platform/AGENTS.md` is present in the dev environment where assistants run. Part of the tracking issue #2444.