### PR TITLE
feat(platform): ship an Agent Plugins v1.0.0 conformant plugin

### DIFF
--- a/apps/docs-analog/src/content/integrations/ai/index.md
+++ b/apps/docs-analog/src/content/integrations/ai/index.md
@@ -67,6 +67,23 @@ The docs site generates these files automatically during its build:
 
 That means the files stay aligned with the published docs instead of requiring a separate export step.
 
+## Framework conventions for coding agents
+
+`@analogjs/platform` ships its own guidance for AI coding assistants, so it tracks the version you have installed instead of drifting from a copy checked into your project.
+
+- `node_modules/@analogjs/platform/AGENTS.md` — Markdown guidance for any client that reads `AGENTS.md`. Generated apps include a root `AGENTS.md` that points here.
+- `node_modules/@analogjs/platform/plugin.json` — an [Agent Plugins v1.0.0](https://github.com/agentplugins/agent-plugins-spec) manifest, with the same guidance as a discoverable skill at `skills/analogjs/SKILL.md`.
+
+Both cover file-based routing, server and API routes, data fetching, content routes, and the modern Angular style Analog expects.
+
+Agent Plugins v1 has no discovery mechanism for plugins installed in `node_modules`, so register the plugin root with your client by hand:
+
+```text
+node_modules/@analogjs/platform
+```
+
+The `AGENTS.md` pointer keeps working with no setup either way.
+
 ## Example workflows
 
 ### Point an assistant at the docs index

--- a/packages/platform/plugin.json
+++ b/packages/platform/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "analogjs",
+  "description": "AnalogJS framework conventions for AI coding assistants — file-based routing, server and API routes, data fetching, and content routes.",
+  "author": {
+    "name": "Brandon Roberts",
+    "email": "robertsbt@gmail.com"
+  },
+  "homepage": "https://analogjs.org",
+  "repository": "https://github.com/analogjs/analog",
+  "license": "MIT",
+  "keywords": ["analog", "angular", "vite", "meta-framework"]
+}

--- a/packages/platform/plugin.spec.ts
+++ b/packages/platform/plugin.spec.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const read = (file: string) =>
+  readFileSync(new URL(file, import.meta.url), 'utf-8');
+
+describe('agent plugin', () => {
+  it('has a spec-conformant plugin.json', () => {
+    const manifest = JSON.parse(read('./plugin.json'));
+
+    expect(manifest.$schema).toBe(
+      'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json',
+    );
+    expect(manifest.name).toMatch(
+      /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/,
+    );
+  });
+
+  it('exposes the analogjs skill with required frontmatter', () => {
+    const skill = read('./skills/analogjs/SKILL.md');
+    const [, frontmatter] = skill.split('---\n');
+
+    expect(frontmatter).toContain('name: analogjs');
+    expect(frontmatter).toMatch(/description: .+/);
+  });
+
+  it('documents the same APIs as AGENTS.md', () => {
+    const skill = read('./skills/analogjs/SKILL.md');
+
+    for (const api of [
+      'RouteMeta',
+      'inject(ActivatedRoute)',
+      'defineEventHandler',
+      'injectLoad',
+      'injectServerFn',
+      'injectContent',
+    ]) {
+      expect(skill).toContain(api);
+    }
+  });
+});

--- a/packages/platform/project.json
+++ b/packages/platform/project.json
@@ -14,7 +14,13 @@
         "tsConfig": "packages/platform/tsconfig.lib.json",
         "assets": [
           "packages/platform/*.md",
-          "packages/platform/migrations/migration.json"
+          "packages/platform/plugin.json",
+          "packages/platform/migrations/migration.json",
+          {
+            "input": "./packages/platform/skills",
+            "glob": "**/*",
+            "output": "./skills"
+          }
         ],
         "updateBuildableProjectDepsInPackageJson": false
       },

