### PR TITLE
fix(vite-plugin-angular): preserve vendor sourcemaps when build.sourcemap is enabled

### DIFF
--- a/apps/docs-analog/src/content/packages/vite-plugin-angular/overview.md
+++ b/apps/docs-analog/src/content/packages/vite-plugin-angular/overview.md
@@ -78,29 +78,18 @@ The fast compile path currently passes ~91% of Angular's conformance suite. Beha
 
 ## Vendor Sourcemaps
 
-By default, the plugin discards the sourcemaps of dependencies and prebuilt libraries, so stack traces from `node_modules` resolve to the bundled output rather than the original sources.
-
-Set `vendorSourcemaps` to `true` to keep them in the sourcemap chain, similar in intent to the Angular CLI's `sourceMap.vendor` option.
+The sourcemaps of dependencies and prebuilt libraries are preserved whenever `build.sourcemap` is enabled.
 
 ```ts
 export default defineConfig({
-  plugins: [angular({ vendorSourcemaps: true })],
+  plugins: [angular()],
   build: { sourcemap: true },
 });
 ```
 
-In an Analog application, pass it through the `vite` option:
+Expect larger sourcemap files, since they now include the mappings for dependency code. The application bundles are unchanged, and builds without `build.sourcemap` are unaffected.
 
-```ts
-export default defineConfig({
-  plugins: [analog({ vite: { vendorSourcemaps: true } })],
-  build: { sourcemap: true },
-});
-```
-
-`build.sourcemap` must also be enabled, since no sourcemaps are emitted otherwise. Expect larger sourcemap files, as they now include the mappings for dependency code. The application bundles are unchanged.
-
-Angular's own packages are compiled through a separate path that always discards their sourcemaps, so this option does not restore mappings for `@angular/*`.
+Angular's own packages are compiled through a separate path that always discards their sourcemaps, so mappings are not restored for `@angular/*`.
 
 ## Setting up the TypeScript config
 

--- a/apps/docs-analog/src/content/packages/vite-plugin-angular/overview.md
+++ b/apps/docs-analog/src/content/packages/vite-plugin-angular/overview.md
@@ -76,6 +76,32 @@ When `fastCompile` is enabled, template and input type errors will not surface d
 
 The fast compile path currently passes ~91% of Angular's conformance suite. Behavior and output may change between minor releases.
 
+## Vendor Sourcemaps
+
+By default, the plugin discards the sourcemaps of dependencies and prebuilt libraries, so stack traces from `node_modules` resolve to the bundled output rather than the original sources.
+
+Set `vendorSourcemaps` to `true` to keep them in the sourcemap chain, similar in intent to the Angular CLI's `sourceMap.vendor` option.
+
+```ts
+export default defineConfig({
+  plugins: [angular({ vendorSourcemaps: true })],
+  build: { sourcemap: true },
+});
+```
+
+In an Analog application, pass it through the `vite` option:
+
+```ts
+export default defineConfig({
+  plugins: [analog({ vite: { vendorSourcemaps: true } })],
+  build: { sourcemap: true },
+});
+```
+
+`build.sourcemap` must also be enabled, since no sourcemaps are emitted otherwise. Expect larger sourcemap files, as they now include the mappings for dependency code. The application bundles are unchanged.
+
+Angular's own packages are compiled through a separate path that always discards their sourcemaps, so this option does not restore mappings for `@angular/*`.
+
 ## Setting up the TypeScript config
 
 The integration needs a `tsconfig.app.json` at the root of the project for compilation.

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
@@ -2,11 +2,10 @@ import { afterEach, describe, it, expect } from 'vitest';
 import type { Plugin, UserConfig } from 'vite';
 import { buildOptimizerPlugin } from './angular-build-optimizer-plugin';
 
-function createPlugin(vendorSourcemaps = false): Plugin {
+function createPlugin(): Plugin {
   return buildOptimizerPlugin({
     supportedBrowsers: [],
     jit: false,
-    vendorSourcemaps,
   });
 }
 
@@ -117,7 +116,7 @@ describe('buildOptimizerPlugin transform filter', () => {
   });
 });
 
