### PR TITLE
fix(vite-plugin-angular): give explicit build mode precedence over NODE_ENV

### DIFF
--- a/apps/docs-analog/src/content/integrations/storybook/index.md
+++ b/apps/docs-analog/src/content/integrations/storybook/index.md
@@ -453,6 +453,27 @@ npm run test-storybook
 
 You can also run tests directly in the Storybook UI. Start Storybook and use the "Run Tests" button in the sidebar, or navigate to a story to see interaction tests run automatically in the Interactions panel.
 
+## Building with Angular in Development Mode
+
+`storybook build` produces a production build, compiling Angular with optimizations and without its development debug API (for example `window.ng.getComponent`). If tooling runs against the built Storybook and needs that API, such as Playwright component tests, opt the build into Angular's development compilation by setting the Vite `mode` in `viteFinal`:
+
+```ts
+import { UserConfig } from 'vite';
+
+import type { StorybookConfig } from '@analogjs/storybook-angular';
+
+const config: StorybookConfig = {
+  // ... other config, addons, etc.
+  async viteFinal(config: UserConfig) {
+    return { ...config, mode: 'development' };
+  },
+};
+
+export default config;
+```
+
+An explicit `mode` takes precedence over the production `NODE_ENV` that the Storybook CLI sets.
+
 ## Code Coverage
 
 To collect coverage while running your stories, enable the V8 provider on the `storybook` test project:

