### PR TITLE
fix(vite-plugin-angular): hash JIT inline style virtual module ids

### DIFF
--- a/.agents/skills/handhold-pr/SKILL.md
+++ b/.agents/skills/handhold-pr/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: handhold-pr
+description: Watch a PR's CI, diagnose every failing check, fix what's actually broken, and keep iterating until the PR is green. Use when the user says "handhold the PR", "check CI", "get CI green", "resolve any issues until green", or asks why a PR's checks are failing.
+---
+
+Take a pull request from "checks failing" to "all green". This skill owns **watching CI, diagnosing failures, deciding whether a failure is yours, and driving fixes** until every required check passes.
+
+Target the PR the user names (number or URL). With no argument, use the PR for the current branch: `gh pr view --json number,url,headRefName`. If the branch has no PR, say so and stop — this skill doesn't open PRs (that's `open-pr`).
+
+## 1. Get the current check state
+
+- `gh pr checks <n>` — the whole picture in one call. Netlify `skipping` rows are noise; ignore them.
+- If checks are still queued/running, don't guess at outcomes. Wait on them (see step 5) rather than reporting a partial state.
+- Note which checks are **required** for merge vs. advisory (`gh pr view <n> --json statusCheckRollup`). A failing advisory check may not block, but still report it.
+
+## 2. Get the real failure output
+
+Don't diagnose from a check name. Read the log.
+
+- `gh api repos/<owner>/<repo>/actions/runs/<runId>/jobs -q '.jobs[] | "\(.id) \(.name) \(.conclusion)"'` to find the failing job id.
+- `gh run view --job <jobId> --log-failed` for the failing step.
+- **`--log-failed` is often not enough on this repo.** Nx distributed execution prints a task summary table there; the actual test/build output is earlier in the full log. Pull it and search:
+  `gh run view --job <jobId> --log | grep -n "FAIL\|Error:\|✖\|<task-name>"` then `sed -n '<start>,<end>p'` the surrounding block (pipe through `sed 's/\x1b\[[0-9;]*m//g'` to strip ANSI).
+- Nx Cloud task-log URLs (`cloud.nx.app/logs/...`) are auth-gated — don't burn turns fetching them; the GitHub job log has the output.
+
+## 3. Classify the failure before fixing anything
+
+For each failure, answer: **is this caused by the diff on this branch?**
+
+- Compare the failing area against `git diff <base>...HEAD --name-only`. A failure in a package the PR never touched is a strong signal it isn't yours.
+- Check whether the base branch is green: `gh run list --branch beta --limit 5 --json conclusion,name`. A red base means pre-existing breakage.
+- Known non-PR causes in this repo:
+  - **Nx DTE ordering flakes** — a task fails to resolve a workspace package's subpath export (e.g. `@analogjs/vitest-angular/setup-testbed`) because `tsconfig.base.json` maps only the bare specifier, so `test → ^build` doesn't guarantee that dist is on the agent that picked up the task.
+  - **Local-only reproductions** — if a task fails locally but passes in CI, check `node --version` against `.node-version`; a newer Node changes TS/ESM resolution in Vite config loading and produces failures CI never sees.
+- Reproduce locally when the failure is plausibly yours: `nx test <project>`, `nx build <project>`, `nx format:check`, `nx lint <project>`. Say plainly when you could not reproduce.
+
+## 4. Fix, or re-run, or escalate
+
+- **Real failure from the diff** → fix it on the branch, verify locally, commit with a conventional message (same conventions as `open-pr`), push. Keep fixes scoped to the failure; don't fold in unrelated cleanups.
+- **Flake** → re-run just the failed jobs: `gh run rerun <runId> --failed`. Re-run once. If the same task fails a second time, treat it as real and investigate — don't re-run a third time hoping.
+- **Pre-existing breakage on the base** → don't fix it inside this PR. Report it to the user and suggest a separate issue/PR.
+- Never edit workflow files, disable a test, or relax a check to make CI pass unless the user explicitly asks for that.
+
+## 5. Wait for the next run, then loop
+
+- Wait with a background command that exits on completion, not a bare sleep:
+  `until [ "$(gh run view <runId> --json status -q .status)" = "completed" ]; do sleep 30; done`
+  (run it with `run_in_background`, then read the output file when notified).
+- After each run completes, go back to step 1. Keep looping until every non-skipping check passes or you hit something the user has to decide.
+
+## 6. Report
+
+- State the final status plainly: green, or still red with what's left and why.
+- For each failure you handled, give one line: what failed, root cause, what you did (fixed / re-ran as flake / left alone as pre-existing).
+- Don't claim green without having seen the checks pass — quote the actual `gh pr checks` result.
+- Flag latent problems you noticed but didn't fix (e.g. a flake worth its own issue) instead of silently absorbing them.
+
+## Notes
+
+- Re-running CI and pushing commits are outward-facing. They're implied by "get this PR green", but confirm before anything broader (force-pushing, rewriting history, closing/reopening the PR).
+- Don't post comments on the PR unless asked.
+- If CI stays red after two focused attempts at the same failure, stop and hand the user the evidence rather than continuing to churn.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ Reusable agent workflows live in `.agents/skills/`:
 
 - [`fix-issue`](.agents/skills/fix-issue/SKILL.md) - end-to-end flow for resolving a GitHub issue: fetch and understand the issue, create a feature branch off `beta`, implement and verify the fix, then hand off to `open-pr`.
 - [`open-pr`](.agents/skills/open-pr/SKILL.md) - commit the current work, push the feature branch, and open a GitHub PR against `beta` filled out from the PR template.
