### PR TITLE
fix(vite-plugin-angular): serve AOT output for oxc-lowered components on rolldown

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -21,6 +21,7 @@ import {
   formatDiagnosticWithLocation,
   getFileMetadata,
   groupDiagnosticsByFile,
+  isAngularCompilationFile,
   mapTemplateUpdatesToFiles,
   toAngularCompilationFileReplacements,
   isTestWatchMode,
@@ -92,6 +93,32 @@ describe('isTestWatchMode', () => {
     const result = isTestWatchMode(['--watch', 'false']);
 
     expect(result).toBeFalsy();
+  });
+});
+
+describe('isAngularCompilationFile', () => {
+  const rawComponent = `@Component({ selector: 'app-x', templateUrl: './x.component.html' })
+export class XComponent {}`;
+
+  // How rolldown's built-in oxc transform lowers the decorator before this
+  // plugin's transform hook runs — the literal `@Component(` is gone.
+  const loweredComponent = `XComponent = __decorate([Component({ selector: 'app-x', templateUrl: './x.component.html' })], XComponent);`;
+
+  it('matches raw Angular source via the decorator fast-path (no emit yet)', () => {
+    expect(isAngularCompilationFile(rawComponent, false)).toBe(true);
+  });
+
+  it('serves oxc-lowered components using emitted output (#2450)', () => {
+    // The regex alone cannot see the lowered decorator...
+    expect(isAngularCompilationFile(loweredComponent, false)).toBe(false);
+    // ...but program membership rescues it, so the AOT output is served.
+    expect(isAngularCompilationFile(loweredComponent, true)).toBe(true);
+  });
+
+  it('skips non-Angular files that produced no emit', () => {
+    expect(isAngularCompilationFile('export const answer = 42;', false)).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -630,9 +630,15 @@ export function angular(options?: PluginOptions): Plugin[] {
           }
 
           if (pluginOptions.useAngularCompilationAPI) {
-            const isAngular = ANGULAR_DECORATOR_CALL_RE.test(code);
+            // Query-suffixed ids (e.g. `foo.ts?component`) are keyed in
+            // `outputFiles` by their bare path, so strip the query before
+            // looking up the emit result.
+            const emittedId = id.includes('.ts?')
+              ? id.replace(/\?(.*)/, '')
+              : id;
+            const hasEmittedContent = fileEmitter(emittedId)?.content != null;
 
-            if (!isAngular) {
+            if (!isAngularCompilationFile(code, hasEmittedContent)) {
               return;
             }
           }
@@ -1894,6 +1900,26 @@ function getComponentStyleSheetMeta(id: string): {
  */
 function getFilenameFromPath(id: string): string {
   return new URL(id, 'http://localhost').pathname.replace(/^\//, '');
+}
+
+/**
+ * Decides whether a file on the `useAngularCompilationAPI` path should be
+ * served from the Angular compilation's emitted output.
+ *
+ * A source-text regex alone is unreliable here: on rolldown the built-in oxc
+ * transform runs before this plugin's `transform` hook, lowering
+ * `@Component(...)` so the literal decorator no longer appears in `code` even
+ * though the file is an AOT-compiled component. Treating such a file as
+ * non-Angular discards its emitted output and leaves the raw decorator in the
+ * bundle, forcing Angular to JIT at runtime (#2450). Program membership
+ * (`hasEmittedContent`) is the source of truth; the regex is a cheap fast-path
+ * for the raw-source case.
+ */
+export function isAngularCompilationFile(
+  code: string,
+  hasEmittedContent: boolean,
+): boolean {
+  return hasEmittedContent || ANGULAR_DECORATOR_CALL_RE.test(code);
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

On rolldown-vite, a production build with `experimental.useAngularCompilationAPI: true` and `jit: false` shipped application components with their raw `@Component({ templateUrl })` decorator intact instead of AOT-compiled `ɵɵdefineComponent`. At runtime Angular tried to JIT-compile them, but `@angular/compiler` is tree-shaken out of production, so the app threw `JIT compiler unavailable`.

Closes #2450

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A — single focused change scoped to `vite-plugin-angular`.

## What is the new behavior?

**Root cause.** On the `useAngularCompilationAPI` path, the `config` hook leaves rolldown's native oxc TS transform enabled (`oxc: undefined`), unlike the non-compilation path which disables it (`oxc: false`). So on rolldown, oxc runs *before* this plugin's `transform` hook and lowers `@Component({...})` into `__decorate([Component({...})], X)`. The gate then decided whether to serve the already-AOT-compiled output from `outputFiles` using a source-text regex that requires a literal `@Component(` (the `@` anchor added in #2394). Against the lowered source the regex no longer matched, so the file was misclassified as non-Angular and the hook returned early — **discarding the correct AOT output** and letting rolldown's plain type-stripped output (decorator + external `templateUrl` intact) reach the bundle, forcing JIT at runtime.

`emitAffectedFiles()` already compiles the component correctly (`outputFiles` contains `ɵɵdefineComponent` with the inlined template) — the output was simply never consumed.

**Fix.** Key the "serve from `outputFiles`?" decision on program membership (presence of emitted content), not a regex over the possibly-already-transpiled source. The emitter is the source of truth for what Angular compiled; the regex is kept as a cheap fast-path for the raw-source case. The gate logic is extracted into a small exported `isAngularCompilationFile(code, hasEmittedContent)` helper and unit-tested.

The new condition (`hasEmittedContent || regex`) is strictly more permissive than the old one, so no previously-served file can be dropped. Its only behavioral change — in-program non-Angular `.ts` files served from Angular's emit instead of oxc — matches the non-compilation-API path, which has no such gate and already serves all program files from its emit.

## Test plan

- [x] `nx format:check` (`nx format:check --projects=vite-plugin-angular`)
- [x] `pnpm build` (`nx build vite-plugin-angular` — succeeds)
- [x] `pnpm test` (`nx test vite-plugin-angular` — 671 passed, 6 skipped, incl. 3 new `isAngularCompilationFile` tests covering raw source, the oxc-lowered regression, and non-Angular files)
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The fast-compile (non-compilation-API) path is unaffected: it sets `oxc: false`, so it sees raw source and the `@`-anchored regex still works there. This change is isolated to the `useAngularCompilationAPI` gate on the rolldown path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNUShyjBKsYvZ6fNFvayRi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNUShyjBKsYvZ6fNFvayRi)_