### PR TITLE
docs: point the homepage StackBlitz CTA at /new

### DIFF
--- a/apps/docs-analog/src/app/pages/(home).page.ts
+++ b/apps/docs-analog/src/app/pages/(home).page.ts
@@ -133,7 +133,7 @@ const SPONSORS: Sponsor[] = [
               Read the Docs
             </a>
             <a
-              href="https://stackblitz.com/edit/github-vsxw5h?file=src%2Fapp%2Fapp.config.ts"
+              href="/new"
               target="_blank"
               rel="noopener"
               class="inline-flex items-center gap-2 rounded-md border px-5 py-2.5 text-sm font-semibold hover:bg-[var(--bg-subtle)] sm:px-6 sm:py-3 sm:text-base"


### PR DESCRIPTION
## PR Checklist

The "Open in StackBlitz" button on the [analogjs.org](https://analogjs.org/) homepage pointed at a hardcoded, one-off StackBlitz project (`https://stackblitz.com/edit/github-vsxw5h?file=src%2Fapp%2Fapp.config.ts`) that no longer exists, so the button landed on a StackBlitz 404 page.

Closes #2472

## Affected scope

- Primary scope: docs site (`apps/docs-analog`)
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

The CTA now links to `/new` instead of a hardcoded StackBlitz URL:

```html
<a href="/new" target="_blank" rel="noopener" ...>
```

`/new` is the static meta-refresh page at `apps/docs-analog/public/new/index.html`, which already redirects to the maintained `template-latest` project:

```
https://stackblitz.com/github/analogjs/analog/tree/stackblitz/packages/create-analog/template-latest?file=vite.config.ts&preset=node
```

That is the same entry point the README badge, the bug-report issue template, and the contributing guide already use, so the StackBlitz target now lives in exactly one place and can't drift out of sync again. `target="_blank"` and `rel="noopener"` are unchanged, so the button still opens in a new tab; since it's a plain `href` rather than a `routerLink`, the browser performs a full navigation and the server serves the static file rather than the Analog router handling the path.

## Test plan

- [x] `npx prettier --check "apps/docs-analog/src/app/pages/(home).page.ts"`
- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

Notes on the unchecked boxes: dependencies were not installed in the environment this was prepared in, so the workspace build/test targets were not run — the change is a single static attribute value in a template, and CI should cover it. I also could not load either StackBlitz URL to confirm the 404 first-hand, as stackblitz.com is unreachable from that environment; the working target was taken from the existing `/new` redirect maintained in this repo.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

`github-vsxw5h` was the only stale StackBlitz link in the repo — every other reference already goes through `analogjs.org/new`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWzSB2HMToPi1kpjf3zAV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWzSB2HMToPi1kpjf3zAV1)_