--- a/packages/vite-plugin-angular-tools/src/builders/vite-dev-server/dev-server.impl.ts
+++ b/packages/vite-plugin-angular-tools/src/builders/vite-dev-server/dev-server.impl.ts
@@ -31,8 +31,10 @@ async function viteDevServerBuilder(
   const serverConfig: InlineConfig = {
     configFile: buildOptions.configFile as string,
     root: projectConfig.root as string,
-    mode: (process.env.NODE_ENV ??
-      buildOptions.mode ??
+    // An explicit mode from the build options wins over an ambient NODE_ENV.
+    // See #2458.
+    mode: (buildOptions.mode ??
+      process.env.NODE_ENV ??
       'development') as string,
     build: {
       sourcemap: !!buildOptions.sourcemap,

--- a/packages/vite-plugin-angular-tools/src/builders/vite/vite-build.impl.ts
+++ b/packages/vite-plugin-angular-tools/src/builders/vite/vite-build.impl.ts
@@ -29,12 +29,21 @@ async function viteBuilder(
     browserBuilderName,
   );
 
+  // Explicit build options and the requested configuration win over an
+  // ambient NODE_ENV, so `build:production` cannot silently produce a
+  // development build when NODE_ENV happens to be set. See #2458.
+  const mode = (buildOptions.mode ?? configuration) as string;
+
+  if (process.env.NODE_ENV && process.env.NODE_ENV !== mode) {
+    context.logger.warn(
+      `NODE_ENV is set to "${process.env.NODE_ENV}" but is ignored because the build resolved mode "${mode}" from the build options and configuration.`,
+    );
+  }
+
   const buildConfig: InlineConfig = {
     configFile: options.configFile,
     root: projectConfig.root as string,
-    mode: (process.env.NODE_ENV ??
-      buildOptions.mode ??
-      configuration) as string,
+    mode,
     build: {
       outDir: options.outputPath,
       sourcemap: !!buildOptions.sourcemap,

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
@@ -43,6 +43,36 @@ describe('buildOptimizerPlugin apply()', () => {
 });
 
 describe('buildOptimizerPlugin config()', () => {
+  const originalNodeEnv = process.env['NODE_ENV'];
+  afterEach(() => {
+    process.env['NODE_ENV'] = originalNodeEnv;
+  });
+
+  it('should not set defines for an explicit development mode build under production NODE_ENV (#2462)', () => {
+    // `storybook build` sets NODE_ENV=production at CLI entry; an explicit
+    // `mode: 'development'` opts the build into Angular's development
+    // compilation so the debug API (e.g. `window.ng.getComponent`) survives.
+    process.env['NODE_ENV'] = 'production';
+    const plugin = createPlugin();
+    const config = (
+      plugin as Plugin & { config: (c: UserConfig) => UserConfig }
+    ).config({ mode: 'development' });
+
+    expect(config.define).toEqual({});
+  });
+
+  it('should set defines under production NODE_ENV without an explicit mode', () => {
+    process.env['NODE_ENV'] = 'production';
+    const plugin = createPlugin();
+    const config = (
+      plugin as Plugin & { config: (c: UserConfig) => UserConfig }
+    ).config({});
+
+    expect(config.define).toEqual(
+      expect.objectContaining({ ngDevMode: 'false' }),
+    );
+  });
+
   it('should set ngServerMode to true for production SSR builds', () => {
     const plugin = createPlugin();
     const config = (

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -1,6 +1,7 @@
 import type { Plugin, UserConfig } from 'vite';
 import * as vite from 'vite';
 import { JavaScriptTransformer } from './utils/devkit.js';
+import { isProdMode } from './utils/plugin-config.js';
 
 export function buildOptimizerPlugin({
   jit,
@@ -8,15 +9,7 @@ export function buildOptimizerPlugin({
   supportedBrowsers: string[];
   jit: boolean;
 }): Plugin {
-  const javascriptTransformer = new JavaScriptTransformer(
-    {
-      sourcemap: false,
-      thirdPartySourcemaps: false,
-      advancedOptimizations: true,
-      jit: true,
-    },
-    1,
-  );
+  let javascriptTransformer: InstanceType<typeof JavaScriptTransformer>;
   let isProd = false;
 
   return {
@@ -35,9 +28,18 @@ export function buildOptimizerPlugin({
       );
     },
     config(userConfig) {
-      isProd =
-        userConfig.mode === 'production' ||
-        process.env['NODE_ENV'] === 'production';
+      isProd = isProdMode(userConfig.mode);
+      // Advanced optimizations paired with dev-mode defines would strip
+      // dev-only code the debug API needs, so both key off `isProd`.
+      javascriptTransformer ??= new JavaScriptTransformer(
+        {
+          sourcemap: false,
+          thirdPartySourcemaps: false,
+          advancedOptimizations: isProd,
+          jit: true,
+        },
+        1,
+      );
 
       return {
         define: isProd

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -70,6 +70,7 @@ import {
   createTsConfigGetter,
   getTsConfigPath,
   createDepOptimizerConfig,
+  isProdMode,
   type TsConfigResolutionContext,
 } from './utils/plugin-config.js';
 import { VIRTUAL_RAW_PREFIX, toVirtualRawId } from './utils/virtual-ids.js';
@@ -269,9 +270,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       name: '@analogjs/vite-plugin-angular',
       async config(config, { command }) {
         watchMode = command === 'serve';
-        isProd =
-          config.mode === 'production' ||
-          process.env['NODE_ENV'] === 'production';
+        isProd = isProdMode(config.mode);
 
         // Store the config context for later resolution in configResolved
         tsConfigResolutionContext = {

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -33,6 +33,7 @@ import {
   TS_EXT_REGEX,
   getTsConfigPath,
   createDepOptimizerConfig,
+  isProdMode,
   type TsConfigResolutionContext,
 } from './utils/plugin-config.js';
 import { VIRTUAL_RAW_PREFIX, toVirtualRawId } from './utils/virtual-ids.js';
@@ -662,9 +663,7 @@ export function fastCompilePlugin(
     enforce: 'pre' as const,
     async config(config, { command }) {
       watchMode = command === 'serve';
-      const isProd =
-        config.mode === 'production' ||
-        process.env['NODE_ENV'] === 'production';
+      const isProd = isProdMode(config.mode);
 
       tsConfigResolutionContext = {
         root: config.root || '.',

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.spec.ts
@@ -1,8 +1,43 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-import { getTsConfigPath, TS_EXT_REGEX } from './plugin-config.js';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { getTsConfigPath, isProdMode, TS_EXT_REGEX } from './plugin-config.js';
+
+describe('isProdMode', () => {
+  const originalNodeEnv = process.env['NODE_ENV'];
+  afterEach(() => {
+    process.env['NODE_ENV'] = originalNodeEnv;
+  });
+
+  it('is true for an explicit production mode regardless of NODE_ENV', () => {
+    process.env['NODE_ENV'] = 'development';
+    expect(isProdMode('production')).toBe(true);
+  });
+
+  it('is false for an explicit development mode even under production NODE_ENV (#2462)', () => {
+    process.env['NODE_ENV'] = 'production';
+    expect(isProdMode('development')).toBe(false);
+  });
+
+  it('falls back to NODE_ENV for other modes (unchanged behavior)', () => {
+    process.env['NODE_ENV'] = 'production';
+    expect(isProdMode(undefined)).toBe(true);
+    expect(isProdMode('staging')).toBe(true);
+
+    process.env['NODE_ENV'] = 'development';
+    expect(isProdMode(undefined)).toBe(false);
+    expect(isProdMode('staging')).toBe(false);
+  });
+});
 
 describe('TS_EXT_REGEX', () => {
   describe('matches genuine TypeScript files', () => {

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
@@ -26,6 +26,20 @@ import {
  */
 export const TS_EXT_REGEX = /\.[cm]?ts(?![a-z])/;
 
+/**
+ * Resolves whether Angular should be compiled for production. An explicit
+ * `development` mode wins over an ambient production `NODE_ENV` (e.g. set by
+ * `storybook build` at CLI entry), so a build can opt into Angular's
+ * development compilation. See #2458 and #2462.
+ */
+export function isProdMode(mode: string | undefined): boolean {
+  if (mode === 'development') {
+    return false;
+  }
+
+  return mode === 'production' || process.env['NODE_ENV'] === 'production';
+}
+
 export interface TsConfigResolutionContext {
   root: string;
   isProd: boolean;


### PR DESCRIPTION
## PR Checklist

The Vite builder resolved the build `mode` as `process.env.NODE_ENV ?? buildOptions.mode ?? configuration`, so an ambient `NODE_ENV` (from a `.env` auto-loader, CI image, or `storybook build`) outranked the explicit build option and the requested configuration. `nx run app:build:production` could silently produce a development build whose optimized output has no Angular global defines, crashing at runtime with `ReferenceError: ngDevMode is not defined`. Conversely, there was no supported way to build with Angular's development compilation (for tooling that needs the debug API, e.g. `window.ng.getComponent` in Playwright tests against a built Storybook), because a production `NODE_ENV` always won.

Closes #2458
Closes #2462

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: docs

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

Explicit build inputs win over the ambient environment, in both directions:

- The `@analogjs/platform:vite` builder resolves `mode` as `buildOptions.mode ?? configuration` and logs a warning when a conflicting `NODE_ENV` is ignored. `build:production` can no longer emit a dev build because `NODE_ENV=development` leaked in. The dev-server builder uses the same explicit-first ordering.
- A new shared `isProdMode(mode)` helper replaces the `mode === 'production' || NODE_ENV === 'production'` checks in `angular-vite-plugin`, `fast-compile-plugin`, and `angular-build-optimizer-plugin`: an explicit `mode: 'development'` now forces development compilation even under a production `NODE_ENV`, so `viteFinal: (config) => ({ ...config, mode: 'development' })` is the supported way to build Storybook with the debug API intact (documented in the Storybook integration guide). Other modes (`staging`, unset) keep the existing `NODE_ENV` fallback.
- The build optimizer's `JavaScriptTransformer` now runs with `advancedOptimizations: isProd` instead of a hardcoded `true`, so a development-mode build no longer pairs optimizing transforms with empty defines (the state that produced the `ngDevMode` crash).

## Test plan

- [x] `nx format:check`
- [x] `nx test vite-plugin-angular` (1248 tests passing, includes 5 new tests for the precedence matrix, the Storybook scenario, and the NODE_ENV-only fallback)
- [x] `nx build vite-plugin-angular` and `nx build vite-plugin-angular-tools`
- [ ] `pnpm build` / `pnpm test` (full workspace) — left to CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Behavior note: `NODE_ENV=development nx run app:build` with no development configuration previously produced a dev build; it now produces a production build (the configuration defaults to `production`) and logs a warning about the ignored `NODE_ENV`. Setting `mode` in the build options or using a dev configuration restores a dev build explicitly. The Astro Cloudflare `workerd` path (#2438) is unchanged: it runs with both a production `NODE_ENV` and a production mode.

## Other information

The two issues are the same root defect approached from opposite ends: prod-ness was inferred from an ambiguous OR of a free-form mode string and an ambient env var. #2458 fell into the broken "build with dev defines" state by accident; #2462 wanted to enter it deliberately and couldn't. No new `PluginOptions` flag: Vite's `mode` is the explicit knob, and one can be added later if a case shows up that `mode` cannot express.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbfASDa35cNavxsHVBPpEP