### PR TITLE
docs: constrain the forms guide video embed on mobile

### DIFF
--- a/apps/docs-analog/src/content/es/guides/forms.md
+++ b/apps/docs-analog/src/content/es/guides/forms.md
@@ -7,7 +7,9 @@ Analog admite el manejo en el lado del servidor de los envíos y la validación 
     <iframe
       width="560"
       height="315"
-      src="https://www.youtube.com/embed/4pFPO1OpD4Q?si=HcESaJI03LgEljpQ&amp;controls=0">
+      title="Acciones del Servidor para Formularios en Analog"
+      src="https://www.youtube.com/embed/4pFPO1OpD4Q?si=HcESaJI03LgEljpQ&amp;controls=0"
+      allowfullscreen>
     </iframe>
   </div>
 </div>

--- a/apps/docs-analog/src/content/es/guides/forms.md
+++ b/apps/docs-analog/src/content/es/guides/forms.md
@@ -2,8 +2,8 @@
 
 Analog admite el manejo en el lado del servidor de los envíos y la validación de formularios.
 
-<div className="video-container">
-  <div className="video-responsive-wrapper">
+<div class="video-container">
+  <div class="video-responsive-wrapper">
     <iframe
       width="560"
       height="315"

--- a/apps/docs-analog/src/content/guides/forms.md
+++ b/apps/docs-analog/src/content/guides/forms.md
@@ -2,8 +2,8 @@
 
 Analog supports server-side handling of form submissions and validation.
 
-<div className="video-container">
-  <div className="video-responsive-wrapper">
+<div class="video-container">
+  <div class="video-responsive-wrapper">
     <iframe
       width="560"
       height="315"

--- a/apps/docs-analog/src/content/guides/forms.md
+++ b/apps/docs-analog/src/content/guides/forms.md
@@ -7,7 +7,9 @@ Analog supports server-side handling of form submissions and validation.
     <iframe
       width="560"
       height="315"
-      src="https://www.youtube.com/embed/4pFPO1OpD4Q?si=HcESaJI03LgEljpQ&amp;controls=0">
+      title="Form Server Actions in Analog"
+      src="https://www.youtube.com/embed/4pFPO1OpD4Q?si=HcESaJI03LgEljpQ&amp;controls=0"
+      allowfullscreen>
     </iframe>
   </div>
 </div>

--- a/apps/docs-analog/src/content/pt-br/guides/forms.md
+++ b/apps/docs-analog/src/content/pt-br/guides/forms.md
@@ -7,7 +7,9 @@ O Analog suporta manipulação do lado do servidor para envios e validação de 
     <iframe
       width="560"
       height="315"
-      src="https://www.youtube.com/embed/4pFPO1OpD4Q?si=HcESaJI03LgEljpQ&amp;controls=0">
+      title="Ações de Formulários no Servidor no Analog"
+      src="https://www.youtube.com/embed/4pFPO1OpD4Q?si=HcESaJI03LgEljpQ&amp;controls=0"
+      allowfullscreen>
     </iframe>
   </div>
 </div>

--- a/apps/docs-analog/src/content/pt-br/guides/forms.md
+++ b/apps/docs-analog/src/content/pt-br/guides/forms.md
@@ -2,8 +2,8 @@
 
 O Analog suporta manipulação do lado do servidor para envios e validação de formulários.
 
-<div className="video-container">
-  <div className="video-responsive-wrapper">
+<div class="video-container">
+  <div class="video-responsive-wrapper">
     <iframe
       width="560"
       height="315"

--- a/apps/docs-analog/src/content/zh-hans/guides/forms.md
+++ b/apps/docs-analog/src/content/zh-hans/guides/forms.md
@@ -7,7 +7,9 @@ Analog 支持服务器端处理表单提交和验证。
     <iframe
       width="560"
       height="315"
-      src="https://www.youtube.com/embed/4pFPO1OpD4Q?si=HcESaJI03LgEljpQ&amp;controls=0">
+      title="Analog 中的表单服务器操作"
+      src="https://www.youtube.com/embed/4pFPO1OpD4Q?si=HcESaJI03LgEljpQ&amp;controls=0"
+      allowfullscreen>
     </iframe>
   </div>
 </div>

--- a/apps/docs-analog/src/content/zh-hans/guides/forms.md
+++ b/apps/docs-analog/src/content/zh-hans/guides/forms.md
@@ -2,8 +2,8 @@
 
 Analog 支持服务器端处理表单提交和验证。
 
-<div className="video-container">
-  <div className="video-responsive-wrapper">
+<div class="video-container">
+  <div class="video-responsive-wrapper">
     <iframe
       width="560"
       height="315"

--- a/apps/docs-analog/src/styles.css
+++ b/apps/docs-analog/src/styles.css
@@ -288,6 +288,23 @@ body {
   display: none;
 }
 
+/* Responsive video embeds (raw HTML in markdown) */
+.video-container {
+  width: 100%;
+  max-width: 750px;
+  margin: 1.5rem auto;
+}
+.video-responsive-wrapper {
+  aspect-ratio: 16 / 9;
+}
+.video-responsive-wrapper iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: var(--radius-lg);
+}
+
 /* Markdown table */
 .analog-markdown table {
   border-collapse: collapse;


### PR DESCRIPTION
## PR Checklist

The video embed on [/docs/guides/forms](https://analogjs.org/docs/guides/forms) overflows the viewport on mobile. Two causes, both leftovers from the Docusaurus → Analog docs migration (#2453):

1. The markup uses JSX `className="video-container"`, which browsers ignore as an unknown attribute — no class is ever applied.
2. `apps/docs-analog/src/styles.css` has no `.video-container` / `.video-responsive-wrapper` rules. Those only exist in the legacy `apps/docs-app/src/css/custom.css`.

With no class and no styles, the iframe falls back to its literal `width="560"` and overflows narrow viewports.

No linked issue — reported directly.

## Affected scope

- Primary scope: `docs-analog` (docs site, no npm package affected)
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

- `className` → `class` in `guides/forms.md` across all four locales (en, es, pt-br, zh-hans).
- Added responsive video styles to `docs-analog/src/styles.css`, using `aspect-ratio: 16 / 9` rather than porting the old `padding-bottom` hack.
- Added a per-locale `title` and `allowfullscreen` to the iframe (separate commit).

| viewport | before | after |
| --- | --- | --- |
| 390px | iframe 560px, `scrollWidth` 584 → horizontal overflow | iframe 342px, `scrollWidth` 390 → no overflow |
| 1440px | — | iframe 750px, capped at the intended max-width |

Note: the embed URL carries `controls=0`, so YouTube hides its player chrome including the fullscreen button. `allowfullscreen` enables fullscreen via the `f` shortcut and double-click, but there is no visible button to tap. Dropping `controls=0` would be a follow-up content decision, left as-is here.

## Test plan

- [x] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [x] Manual verification

Build and test were not run — this change is CSS and markdown content only, with no TypeScript touched.

Manual verification against `nx serve docs-analog`, measured with Playwright at a 390×844 viewport. All four locale routes return 200, render the localized `title`, resolve `iframe.allowFullscreen` to `true`, and lay out at 342px with no horizontal overflow.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The legacy `apps/docs-app` has no copy of this embed, so the change is confined to `docs-analog`, which is what serves analogjs.org per `zerops.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyexV8dwYXFW8fPLBX1kZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyexV8dwYXFW8fPLBX1kZx)_