### PR TITLE
fix(vite-plugin-angular): await initial compilation in transform

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1000,3 +1000,108 @@ describe('formatDiagnosticWithLocation', () => {
     );
   });
 });
+
+describe('buildStart initial compilation', () => {
+  // Rollup runs `buildStart` hooks in parallel, so a plugin registered before
+  // this one (e.g. `@module-federation/vite`) can pull modules through
+  // `transform` while the initial compilation is still running. `buildStart`
+  // has to publish its compilation promise so `transform` waits for the file
+  // emitter instead of falling through to esbuild without AOT. (#2425)
+  const fixtureDir = path.resolve(
+    import.meta.dirname,
+    '../../../..',
+    'tmp',
+    'vpa-buildstart-race',
+  );
+  const componentPath = normalizePath(
+    path.join(fixtureDir, 'src', 'app.component.ts'),
+  );
+
+  beforeEach(() => {
+    realFs.rmSync(fixtureDir, { recursive: true, force: true });
+    realFs.mkdirSync(path.join(fixtureDir, 'src'), { recursive: true });
+    realFs.writeFileSync(
+      path.join(fixtureDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ES2022',
+          moduleResolution: 'bundler',
+          experimentalDecorators: true,
+          skipLibCheck: true,
+          types: [],
+        },
+        files: ['src/app.component.ts'],
+      }),
+      'utf-8',
+    );
+    realFs.writeFileSync(
+      componentPath,
+      `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  template: '<h1>hello</h1>',
+})
+export class AppComponent {}
+`,
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    realFs.rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  // The plugin reads these at creation time to pick the AOT/JIT path, so an
+  // app build has to be simulated by clearing Vitest's own markers.
+  function createAppBuildPlugin() {
+    const { VITEST, NODE_ENV } = process.env;
+    delete process.env['VITEST'];
+    delete process.env['NODE_ENV'];
+
+    try {
+      return angular({
+        tsconfig: path.join(fixtureDir, 'tsconfig.json'),
+        workspaceRoot: fixtureDir,
+      }).find((p) => p.name === '@analogjs/vite-plugin-angular') as any;
+    } finally {
+      process.env['VITEST'] = VITEST as string;
+      if (NODE_ENV) {
+        process.env['NODE_ENV'] = NODE_ENV;
+      }
+    }
+  }
+
+  it('waits for the initial compilation before emitting a transform result', async () => {
+    const mainPlugin = createAppBuildPlugin();
+
+    await mainPlugin.config(
+      { root: fixtureDir, build: {} },
+      { command: 'build' },
+    );
+    mainPlugin.configResolved({
+      root: fixtureDir,
+      mode: 'production',
+      build: {},
+      server: { watch: {} },
+      safeModulePaths: new Set(),
+    });
+
+    const ctx = { warn: vi.fn(), error: vi.fn(), addWatchFile: vi.fn() };
+    const code = realFs.readFileSync(componentPath, 'utf-8');
+
+    // Deliberately don't await `buildStart` — this is the racing plugin's view.
+    const buildStart = mainPlugin.buildStart.call(ctx);
+    const result = await mainPlugin.transform.handler.call(
+      ctx,
+      code,
+      componentPath,
+    );
+    await buildStart;
+
+    expect(result?.code).toContain('ɵcmp');
+    expect(ctx.warn).not.toHaveBeenCalled();
+  }, 60_000);
+});

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -361,7 +361,8 @@ export function angular(options?: PluginOptions): Plugin[] {
       async buildStart() {
         // Defer the first compilation in test mode
         if (!isVitestVscode) {
-          await performCompilation(resolvedConfig);
+          pendingCompilation = performCompilation(resolvedConfig);
+          await pendingCompilation;
           pendingCompilation = null;
 
           initialCompilation = true;


### PR DESCRIPTION
## PR Checklist

`buildStart` awaited its initial `performCompilation()` without assigning `pendingCompilation` first, so the `if (pendingCompilation) await pendingCompilation;` guard in `transform` never covered the initial build-mode compilation. Rollup runs `buildStart` hooks in parallel, so any plugin that pulls modules through the pipeline from its own `buildStart` — `@module-federation/vite` emits a chunk per `exposes` entry — can reach analog's `transform` before the file emitter has output. Those files silently fell through to Vite's plain esbuild pipeline as `__decorate`/`__decorateClass` JIT classes with no `ɵmod`/`ɵcmp`/`ɵinj`, so the build succeeded and the app crashed at runtime with NG0202 / "needs to be compiled using the JIT compiler".

Closes #2425

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A

## What is the new behavior?

`buildStart` publishes its compilation promise before awaiting it:

```ts
pendingCompilation = performCompilation(resolvedConfig);
await pendingCompilation;
pendingCompilation = null;
```

A `transform` that races the initial compilation now waits on the existing guard and re-requests the file from the same emitter, so it gets the AOT output instead of falling through. Note that recompiling on a `fileEmitter` miss is *not* a valid alternative — the second, incremental `NgtscProgram` reuses the already-analyzed files and emits them without the AOT transform.

## Test plan

- [x] `nx format:check`
- [x] `pnpm build` (`nx build vite-plugin-angular`)
- [x] `pnpm test` (`nx test vite-plugin-angular` — 1243 passed)
- [x] Manual verification

Added a regression test (`buildStart initial compilation`) that drives the plugin's hooks the way rollup does: it calls `buildStart` without awaiting it, then immediately calls `transform` for a component in the program, and asserts the result is AOT (`ɵcmp`) with no "not in the TypeScript program" warning. Verified it fails on `beta` and passes with the fix.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The reporter validated an equivalent patch on a production Angular 20 module-federation workspace: "not in the TypeScript program" warnings 31 → 0, module chunk 0 → 196 `ɵmod` / 0 → 330 `ɵcmp`, and the runtime NG0202 failures gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01584NpH3tkwRbGxyf9cWDF6