### PR TITLE
fix(vite-plugin-angular): replace ts-morph with oxc-parser in component resolvers

### DIFF
--- a/packages/vite-plugin-angular/package.json
+++ b/packages/vite-plugin-angular/package.json
@@ -56,8 +56,7 @@
     "magic-string": "^0.30.21",
     "obug": "^2.1.1",
     "oxc-parser": "^0.121.0",
-    "tinyglobby": "^0.2.14",
-    "ts-morph": "^21.0.0"
+    "tinyglobby": "^0.2.14"
   },
   "builders": "./src/lib/tools/builders.json",
   "ng-update": {

--- a/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.spec.ts
@@ -250,6 +250,21 @@ describe('component-resolvers', () => {
 
       expect(resolvedPaths).toMatchNormalizedPaths(expectedPaths);
     });
+
+    it('should ignore style urls that are not static strings', () => {
+      const code = `
+        @Component({
+          styleUrl: STYLE_URL,
+          styleUrls: [\`./\${name}.css\`]
+        })
+        export class MyComponent {}
+      `;
+
+      const styleUrlsResolver = new StyleUrlsResolver();
+      const resolvedPaths = styleUrlsResolver.resolve(code, id);
+
+      expect(resolvedPaths).toHaveLength(0);
+    });
   });
 
   describe('caching', () => {
@@ -455,6 +470,24 @@ describe('component-resolvers', () => {
         const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
 
         expect(resolvedTemplateUrls).toMatchNormalizedPaths([expectedUrl]);
+      });
+
+      it('should ignore templateUrls inside string literals', () => {
+        const code = `
+        const snippet = "templateUrl: './not-a-real-template.html'";
+
+        @Component({
+          templateUrl: './app.component.html'
+        })
+        export class MyComponent {}
+      `;
+
+        const templateUrlsResolver = new TemplateUrlsResolver();
+        const resolvedTemplateUrls = templateUrlsResolver.resolve(code, id);
+
+        expect(resolvedTemplateUrls).toMatchNormalizedPaths([
+          './app.component.html|/path/to/src/app.component.html',
+        ]);
       });
     });
   });

--- a/packages/vite-plugin-angular/src/lib/component-resolvers.ts
+++ b/packages/vite-plugin-angular/src/lib/component-resolvers.ts
@@ -1,10 +1,5 @@
 import { dirname, resolve } from 'node:path';
-import {
-  ArrayLiteralExpression,
-  Project,
-  PropertyAssignment,
-  SyntaxKind,
-} from 'ts-morph';
+import { parseSync } from 'oxc-parser';
 import { normalizePath } from 'vite';
 
 interface StyleUrlsCacheEntry {
@@ -36,52 +31,95 @@ export class StyleUrlsResolver {
   }
 }
 