+- [`handhold-pr`](.agents/skills/handhold-pr/SKILL.md) - watch a PR's CI, pull the real failure logs, separate genuine failures from Nx DTE flakes and pre-existing base breakage, and iterate until the PR is green.
 
 ## Contribution Policy
 

--- a/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
@@ -1,5 +1,8 @@
-import { createHash } from 'node:crypto';
 import { Plugin, ResolvedConfig, preprocessCSS } from 'vite';
+import {
+  JIT_INLINE_STYLE_PREFIX,
+  getJitInlineStyles,
+} from './utils/jit-inline-styles.js';
 
 export function jitPlugin({
   inlineStylesExtension,
@@ -21,16 +24,16 @@ export function jitPlugin({
       return;
     },
     async load(id: string) {
-      if (id.includes('virtual:angular:jit:style:inline;')) {
-        const styleId = id.split('style:inline;')[1];
-        // styleId may exceed 255 bytes of base64-encoded content, limit to 16
-        const styleIdHash = createHash('sha256')
-          .update(styleId)
-          .digest('hex')
-          .slice(0, 16);
+      if (id.includes(JIT_INLINE_STYLE_PREFIX)) {
+        const styleIdHash = id.split('style:inline;')[1];
+        const encodedStyles = getJitInlineStyles(styleIdHash);
+
+        if (encodedStyles === undefined) {
+          return;
+        }
 
         const decodedStyles = Buffer.from(
-          decodeURIComponent(styleId),
+          decodeURIComponent(encodedStyles),
           'base64',
         ).toString();
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -78,6 +78,7 @@ import {
   rewriteHtmlRawImport,
 } from './utils/virtual-resources.js';
 import { markStylePathSafe } from './utils/safe-module-paths.js';
+import { toJitInlineStyleId } from './utils/jit-inline-styles.js';
 
 export enum DiagnosticModes {
   None = 0,
@@ -763,9 +764,12 @@ export function angular(options?: PluginOptions): Plugin[] {
           let data = typescriptResult.content ?? '';
 
           if (jit && data.includes('angular:jit:')) {
+            // The emitted id carries the base64 of the entire stylesheet,
+            // and the bundler derives chunk names from it — hash it so a
+            // large inline style can't produce an over-long filename (#2459).
             data = data.replace(
-              /angular:jit:style:inline;/g,
-              'virtual:angular:jit:style:inline;',
+              /angular:jit:style:inline;([A-Za-z0-9+/=]*)/g,
+              (_match, encodedStyles) => toJitInlineStyleId(encodedStyles),
             );
 
             // Templates use virtual ids (no extension) so Vite's asset/CSS

--- a/packages/vite-plugin-angular/src/lib/utils/jit-inline-styles.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/jit-inline-styles.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  JIT_INLINE_STYLE_PREFIX,
+  getJitInlineStyles,
+  toJitInlineStyleId,
+} from './jit-inline-styles.js';
+
+describe('toJitInlineStyleId', () => {
+  it('keeps the id bounded for large stylesheets (#2459)', () => {
+    const encodedStyles = Buffer.from(
+      `.a { color: red; }`.repeat(1000),
+    ).toString('base64');
+
+    const id = toJitInlineStyleId(encodedStyles);
+
+    expect(id.startsWith(JIT_INLINE_STYLE_PREFIX)).toBe(true);
+    expect(id.length).toBeLessThan(255);
+  });
+
+  it('resolves the hashed id back to the encoded styles', () => {
+    const encodedStyles = Buffer.from(`.b { color: blue; }`).toString('base64');
+
+    const id = toJitInlineStyleId(encodedStyles);
+    const hash = id.split('style:inline;')[1];
+
+    expect(getJitInlineStyles(hash)).toBe(encodedStyles);
+  });
+
+  it('returns undefined for an unknown hash', () => {
+    expect(getJitInlineStyles('deadbeefdeadbeef')).toBeUndefined();
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/utils/jit-inline-styles.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/jit-inline-styles.ts
@@ -1,0 +1,25 @@
+// Angular's JIT resource transformer emits inline component styles as
+// `angular:jit:style:inline;<base64 of the whole stylesheet>`. Keeping that
+// payload in the module id makes the emitted chunk name grow with the
+// stylesheet, so a large inline style blows past the 255-byte filename
+// limit and the build fails with ENAMETOOLONG. Hash the payload into the
+// id and keep the base64 in a lookup table instead. (#2459)
+
+import { createHash } from 'node:crypto';
+
+export const JIT_INLINE_STYLE_PREFIX = 'virtual:angular:jit:style:inline;';
+
+const inlineStyles = new Map<string, string>();
+
+export function toJitInlineStyleId(encodedStyles: string): string {
+  const hash = createHash('sha256')
+    .update(encodedStyles)
+    .digest('hex')
+    .slice(0, 16);
+  inlineStyles.set(hash, encodedStyles);
+  return `${JIT_INLINE_STYLE_PREFIX}${hash}`;
+}
+
+export function getJitInlineStyles(hash: string): string | undefined {
+  return inlineStyles.get(hash);
+}


### PR DESCRIPTION
## PR Checklist

In JIT mode, Angular's resource transformer emits inline component styles as `angular:jit:style:inline;<base64 of the whole stylesheet>`. The plugin rewrote only the prefix, leaving the full base64 in the module id. The bundler derives the emitted chunk name from that id, so a large inline stylesheet pushed the filename past the 255-byte limit and the build failed with `ENAMETOOLONG` / `File name too long (os error 63)`.

Closes #2459

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

The base64 payload is hashed to 16 chars at rewrite time and kept in a lookup table (`utils/jit-inline-styles.ts`) that the JIT plugin's `load` hook reads back, so the virtual module id is a fixed length regardless of stylesheet size. The JIT plugin no longer re-hashes for the `preprocessCSS` filename — the id it receives is already bounded.

Emitted chunk before: `_virtual_angular_jit_style_inline_<entire base64>.js`
Emitted chunk after: `_virtual_angular_jit_style_inline_db5785c80e45692c-Np9tqdeL.js`

## Test plan

- [x] `nx format:check`
- [x] `pnpm build` (`nx build vite-plugin-angular`)
- [x] `pnpm test` (`nx test vite-plugin-angular` — 39 files / 1238 tests pass, incl. new `jit-inline-styles.spec.ts`)
- [x] Manual verification

Manual verification used a minimal JIT app (Angular 22, Vite 8 / rolldown) with a ~20KB inline `styles` block and `preserveModules` so each module gets its own chunk name:

- Before the fix: `vite build` fails with `File name too long (os error 63)`.
- After the fix: build succeeds, the emitted chunk name is bounded, and the full stylesheet is present in the output.
- Dev server: the component module imports `/@id/__x00__virtual:angular:jit:style:inline;db5785c80e45692c`, which serves the complete stylesheet.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The reported workaround (`build.rollupOptions.output.chunkFileNames`) is no longer needed. The fast-compile JIT path is unaffected — it keeps inline `styles` in the decorator metadata and never creates a virtual module for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)