### PR TITLE
fix(vite-plugin-angular): fall back to workspaceRoot when resolving tsconfig

### DIFF
--- a/.agents/skills/investigate-issue/SKILL.md
+++ b/.agents/skills/investigate-issue/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: investigate-issue
+description: Investigate a GitHub issue end to end — reproduce the reporter's repo or code snippet in an isolated sandbox outside the monorepo, trace the root cause in the source, and draft a reply back to the reporter for the maintainer to confirm before posting. Use when the user says "investigate issue <n>", "look into issue <n>", "can you reproduce this", or wants a triage answer rather than a fix.
+---
+
+Turn a reported issue into a verified verdict: **does it reproduce, why, and what should we tell the reporter?** This skill owns **reproduction, root-cause analysis, and drafting the response**. It does not fix the bug (`fix-issue`) and it does not post anything to GitHub without explicit approval.
+
+Take the issue number/URL from the user. If none is given, ask for it.
+
+## 1. Read the issue
+
+- `gh issue view <n> --json title,body,state,labels,comments,author,createdAt`. Plain `gh issue view <n>` may fail on this repo with a Projects-classic GraphQL error — use the `--json` form. `gh api repos/analogjs/analog/issues/<n>` also works.
+- Pull out the facts that decide the investigation:
+  - **Versions** — Analog, Angular, Vite, Nx, Node, and the package manager. The bug report template asks for an environment; if it's vague, note the gap now rather than guessing later.
+  - **Affected package** — the reporter's dropdown answer is a hint, not a verdict. Confirm it from the stack trace and the code you end up reading.
+  - **The reproduction** — a git repo, a StackBlitz link, a code snippet, or nothing.
+- Search for prior art before spending time: `gh issue list --search "<keywords>" --state all` and `git log --oneline --grep "<keywords>"`. An issue that a recent commit already fixed on `beta` is the single most common outcome — check that early.
+
+## 2. Get the reproduction into an isolated sandbox
+
+**Never install or run a reporter's project inside this monorepo.** `pnpm-workspace.yaml` will absorb it, its dependencies will resolve to workspace packages, and whatever you observe will be an artifact of your setup rather than their bug. Work in a scratch directory outside the repo (the session scratchpad, or `mktemp -d`).
+
+By what the reporter gave you:
+
+- **Git repo** → `git clone --depth 1 <url> <sandbox>/repro`, then install with the lockfile they committed (`pnpm i --frozen-lockfile`, `npm ci`, …). Their lockfile is evidence; replacing it changes the experiment.
+- **StackBlitz / CodeSandbox link** → these can't be driven from here. If the project is backed by a git repo, clone that. Otherwise scaffold the equivalent locally: `npm create analog@latest` in the sandbox (`template-minimal` for a bare case, `template-latest` for a full app), then transplant the reporter's files.
+- **Code snippet only** → build the smallest project that exercises it, same scaffold route. If the snippet is really about compiler or plugin behavior, a focused spec in the affected package (`packages/<pkg>/src/**/*.spec.ts`) is a faster and more durable reproduction than an app — prefer it when it can express the bug.
+- **Nothing** → don't invent one. Try a good-faith minimal reproduction from the description; if it doesn't reproduce, that's a legitimate finding and the draft reply should ask for a repro rather than assert the bug isn't real.
+
+Pin the reported versions first. Reproducing against the versions they named is the experiment; anything else is a different one.
+
+## 3. Reproduce, and record what you actually ran
+
+- Run the command from the issue — `dev`, `build`, `test`, `storybook`, whatever they reported — and capture the real output, not a paraphrase.
+- Record the verdict plainly: **reproduced**, **not reproduced**, or **partially reproduced** (e.g. the error appears but only on build, not dev). "Partially" is a real answer and usually the most informative one.
+- If it doesn't reproduce, vary one thing at a time — package manager, Node version against `.node-version`, Vite major, `jit` vs AOT, dev vs build vs SSR — and say which variable flipped it. A bug that only appears under one of these is a scoping fact the reporter needs.
+
+## 4. Trace the root cause in this repo
+
+- Once you can see the failure, find the code that causes it. Read the source — don't infer from the stack trace alone. Delegate broad searches to the Explore agent when the cause could live in several places.
+- Cite evidence as `file:line`. A verdict without a line number is a hypothesis.
+- Decide where the bug actually lives, and be willing to conclude it isn't ours:
+  - **Analog bug** — our code does the wrong thing. Note every call path that hits it; a util with two callers usually needs both fixed.
+  - **Upstream** (Angular, Vite/Rolldown, Nx, Nitro, Storybook) — say which project, and whether we can still be resilient to it on our side. Both can be true, and "we should tolerate this even though it's their bug" is a fine recommendation.
+  - **Usage / configuration** — then the reply is documentation, not a patch. Check whether `apps/docs-analog` actually covers it; if it doesn't, that gap is the real finding.
+- Check the current `beta` too, not just the reported version. If it's already fixed, identify the commit that fixed it — that's the whole answer.
+
+## 5. Validate the diagnosis against local changes when it matters
+
+When the diagnosis implies a specific fix and you want confidence before recommending it:
+
+- Build the package into the workspace `node_modules` (that's its `outputPath`): `nx build <package>`.
+- Pack it and install the tarball into the sandbox so the repro runs against your build:
+  `npm pack node_modules/@analogjs/<package>` → install the resulting `.tgz` in the sandbox project.
+- Re-run the failing command. A diagnosis that survives this is worth reporting as confirmed; one that doesn't is a hypothesis you should label as such.
+
+This step is optional — skip it when the root cause is unambiguous from reading the source, and say you skipped it.
+
+## 6. Draft the response — don't post it
+
+Write the reply as a draft for the maintainer to review. **Do not run `gh issue comment`, add labels, close, or reopen anything until the user explicitly approves.**
+
+Keep it short and concrete, in the maintainer's voice — direct, no filler thanks-for-the-report padding:
+
+- Whether it reproduced, and under exactly what versions/commands.
+- The root cause in one or two sentences, with the `file:line` evidence.
+- Where it lives: our bug, upstream, or usage — and for upstream, whether we plan to be resilient anyway.
+- What happens next: a fix is coming, a repro is needed, a doc will be updated, or it's already fixed on `beta` (name the commit).
+- Any question the reporter has to answer for this to move.
+
+Present the draft inline for approval. On approval, post with `gh issue comment <n> --body-file <path>`. If the reporter needs to supply something, say so once and clearly rather than hedging.
+
+## 7. Report to the user, then hand off
+
+- Summarize: reproduced or not, root cause with evidence, where it belongs, and your recommendation.
+- If it's a real Analog bug and the user wants it fixed, hand off to **`fix-issue`** — it owns branching and implementation. Don't start editing `packages/` from this skill.
+- If the investigation turns up something adjacent (a second bug, a missing doc, a flaky path), flag it as its own issue instead of folding it in.
+
+## Notes
+
+- Clean up sandboxes when you're done, and never point a sandbox's dependencies at the working monorepo except via a packed tarball.
+- Report reproduction attempts faithfully. "I couldn't get their repo to install" is useful; a confident verdict built on a broken sandbox is not.
+- Timebox variable-hunting. After a few honest attempts at reproducing, the better answer is a draft asking the reporter for the missing piece.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ This is the monorepo that contains all the code and infrastructure for AnalogJS.
 
 Reusable agent workflows live in `.agents/skills/`:
 
+- [`investigate-issue`](.agents/skills/investigate-issue/SKILL.md) - triage a GitHub issue: reproduce the reporter's repo or snippet in an isolated sandbox outside the monorepo, trace the root cause, and draft a reply for the maintainer to confirm before posting.
 - [`fix-issue`](.agents/skills/fix-issue/SKILL.md) - end-to-end flow for resolving a GitHub issue: fetch and understand the issue, create a feature branch off `beta`, implement and verify the fix, then hand off to `open-pr`.
 - [`open-pr`](.agents/skills/open-pr/SKILL.md) - commit the current work, push the feature branch, and open a GitHub PR against `beta` filled out from the PR template.
 - [`handhold-pr`](.agents/skills/handhold-pr/SKILL.md) - watch a PR's CI, pull the real failure logs, separate genuine failures from Nx DTE flakes and pre-existing base breakage, and iterate until the PR is green.

--- a/apps/docs-analog/project.json
+++ b/apps/docs-analog/project.json
@@ -5,6 +5,7 @@
   "sourceRoot": "apps/docs-analog/src",
   "prefix": "docs",
   "tags": [],
+  "implicitDependencies": ["vitest-angular"],
   "targets": {
     "build": {
       "executor": "@nx/vite:build",

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -888,6 +888,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       tsConfigResolutionContext!.isProd,
       isTest,
       tsConfigResolutionContext!.isLib,
+      pluginOptions.workspaceRoot,
     );
   }
 

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -653,6 +653,7 @@ export function fastCompilePlugin(
       isProd,
       pluginOptions.isTest,
       isLib,
+      pluginOptions.workspaceRoot,
     );
   }
 

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { TS_EXT_REGEX } from './plugin-config.js';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { getTsConfigPath, TS_EXT_REGEX } from './plugin-config.js';
 
 describe('TS_EXT_REGEX', () => {
   describe('matches genuine TypeScript files', () => {
@@ -53,5 +56,95 @@ describe('TS_EXT_REGEX', () => {
     ])('%s', (id) => {
       expect(TS_EXT_REGEX.test(id)).toBe(false);
     });
+  });
+});
+
+describe('getTsConfigPath', () => {
+  // Mirrors the Nx/Storybook layout: workspace root with a project below it,
+  // where the Vite root is the project directory.
+  let workspaceRoot: string;
+  let projectRoot: string;
+  const projectRelativeTsConfig = 'features/x/.storybook/tsconfig.json';
+
+  beforeAll(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'analog-tsconfig-'));
+    projectRoot = join(workspaceRoot, 'features/x');
+    mkdirSync(join(workspaceRoot, projectRelativeTsConfig, '..'), {
+      recursive: true,
+    });
+    writeFileSync(join(workspaceRoot, projectRelativeTsConfig), '{}', 'utf-8');
+    writeFileSync(join(projectRoot, 'tsconfig.app.json'), '{}', 'utf-8');
+  });
+
+  afterAll(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('resolves a project-relative tsconfig against the vite root', () => {
+    expect(
+      getTsConfigPath(
+        projectRoot,
+        './.storybook/tsconfig.json',
+        false,
+        false,
+        false,
+        workspaceRoot,
+      ),
+    ).toBe(resolve(workspaceRoot, projectRelativeTsConfig));
+  });
+
+  it('falls back to the workspace root when the vite root misses', () => {
+    expect(
+      getTsConfigPath(
+        projectRoot,
+        projectRelativeTsConfig,
+        false,
+        false,
+        false,
+        workspaceRoot,
+      ),
+    ).toBe(resolve(workspaceRoot, projectRelativeTsConfig));
+  });
+
+  it('returns an absolute tsconfig untouched', () => {
+    const absolute = join(workspaceRoot, projectRelativeTsConfig);
+
+    expect(
+      getTsConfigPath(
+        projectRoot,
+        absolute,
+        false,
+        false,
+        false,
+        workspaceRoot,
+      ),
+    ).toBe(absolute);
+  });
+
+  it('reports both attempted paths when neither exists', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const resolved = getTsConfigPath(
+        projectRoot,
+        'missing/tsconfig.json',
+        false,
+        false,
+        false,
+        workspaceRoot,
+      );
+
+      expect(resolved).toBe(resolve(projectRoot, 'missing/tsconfig.json'));
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `${resolve(projectRoot, 'missing/tsconfig.json')} or ${resolve(
+            workspaceRoot,
+            'missing/tsconfig.json',
+          )}`,
+        ),
+      );
+    } finally {
+      error.mockRestore();
+    }
   });
 });

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
@@ -38,6 +38,7 @@ export function getTsConfigPath(
   isProd: boolean,
   isTest: boolean,
   isLib: boolean,
+  workspaceRoot?: string,
 ) {
   if (tsconfig && isAbsolute(tsconfig)) {
     if (!existsSync(tsconfig)) {
@@ -67,11 +68,30 @@ export function getTsConfigPath(
 
   const resolvedPath = resolve(root, tsconfigFilePath);
 
-  if (!existsSync(resolvedPath)) {
-    console.error(
-      `[@analogjs/vite-plugin-angular]: Unable to resolve tsconfig at ${resolvedPath}. This causes compilation issues. Check the path or set the "tsconfig" property with an absolute path.`,
-    );
+  if (existsSync(resolvedPath)) {
+    return resolvedPath;
   }
+
+  // Callers such as Storybook's Angular builder document their `tsConfig` as
+  // workspace-relative while setting the Vite root to the project directory,
+  // so the path joins onto the project root twice. Fall back to the workspace
+  // root before failing.
+  const workspacePath = workspaceRoot
+    ? resolve(workspaceRoot, tsconfigFilePath)
+    : undefined;
+
+  if (workspacePath && existsSync(workspacePath)) {
+    return workspacePath;
+  }
+
+  const attemptedPaths =
+    workspacePath && workspacePath !== resolvedPath
+      ? `${resolvedPath} or ${workspacePath}`
+      : resolvedPath;
+
+  console.error(
+    `[@analogjs/vite-plugin-angular]: Unable to resolve tsconfig at ${attemptedPaths}. This causes compilation issues. Check the path or set the "tsconfig" property with an absolute path.`,
+  );
 
   return resolvedPath;
 }


### PR DESCRIPTION
## PR Checklist

Closes #2461

`getTsConfigPath` resolved a relative tsconfig only against the Vite root — which is the *project* root — so a caller that documents its `tsConfig` as workspace-relative while setting the Vite root to the project directory gets the project segment joined twice (`features/x/features/x/.storybook/tsconfig.json`). `PluginOptions.workspaceRoot` already existed and defaulted to `process.cwd()`, but neither `resolveTsConfigPath` wrapper passed it through.

The missing path was then returned anyway — `existsSync` only gated a `console.error` — so `readConfiguration` got a non-existent file, `rootNames` came back empty, and every source file fell outside the TypeScript program. That's the "hundreds of not-in-the-TypeScript-program errors, nothing renders" symptom in the issue.

The upstream trigger is on Storybook's side (`@storybook/angular-vite` breaks its own documented contract); this PR makes our resolution resilient regardless of what the caller passes.

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: `repo` (adds the `investigate-issue` agent skill + `AGENTS.md` entry)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

n/a — squash is fine. Note that the branch carries a second, unrelated `chore:` commit adding the `investigate-issue` agent skill; squashing folds it under the `fix(vite-plugin-angular)` title. Say the word if you'd rather it move to its own PR.

## What is the new behavior?

`getTsConfigPath` takes an optional `workspaceRoot` and tries it when the Vite-root resolution misses:

- Vite root resolves and exists → returned, unchanged from today.
- Vite root misses, workspace root hits → workspace path returned (the new behavior).
- Neither exists → the error now names **both** attempted paths, and the Vite-root path is still returned, preserving current behavior.

The absolute-path branch is untouched. The only behavior that changes is a case that was previously a guaranteed failure, so this is backward compatible. Both call sites — `angular-vite-plugin.ts` (Angular-compilation path) and `fast-compile-plugin.ts` (fast-compile path) — now pass `pluginOptions.workspaceRoot`; there are no other callers.

Also adds coverage for `getTsConfigPath`, which previously had none: four tests over a real temp workspace laid out like the Nx/Storybook case — vite-root hit, workspace-root fallback, absolute passthrough, and the both-paths error message.

## Test plan

- [x] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

Ran package-scoped rather than workspace-wide — `nx build vite-plugin-angular` and `nx test vite-plugin-angular` (1242 passed, 26 skipped, 39 files) both green, plus `nx format:check` clean. Leaving the full `pnpm build` / `pnpm test` boxes unchecked for CI to cover.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

A companion issue against `storybookjs/storybook` for the workspace-relative-vs-project-root contract is tracked separately, per the issue description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)