### PR TITLE
fix(vite-plugin-angular): clear mapRoot/sourceRoot in Compilation API path (TS5069)

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1010,6 +1010,14 @@ export function angular(options?: PluginOptions): Plugin[] {
           tsCompilerOptions['isolatedModules'] = false;
         }
 
+        // Mirror the legacy `readConfiguration` path (#2322): `@angular/build`'s
+        // `loadConfiguration()` forces `sourceMap`/`declarationMap` off but does
+        // not clear an inherited `mapRoot`/`sourceRoot`, so a monorepo base
+        // tsconfig that sets either trips TS5069 here. Sourcemaps are already
+        // off in this path, so clearing them is safe. See #2449.
+        tsCompilerOptions['mapRoot'] = '';
+        tsCompilerOptions['sourceRoot'] = '';
+
         if (isTest) {
           // Allow `TestBed.overrideXXX()` APIs.
           tsCompilerOptions['supportTestBed'] = true;


### PR DESCRIPTION
## PR Checklist

Closes #2449

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A — single focused change to one package.

## What is the new behavior?

The #2322 fix clears `mapRoot`/`sourceRoot` in the legacy `readConfiguration` path, but that branch is skipped when `experimental.useAngularCompilationAPI` is enabled. The Compilation API path (`performAngularCompilation`) delegates tsconfig loading to `@angular/build`'s `loadConfiguration()`, which forces `sourceMap`/`declarationMap` off but does **not** clear an inherited `mapRoot`/`sourceRoot`. A monorepo base tsconfig that sets `mapRoot` therefore re-triggers `TS5069: Option 'mapRoot' cannot be specified without specifying option 'sourceMap' or option 'declarationMap'` in production builds.

This PR mirrors the legacy fix inside the `compilerOptionsTransformer` by clearing `mapRoot`/`sourceRoot` (sourcemaps are already forced off in this path, so clearing them is safe). The fast-compile path is unaffected — it never creates a tsc/ngtsc emit program, so TS5069 cannot arise there.

## Test plan

- [x] `nx format:check` (scoped to `vite-plugin-angular`) — clean
- [x] `nx build vite-plugin-angular` — compiles
- [x] `nx test vite-plugin-angular` — passing

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Two-line change mirroring the existing #2322 fix; no new abstractions introduced.