-describe('buildOptimizerPlugin vendorSourcemaps', () => {
+describe('buildOptimizerPlugin vendor sourcemaps', () => {
   const originalNodeEnv = process.env['NODE_ENV'];
   afterEach(() => {
     process.env['NODE_ENV'] = originalNodeEnv;
@@ -131,18 +130,23 @@ describe('buildOptimizerPlugin vendorSourcemaps', () => {
     return (plugin.transform as any).handler.call({}, code, id);
   }
 
-  function configure(plugin: Plugin, mode: 'production' | 'development'): void {
+  function configure(
+    plugin: Plugin,
+    mode: 'production' | 'development',
+    sourcemap: boolean | 'inline' | 'hidden',
+  ): void {
     process.env['NODE_ENV'] = mode;
     (plugin as Plugin & { config: (c: UserConfig) => UserConfig }).config({
       mode,
     });
+    (plugin.configResolved as any).call({}, { build: { sourcemap } });
   }
 
   const sourceWithMapUrl = 'const a = 1;\n//# sourceMappingURL=vendor.js.map\n';
 
-  it('discards vendor sourcemaps by default in development (unchanged behavior)', async () => {
+  it('discards vendor sourcemaps without build.sourcemap in development', async () => {
     const plugin = createPlugin();
-    configure(plugin, 'development');
+    configure(plugin, 'development', false);
 
     const result = await transform(plugin, sourceWithMapUrl, '/x/vendor.js');
 
@@ -151,9 +155,9 @@ describe('buildOptimizerPlugin vendorSourcemaps', () => {
     expect(result?.code).toBe(sourceWithMapUrl);
   });
 
-  it('discards vendor sourcemaps by default in production, stripping the map comment', async () => {
+  it('discards vendor sourcemaps without build.sourcemap in production, stripping the map comment', async () => {
     const plugin = createPlugin();
-    configure(plugin, 'production');
+    configure(plugin, 'production', false);
 
     const result = await transform(plugin, sourceWithMapUrl, '/x/vendor.js');
 
@@ -161,9 +165,11 @@ describe('buildOptimizerPlugin vendorSourcemaps', () => {
     expect(result?.code).not.toContain('sourceMappingURL');
   });
 
-  it('preserves vendor sourcemaps when enabled in development', async () => {
-    const plugin = createPlugin(true);
-    configure(plugin, 'development');
+  it('preserves vendor sourcemaps when build.sourcemap is enabled, keeping the map comment', async () => {
+    // The prod-only `sourceMappingURL` strip would make the preserved map
+    // unreachable, so it must not run once sourcemaps are requested.
+    const plugin = createPlugin();
+    configure(plugin, 'production', true);
 
     const result = await transform(plugin, sourceWithMapUrl, '/x/vendor.js');
 
@@ -171,11 +177,10 @@ describe('buildOptimizerPlugin vendorSourcemaps', () => {
     expect(result?.code).toBe(sourceWithMapUrl);
   });
 
-  it('preserves vendor sourcemaps when enabled in production, keeping the map comment', async () => {
-    // The prod-only `sourceMappingURL` strip would make the map unreachable,
-    // so it must not run while the option is enabled.
-    const plugin = createPlugin(true);
-    configure(plugin, 'production');
+  it('treats non-boolean build.sourcemap values as enabled', async () => {
+    // `build.sourcemap` also accepts 'inline' | 'hidden'.
+    const plugin = createPlugin();
+    configure(plugin, 'production', 'hidden');
 
     const result = await transform(plugin, sourceWithMapUrl, '/x/vendor.js');
 

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
@@ -2,10 +2,11 @@ import { afterEach, describe, it, expect } from 'vitest';
 import type { Plugin, UserConfig } from 'vite';
 import { buildOptimizerPlugin } from './angular-build-optimizer-plugin';
 
-function createPlugin(): Plugin {
+function createPlugin(vendorSourcemaps = false): Plugin {
   return buildOptimizerPlugin({
     supportedBrowsers: [],
     jit: false,
+    vendorSourcemaps,
   });
 }
 
@@ -113,5 +114,72 @@ describe('buildOptimizerPlugin transform filter', () => {
     expect(re.test('/x/foo.json')).toBe(false);
     expect(re.test('/x/foo.ts')).toBe(false);
     expect(re.test('/x/foo.css?v=1')).toBe(false);
+  });
+});
+
+describe('buildOptimizerPlugin vendorSourcemaps', () => {
+  const originalNodeEnv = process.env['NODE_ENV'];
+  afterEach(() => {
+    process.env['NODE_ENV'] = originalNodeEnv;
+  });
+
+  async function transform(
+    plugin: Plugin,
+    code: string,
+    id: string,
+  ): Promise<{ code: string; map?: unknown } | null | undefined> {
+    return (plugin.transform as any).handler.call({}, code, id);
+  }
+
+  function configure(plugin: Plugin, mode: 'production' | 'development'): void {
+    process.env['NODE_ENV'] = mode;
+    (plugin as Plugin & { config: (c: UserConfig) => UserConfig }).config({
+      mode,
+    });
+  }
+
+  const sourceWithMapUrl = 'const a = 1;\n//# sourceMappingURL=vendor.js.map\n';
+
+  it('discards vendor sourcemaps by default in development (unchanged behavior)', async () => {
+    const plugin = createPlugin();
+    configure(plugin, 'development');
+
+    const result = await transform(plugin, sourceWithMapUrl, '/x/vendor.js');
+
+    expect(result?.map).toEqual({ mappings: '' });
+    // The `sourceMappingURL` comment is only stripped in production.
+    expect(result?.code).toBe(sourceWithMapUrl);
+  });
+
+  it('discards vendor sourcemaps by default in production, stripping the map comment', async () => {
+    const plugin = createPlugin();
+    configure(plugin, 'production');
+
+    const result = await transform(plugin, sourceWithMapUrl, '/x/vendor.js');
+
+    expect(result?.map).toEqual({ mappings: '' });
+    expect(result?.code).not.toContain('sourceMappingURL');
+  });
+
+  it('preserves vendor sourcemaps when enabled in development', async () => {
+    const plugin = createPlugin(true);
+    configure(plugin, 'development');
+
+    const result = await transform(plugin, sourceWithMapUrl, '/x/vendor.js');
+
+    expect(result?.map).toBeNull();
+    expect(result?.code).toBe(sourceWithMapUrl);
+  });
+
+  it('preserves vendor sourcemaps when enabled in production, keeping the map comment', async () => {
+    // The prod-only `sourceMappingURL` strip would make the map unreachable,
+    // so it must not run while the option is enabled.
+    const plugin = createPlugin(true);
+    configure(plugin, 'production');
+
+    const result = await transform(plugin, sourceWithMapUrl, '/x/vendor.js');
+
+    expect(result?.map).toBeNull();
+    expect(result?.code).toBe(sourceWithMapUrl);
   });
 });

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -4,11 +4,9 @@ import { JavaScriptTransformer } from './utils/devkit.js';
 
 export function buildOptimizerPlugin({
   jit,
-  vendorSourcemaps,
 }: {
   supportedBrowsers: string[];
   jit: boolean;
-  vendorSourcemaps: boolean;
 }): Plugin {
   const javascriptTransformer = new JavaScriptTransformer(
     {
@@ -20,6 +18,7 @@ export function buildOptimizerPlugin({
     1,
   );
   let isProd = false;
+  let preserveVendorMaps = false;
 
   return {
     name: '@analogjs/vite-plugin-angular-optimizer',
@@ -62,6 +61,9 @@ export function buildOptimizerPlugin({
         },
       } as UserConfig;
     },
+    configResolved(config) {
+      preserveVendorMaps = !!config.build.sourcemap;
+    },
     transform: {
       filter: {
         // Allow an optional `?query` after the extension. Some environments
@@ -84,10 +86,10 @@ export function buildOptimizerPlugin({
           // what makes that map unreachable, so it only runs when discarding.
           return {
             code:
-              isProd && !vendorSourcemaps
+              isProd && !preserveVendorMaps
                 ? code.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, '')
                 : code,
-            map: vendorSourcemaps ? null : { mappings: '' },
+            map: preserveVendorMaps ? null : { mappings: '' },
           };
         }
 

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -4,9 +4,11 @@ import { JavaScriptTransformer } from './utils/devkit.js';
 
 export function buildOptimizerPlugin({
   jit,
+  vendorSourcemaps,
 }: {
   supportedBrowsers: string[];
   jit: boolean;
+  vendorSourcemaps: boolean;
 }): Plugin {
   const javascriptTransformer = new JavaScriptTransformer(
     {
@@ -77,13 +79,15 @@ export function buildOptimizerPlugin({
         const angularPackage = /fesm20/.test(cleanId);
 
         if (!angularPackage) {
+          // `{ mappings: '' }` declares zero segments, dropping the module's own
+          // map from the chain; `null` keeps it. Removing `sourceMappingURL` is
+          // what makes that map unreachable, so it only runs when discarding.
           return {
-            code: isProd
-              ? code.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, '')
-              : code,
-            map: {
-              mappings: '',
-            },
+            code:
+              isProd && !vendorSourcemaps
+                ? code.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, '')
+                : code,
+            map: vendorSourcemaps ? null : { mappings: '' },
           };
         }
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -116,14 +116,6 @@ export interface PluginOptions {
    */
   fastCompile?: boolean;
   /**
-   * Preserve the sourcemaps of dependencies and prebuilt libraries instead of
-   * discarding them. Requires `build.sourcemap`, and produces larger
-   * sourcemaps. Angular's own packages are compiled through a path that always
-   * discards their sourcemaps and are unaffected.
-   * Defaults to `false`.
-   */
-  vendorSourcemaps?: boolean;
-  /**
    * Compilation output mode used when `fastCompile` is enabled.
    * - `'full'` (default): Emit final Ivy definitions for application builds.
    * - `'partial'`: Emit partial declarations for library publishing.
@@ -183,7 +175,6 @@ export function angular(options?: PluginOptions): Plugin[] {
       options?.experimental?.useAngularCompilationAPI ?? false,
     fastCompile: options?.fastCompile ?? false,
     fastCompileMode: options?.fastCompileMode ?? 'full',
-    vendorSourcemaps: options?.vendorSourcemaps ?? false,
   };
 
   let resolvedConfig: ResolvedConfig;
@@ -867,7 +858,6 @@ export function angular(options?: PluginOptions): Plugin[] {
     buildOptimizerPlugin({
       supportedBrowsers: pluginOptions.supportedBrowsers,
       jit,
-      vendorSourcemaps: pluginOptions.vendorSourcemaps,
     }),
     routerPlugin(),
     angularFullVersion < 190004 && pendingTasksPlugin(),

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -116,6 +116,14 @@ export interface PluginOptions {
    */
   fastCompile?: boolean;
   /**
+   * Preserve the sourcemaps of dependencies and prebuilt libraries instead of
+   * discarding them. Requires `build.sourcemap`, and produces larger
+   * sourcemaps. Angular's own packages are compiled through a path that always
+   * discards their sourcemaps and are unaffected.
+   * Defaults to `false`.
+   */
+  vendorSourcemaps?: boolean;
+  /**
    * Compilation output mode used when `fastCompile` is enabled.
    * - `'full'` (default): Emit final Ivy definitions for application builds.
    * - `'partial'`: Emit partial declarations for library publishing.
@@ -175,6 +183,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       options?.experimental?.useAngularCompilationAPI ?? false,
     fastCompile: options?.fastCompile ?? false,
     fastCompileMode: options?.fastCompileMode ?? 'full',
+    vendorSourcemaps: options?.vendorSourcemaps ?? false,
   };
 
   let resolvedConfig: ResolvedConfig;
@@ -858,6 +867,7 @@ export function angular(options?: PluginOptions): Plugin[] {
     buildOptimizerPlugin({
       supportedBrowsers: pluginOptions.supportedBrowsers,
       jit,
+      vendorSourcemaps: pluginOptions.vendorSourcemaps,
     }),
     routerPlugin(),
     angularFullVersion < 190004 && pendingTasksPlugin(),


### PR DESCRIPTION
## PR Checklist

Sometimes you want sourcemaps for vendor code, either to debug into a dependency or because part of the app lives in libraries that are built separately and consumed as prebuilt output. Both of those look like vendor code to the bundler, and right now their maps don't survive the build: stack frames land in the bundled chunk instead of the original file, and since lookups fall back to the nearest preceding mapping, a frame can end up pointing at an unrelated file.

The reason is that the build optimizer plugin returns `map: { mappings: '' }` from its transform hook for every non-FESM module. An empty `mappings` string is still a valid map, it just says the module has zero source segments, so Rollup/Rolldown take it at face value and drop the module's own map out of the chain.

That value comes from `4144bab3`, where it was used to quiet the `SOURCEMAP_BROKEN` warning from #410 / #1737, which it does. `null` works for that too: Rollup only warns when the hook returns `undefined`, so keeping the maps doesn't bring the warning back. I checked all three shapes against Rollup 4.61, and only `undefined` warns.

So the maps are now kept whenever `build.sourcemap` is on. Asking for sourcemaps and getting ones that don't resolve is the actual bug, and there's already a config knob for it, so no new option.

Closes #2476

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: docs

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

With `build.sourcemap` enabled, the non-FESM branch returns `map: null` instead of `{ mappings: '' }`, and the prod-only `sourceMappingURL` strip is skipped. That strip has to go too, otherwise the map we just kept can't be found.

```ts
export default defineConfig({
  plugins: [angular()],
  build: { sourcemap: true },
});
```

A few things worth knowing:

- Builds without `build.sourcemap` are unaffected, which is the default.
- The `.map` files get a lot bigger. The emitted app code is identical either way.
- Angular's own packages go through the FESM path, which discards their maps regardless. Didn't touch that here.

Docs updated in the `vite-plugin-angular` overview.

## Test plan

- [x] `nx format:check`
- [x] `pnpm build`
- [x] `pnpm test`
- [x] Manual verification

Added cases to `angular-build-optimizer-plugin.spec.ts`: without `build.sourcemap` the map is still dropped in both dev and prod (and the comment stripped in prod), with it the hook returns `null` and leaves the code untouched. One more covers `'hidden'`, since `build.sourcemap` also accepts `'inline' | 'hidden'`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