--- a/packages/platform/skills/analogjs/SKILL.md
+++ b/packages/platform/skills/analogjs/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: analogjs
+description: Conventions for working in an AnalogJS app (an Angular meta-framework powered by Vite) — file-based routing with `.page.ts` files, `RouteMeta`, server and API routes on Nitro/h3, page load functions and server functions in `.server.ts` files, markdown content routes, and the modern Angular style Analog expects. Use when reading or writing code in a project that depends on `@analogjs/platform`.
+license: MIT
+---
+
+# AnalogJS — conventions for AI coding assistants
+
+This skill ships with `@analogjs/platform` and documents how to work in an [AnalogJS](https://analogjs.org) app (an Angular meta-framework, powered by Vite). It mirrors the `AGENTS.md` published alongside it, so the guidance stays in sync with the installed version.
+
+## Commands
+
+- `npm start` / `npm run dev` — start the dev server (Vite)
+- `npm run build` — production build
+- `npm test` — run unit tests (Vitest)
+- `npm run preview` — run the built server locally
+
+## Project structure
+
+- `src/app/pages/` — file-based routes (see Routing below)
+- `src/app/` — components and app config (`app.config.ts`, `app.config.server.ts`)
+- `src/server/routes/` — server and API routes (Nitro + h3)
+- `src/main.ts` / `src/main.server.ts` — client and server bootstrap
+- `vite.config.ts` — Vite + Analog plugin and Vitest config
+
+## Routing
+
+Routes are file-based. A file in `src/app/pages/` ending in `.page.ts` becomes a route, and it must `export default` a standalone Angular component.
+
+- `index.page.ts` → `/`
+- `about.page.ts` → `/about`
+- `products/index.page.ts` → `/products`
+- `products/[productId].page.ts` → `/products/:productId` (dynamic segment)
+- `(auth).page.ts` + `(auth)/*.page.ts` → pathless layout: `(auth).page.ts` renders a `<router-outlet />` and wraps its child routes (e.g. `(auth)/login.page.ts` → `/login`, `(auth)/signup.page.ts` → `/signup`) without adding a path segment
+- `[...not-found].page.ts` → catch-all / 404
+
+Read route params with `inject(ActivatedRoute)` from `@angular/router`.
+
+Define per-route metadata (title, meta tags, guards, resolvers) by exporting a `RouteMeta`:
+
+```ts
+import { RouteMeta } from '@analogjs/router';
+
+export const routeMeta: RouteMeta = {
+  title: 'Products',
+};
+```
+
+## Server & API routes
+
+Server routes live in `src/server/routes/` and use [h3](https://h3.dev). API routes are conventionally under `src/server/routes/api/`.
+
+```ts
+import { defineEventHandler } from 'h3';
+
+export default defineEventHandler(() => ({ message: 'Hello World' }));
+```
+
+Filenames encode the HTTP method and params: `hello.get.ts`, `users.post.ts`, `users/[id].get.ts`.
+
+## Data fetching
+
+- **Page load functions:** add a sibling `.server.ts` `load` function and read its result in the page with `injectLoad` from `@analogjs/router`.
+- **Server functions:** define functions in `.server.ts` files and call them from the client with `injectServerFn`.
+
+## Content routes
+
+Markdown content is supported via `@analogjs/content`: `injectContent` / `injectContentFiles` to load content, and `MarkdownComponent` (`analog-markdown`) to render it. Content files live in `src/content/`.
+
+## Conventions
+
+- Use modern Angular: standalone components, `inject()`, signals, and the built-in control flow (`@if`, `@for`, `@switch`).
+- Page components are **default-exported**.
+- Tests are colocated as `*.spec.ts` and run under Vitest (jsdom environment).
+- Prefer existing Angular and Analog APIs over hand-rolled equivalents.
+
+## More
+
+Full documentation: https://analogjs.org/docs
+LLM-friendly docs index: https://analogjs.org/llms.txt


### PR DESCRIPTION
## PR Checklist

Adds an [Agent Plugins v1.0.0](https://github.com/agentplugins/agent-plugins-spec) conformant plugin to `@analogjs/platform`, giving the guidance already published as `AGENTS.md` a structured, machine discoverable form.

Closes #2464

## Affected scope

- Primary scope: `platform`
- Secondary scopes: `docs`

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A — squash is fine.

## What is the new behavior?

New files under `packages/platform/`:

```
packages/platform/
├── plugin.json               # new
├── AGENTS.md                 # unchanged
└── skills/
    └── analogjs/
        └── SKILL.md          # new, mirrors AGENTS.md
```

- **`plugin.json`** — required `$schema` (canonical `1.0.0` identifier) and `name` (`analogjs`), plus `description`, `author`, `homepage`, `repository`, `license`, `keywords`. The plugin root is the package root, so `plugin.json` and `package.json` sit side by side.
- **`skills/analogjs/SKILL.md`** — one skill, not one per topic, per the issue's reasoning. `name` / `description` / `license` frontmatter as required by the [Agent Skills spec](https://agentskills.io/specification).
- **`project.json`** — the `packages/platform/*.md` asset glob is widened to also copy `plugin.json` and `skills/**/*` into the published package.
- **Docs** — a "Framework conventions for coding agents" section on the *Build with AI* page covering both the `AGENTS.md` pointer and the plugin root, including the manual registration step (spec v1 has no discovery mechanism for plugins under `node_modules`).

### `version` is deliberately omitted

The manifest's `version` field is optional. Releases only bump `package.json`, so a hardcoded `version` in `plugin.json` would go stale on the next release. Wiring it up means build machinery that isn't worth it at this size — better absent than wrong.

### Backward compatibility

Purely additive. Markdown based clients keep reading `AGENTS.md` exactly as they do now, and generated apps' root `AGENTS.md` pointer is unchanged.

## Test plan

- [ ] `nx format:check`
- [x] `pnpm build`
- [x] `pnpm test`
- [x] Manual verification

Ran locally:

- `nx test platform` — 59 passed, 1 skipped, including 3 new tests in `packages/platform/plugin.spec.ts` (manifest `$schema` + `name` pattern, skill frontmatter, API parity with `AGENTS.md`).
- `nx build-package platform` — confirmed the published output contains `plugin.json` and `skills/analogjs/SKILL.md`, and that `plugin.spec.ts` is *not* shipped.
- `npx prettier --check` on all changed files — clean.
- `npx eslint packages/platform/plugin.spec.ts` — clean.

`nx format:check` is left unchecked: the full-workspace run didn't finish locally, so per-file `prettier --check` was run instead. CI will confirm.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Spec v1 has no discovery mechanism for installed plugins — nothing tells a client to look in `node_modules`, so users register the plugin root by hand for now. Adopting today is a bet that client conventions converge later; the `AGENTS.md` pointer keeps working with zero user action either way, so the downside is bounded.

Only the English docs page was updated. The `de` / `es` / `zh-hans` translations of that page are left for a separate pass.

Growth path, when a section outgrows the body: move it into `skills/analogjs/references/` rather than adding a sibling skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)