-// Shared project so template and style extraction for the same code reuse a
-// single parse. `resolve()` is synchronous, so the last-parse memo cannot be
-// interleaved by another file's code.
-const project = new Project({ useInMemoryFileSystem: true });
-let lastParsedCode: string | undefined;
-let lastParsedProperties: PropertyAssignment[] = [];
-
-function getPropertyAssignments(code: string): PropertyAssignment[] {
-  if (code === lastParsedCode) {
-    return lastParsedProperties;
-  }
-
-  const sourceFile = project.createSourceFile('cmp.ts', code, {
-    overwrite: true,
-  });
-  lastParsedCode = code;
-  lastParsedProperties = sourceFile.getDescendantsOfKind(
-    SyntaxKind.PropertyAssignment,
-  );
-  return lastParsedProperties;
+interface ResourceUrls {
+  templateUrls: string[];
+  styleUrls: string[];
 }
 
-function getTextByProperty(name: string, properties: PropertyAssignment[]) {
-  return properties
-    .filter((property) => property.getName() === name)
-    .map((property) =>
-      property.getInitializer()?.getText().replace(/['"`]/g, ''),
-    )
-    .filter((url): url is string => url !== undefined);
+// Shared memo so template and style extraction for the same code reuse a
+// single parse. `resolve()` is synchronous, so the last-parse memo cannot be
+// interleaved by another file's code.
+let lastParsedCode: string | undefined;
+let lastParsedUrls: ResourceUrls = { templateUrls: [], styleUrls: [] };
+
+function getResourceUrls(code: string): ResourceUrls {
+  if (code === lastParsedCode) {
+    return lastParsedUrls;
+  }
+
+  const urls: ResourceUrls = { templateUrls: [], styleUrls: [] };
+  // A fixed TypeScript filename keeps decorator parsing independent of the
+  // module id, which may carry Vite query suffixes.
+  const { program } = parseSync('cmp.ts', code);
+  visit(program, urls);
+
+  lastParsedCode = code;
+  lastParsedUrls = urls;
+  return urls;
+}
+
+/** Value of a string literal or a template literal without interpolations. */
+function getStringValue(node: any): string | undefined {
+  if (node?.type === 'Literal' && typeof node.value === 'string') {
+    return node.value;
+  }
+
+  if (node?.type === 'TemplateLiteral' && node.quasis?.length === 1) {
+    return node.quasis[0].value.cooked ?? node.quasis[0].value.raw;
+  }
+
+  return undefined;
+}
+
+function collectFromObjectExpression(node: any, urls: ResourceUrls): void {
+  for (const property of node.properties ?? []) {
+    if (property.type !== 'Property') continue;
+
+    const key = property.key?.name ?? property.key?.value;
+    const value = property.value;
+
+    if (key === 'templateUrl') {
+      const url = getStringValue(value);
+      if (url !== undefined) urls.templateUrls.push(url);
+    } else if (key === 'styleUrl') {
+      const url = getStringValue(value);
+      if (url !== undefined) urls.styleUrls.push(url);
+    } else if (key === 'styleUrls' && value?.type === 'ArrayExpression') {
+      for (const element of value.elements) {
+        const url = getStringValue(element);
+        if (url !== undefined) urls.styleUrls.push(url);
+      }
+    }
+  }
+}
+
+// Object literals holding these properties are not always decorator arguments
+// on a top-level class, so every object expression in the file is inspected.
+function visit(node: any, urls: ResourceUrls): void {
+  // Array holes (`[a, , b]`) are `null` entries in the AST.
+  if (!node) return;
+
+  if (Array.isArray(node)) {
+    for (const element of node) visit(element, urls);
+    return;
+  }
+
+  if (node.type === 'ObjectExpression') {
+    collectFromObjectExpression(node, urls);
+  }
+
+  for (const key in node) {
+    const child = node[key];
+    if (child && typeof child === 'object') visit(child, urls);
+  }
 }
 
 export function getStyleUrls(code: string) {
-  const properties = getPropertyAssignments(code);
-  const styleUrl = getTextByProperty('styleUrl', properties);
-  const styleUrls = properties
-    .filter((property) => property.getName() === 'styleUrls')
-    .map((property) => property.getInitializer() as ArrayLiteralExpression)
-    .flatMap((array) =>
-      array.getElements().map((el) => el.getText().replace(/['"`]/g, '')),
-    );
-
-  return [...styleUrls, ...styleUrl];
+  return getResourceUrls(code).styleUrls;
 }
 
 export function getTemplateUrls(code: string) {
-  return getTextByProperty('templateUrl', getPropertyAssignments(code));
+  return getResourceUrls(code).templateUrls;
 }
 
 interface TemplateUrlsCacheEntry {


### PR DESCRIPTION
## PR Checklist

`@analogjs/vite-plugin-angular` declares `ts-morph@^21.0.0`, which pulls in a vulnerable transitive dependency:

```
@analogjs/vite-plugin-angular
 └─┬ ts-morph@21.0.1
   └─┬ @ts-morph/common@0.22.0
     └─┬ minimatch@9.0.9
       └── brace-expansion@2.1.4   ← CVE-2026-14257
```

The issue proposes bumping `ts-morph` to v25+. This PR removes the dependency instead: `ts-morph` had exactly one remaining use in the package — `component-resolvers.ts`, which extracts `templateUrl` / `styleUrl` / `styleUrls` from component source so Vite can watch those files. `oxc-parser` is already a direct dependency of this same package (used by `compile.ts`, `resource-inliner.ts`, `style-ast.ts`, `type-elision.ts`, `jit-transform.ts`, `dts-reader.ts`, `registry.ts`), and handles this extraction directly.

So the CVE chain existed only to support one small extraction routine the existing parser already covers. No new dependency is added.

Closes #2455

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

`component-resolvers.ts` is reimplemented on `oxc-parser`, following the patterns already established in `style-ast.ts` and `resource-inliner.ts`. The per-id caches and the shared last-parse memo are preserved, so `StyleUrlsResolver` and `TemplateUrlsResolver` still share a single parse of the same code.

Two behavior notes worth reviewer attention:

1. **Non-literal values are now skipped.** The old implementation did `.getText().replace(/['"`]/g, '')` on the initializer, so `styleUrl: STYLE_URL` produced the bogus path `"STYLE_URL"`, and a template literal with interpolation produced a mangled string. The new implementation accepts only string literals and interpolation-free template literals. This is a fix, but it is a behavior change — covered by an added test.

2. **The generic AST walk is deliberate.** `style-ast.ts` scopes its search to `@Component` decorators on top-level classes; this file does not. ts-morph's `getDescendantsOfKind(PropertyAssignment)` scanned the entire file, so narrowing the scope could silently break style/template HMR for components declared inside functions or in non-top-level classes. The walk visits every `ObjectExpression`, matching the previous behavior.

Also fixes a latent crash found while validating: array holes (`styleUrls: ['./a.css', , './b.css']`) are `null` entries in the oxc AST and crashed the recursive walk. `resource-inliner.ts` guards against sparse arrays for the same reason, so this is a case that occurs in practice.

## Test plan

- [x] `nx format:check` — clean
- [x] `nx build vite-plugin-angular` — succeeds (package-scoped; full `pnpm build` not run)
- [x] `vitest run --root packages/vite-plugin-angular` — 673 passed / 6 skipped across 36 files (up from 671, with the 2 added tests)
- [x] Manual verification — validated against the real parser that the oxc AST has no cycles (so the recursive walk needs no visited-set), and that the walk costs ~5.6ms on a synthetic 80KB / 400-component file, well under the ts-morph parse it replaces

Two added tests cover the cases where AST parsing is now more correct than the old text-stripping: a `styleUrl` bound to an identifier / an interpolated template literal is ignored rather than yielding a bogus path, and a `templateUrl:` occurring inside an unrelated string literal is not picked up.

Note there is no `lint` target configured for this project, so `nx lint vite-plugin-angular` was not run.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Consumers who passed a non-static value to `styleUrl` / `templateUrl` previously got a nonsensical resolved path, so nothing that worked before stops working.

## Other information

Out of scope for this CVE and intentionally untouched: `packages/content-plugin` uses `ts-morph@^27` (already past the fix) and the root `devDependency` is `^27.0.2`.

`pnpm-lock.yaml` is unchanged, and that is expected — `packages/` are not pnpm workspace members (only `apps/docs-app` is), so the lockfile never contained the vulnerable `ts-morph@21` tree. It comes solely from the published package's declared `dependencies`, which is what this PR edits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EH2A3qqHtfMuagi7kfsuh7)_