### PR TITLE
fix(router): forward query params to server load requests during SSR

### DIFF
--- a/.agents/skills/handhold-pr/SKILL.md
+++ b/.agents/skills/handhold-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handhold-pr
-description: Watch a PR's CI, diagnose every failing check, fix what's actually broken, and keep iterating until the PR is green. Use when the user says "handhold the PR", "check CI", "get CI green", "resolve any issues until green", or asks why a PR's checks are failing.
+description: Watch a PR's CI, diagnose every failing check, fix what's actually broken, resolve CodeRabbit's major findings, and keep iterating until the PR is green. Use when the user says "handhold the PR", "check CI", "get CI green", "resolve any issues until green", or asks why a PR's checks are failing.
 ---
 
 Take a pull request from "checks failing" to "all green". This skill owns **watching CI, diagnosing failures, deciding whether a failure is yours, and driving fixes** until every required check passes.
@@ -48,10 +48,20 @@ For each failure, answer: **is this caused by the diff on this branch?**
   (run it with `run_in_background`, then read the output file when notified).
 - After each run completes, go back to step 1. Keep looping until every non-skipping check passes or you hit something the user has to decide.
 
-## 6. Report
+## 6. Resolve CodeRabbit's major findings
+
+Green CI isn't done. CodeRabbit reports as a **passing check even when it has posted actionable inline comments**, so its review has to be read separately.
+
+- `gh pr view <n> --json reviews` for the summary (it states how many actionable comments it posted), and `gh api repos/<owner>/<repo>/pulls/<n>/comments` for the inline findings. Each is tagged with a severity — `🟠 Major`, `🟡 Minor`, and so on.
+- **Verify every finding against the current code before acting** — CodeRabbit is wrong often enough that you should reproduce the claim first. Where the finding is a real code path, add a test and confirm it fails without the fix.
+- Fix the still-valid **major** findings on the branch, with their own commit. Lesser findings are a judgment call — apply the cheap correct ones, and say which you skipped and why rather than silently dropping them.
+- Note when a finding is pre-existing (the same defect exists on the base branch) — it's still worth fixing if it sits in code the PR touches, but say so.
+- Pushing the fix restarts CI, so go back to step 1 and wait for the new run.
+
+## 7. Report
 
 - State the final status plainly: green, or still red with what's left and why.
-- For each failure you handled, give one line: what failed, root cause, what you did (fixed / re-ran as flake / left alone as pre-existing).
+- For each failure you handled, give one line: what failed, root cause, what you did (fixed / re-ran as flake / left alone as pre-existing). Do the same for each CodeRabbit finding (fixed / skipped with reason).
 - Don't claim green without having seen the checks pass — quote the actual `gh pr checks` result.
 - Flag latent problems you noticed but didn't fix (e.g. a flake worth its own issue) instead of silently absorbing them.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Reusable agent workflows live in `.agents/skills/`:
 - [`investigate-issue`](.agents/skills/investigate-issue/SKILL.md) - triage a GitHub issue: reproduce the reporter's repo or snippet in an isolated sandbox outside the monorepo, trace the root cause, and draft a reply for the maintainer to confirm before posting.
 - [`fix-issue`](.agents/skills/fix-issue/SKILL.md) - end-to-end flow for resolving a GitHub issue: fetch and understand the issue, create a feature branch off `beta`, implement and verify the fix, then hand off to `open-pr`.
 - [`open-pr`](.agents/skills/open-pr/SKILL.md) - commit the current work, push the feature branch, and open a GitHub PR against `beta` filled out from the PR template.
-- [`handhold-pr`](.agents/skills/handhold-pr/SKILL.md) - watch a PR's CI, pull the real failure logs, separate genuine failures from Nx DTE flakes and pre-existing base breakage, and iterate until the PR is green.
+- [`handhold-pr`](.agents/skills/handhold-pr/SKILL.md) - watch a PR's CI, pull the real failure logs, separate genuine failures from Nx DTE flakes and pre-existing base breakage, resolve CodeRabbit's major findings, and iterate until the PR is green.
 
 ## Contribution Policy
 

--- a/packages/router/src/lib/request-context.spec.ts
+++ b/packages/router/src/lib/request-context.spec.ts
@@ -1,0 +1,92 @@
+import { HttpParams, HttpRequest, HttpResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { API_PREFIX, BASE_URL } from '@analogjs/router/tokens';
+import { firstValueFrom, of } from 'rxjs';
+
+import { requestContextInterceptor } from './request-context';
+
+describe('requestContextInterceptor', () => {
+  const baseUrl = 'http://localhost:3000';
+  const endpoint = `${baseUrl}/api/_analog/pages/index`;
+
+  function setup() {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: BASE_URL, useValue: baseUrl },
+        { provide: API_PREFIX, useValue: 'api' },
+      ],
+    });
+
+    const raw = vi.fn().mockResolvedValue({ _data: {}, headers: {} });
+    (global as any).$fetch = { raw };
+
+    return { raw };
+  }
+
+  afterEach(() => {
+    delete (global as any).$fetch;
+    TestBed.resetTestingModule();
+  });
+
+  function intercept(
+    req: HttpRequest<unknown>,
+    next: any = () => of(new HttpResponse()),
+  ) {
+    return TestBed.runInInjectionContext(() =>
+      requestContextInterceptor(req, next),
+    );
+  }
+
+  it('should forward the query string to the internal fetch', async () => {
+    const { raw } = setup();
+
+    await firstValueFrom(
+      intercept(new HttpRequest('GET', `${endpoint}?level=middle&level=top`)),
+    );
+
+    expect(raw).toHaveBeenCalledWith(
+      '/api/_analog/pages/index?level=middle&level=top',
+      expect.anything(),
+    );
+  });
+
+  it('should forward request params to the internal fetch', async () => {
+    const { raw } = setup();
+
+    await firstValueFrom(
+      intercept(
+        new HttpRequest('GET', endpoint, {
+          params: new HttpParams().set('level', 'middle'),
+        }),
+      ),
+    );
+
+    expect(raw).toHaveBeenCalledWith(
+      '/api/_analog/pages/index?level=middle',
+      expect.anything(),
+    );
+  });
+
+  it('should restore the transferred response for the matching query only', async () => {
+    setup();
+
+    const serverResponse = (await firstValueFrom(
+      intercept(new HttpRequest('GET', `${endpoint}?level=middle`)),
+    )) as HttpResponse<unknown>;
+    expect(serverResponse.url).toBe('/api/_analog/pages/index?level=middle');
+
+    delete (global as any).$fetch;
+
+    const restored = await firstValueFrom(
+      intercept(new HttpRequest('GET', `${endpoint}?level=middle`)),
+    );
+    expect(restored).toBeInstanceOf(HttpResponse);
+
+    const notRestored = await firstValueFrom(
+      intercept(new HttpRequest('GET', `${endpoint}?level=top`), () =>
+        of('from network'),
+      ),
+    );
+    expect(notRestored).toBe('from network');
+  });
+});

--- a/packages/router/src/lib/request-context.spec.ts
+++ b/packages/router/src/lib/request-context.spec.ts
@@ -89,4 +89,21 @@ describe('requestContextInterceptor', () => {
     );
     expect(notRestored).toBe('from network');
   });
+
+  it('should restore the transferred response for a relative endpoint URL', async () => {
+    setup();
+
+    await firstValueFrom(
+      intercept(new HttpRequest('GET', `${endpoint}?level=middle`)),
+    );
+
+    delete (global as any).$fetch;
+
+    const restored = await firstValueFrom(
+      intercept(
+        new HttpRequest('GET', '/api/_analog/pages/index?level=middle'),
+      ),
+    );
+    expect(restored).toBeInstanceOf(HttpResponse);
+  });
 });

--- a/packages/router/src/lib/request-context.ts
+++ b/packages/router/src/lib/request-context.ts
@@ -39,10 +39,10 @@ export function requestContextInterceptor(
       req.url.startsWith(baseUrl) ||
       req.url.startsWith(`/${apiPrefix}`))
   ) {
-    const requestUrl = new URL(req.url, baseUrl);
-    const cacheKey = makeCacheKey(req, new URL(requestUrl).pathname);
+    const requestUrl = new URL(req.urlWithParams, baseUrl);
+    const fetchUrl = `${requestUrl.pathname}${requestUrl.search}`;
+    const cacheKey = makeCacheKey(req, fetchUrl);
     const storeKey = makeStateKey<unknown>(`analog_${cacheKey}`);
-    const fetchUrl = requestUrl.pathname;
 
     const responseType =
       req.responseType === 'arraybuffer' ? 'arrayBuffer' : req.responseType;
@@ -52,7 +52,6 @@ export function requestContextInterceptor(
         .raw(fetchUrl, {
           method: req.method as any,
           body: req.body ? req.body : undefined,
-          params: requestUrl.searchParams,
           responseType,
           headers: req.headers.keys().reduce((hdrs, current) => {
             return {
@@ -83,10 +82,11 @@ export function requestContextInterceptor(
     (req.url.startsWith('/') || req.url.includes('/_analog/'))
   ) {
     // /_analog/ requests are full URLs
-    const requestUrl = req.url.includes('/_analog/')
-      ? req.url
-      : `${window.location.origin}${req.url}`;
-    const cacheKey = makeCacheKey(req, new URL(requestUrl).pathname);
+    const toAbsoluteUrl = (url: string) =>
+      url.includes('/_analog/') ? url : `${window.location.origin}${url}`;
+    const requestUrl = toAbsoluteUrl(req.url);
+    const { pathname, search } = new URL(toAbsoluteUrl(req.urlWithParams));
+    const cacheKey = makeCacheKey(req, `${pathname}${search}`);
     const storeKey = makeStateKey<unknown>(`analog_${cacheKey}`);
     const cacheRestoreResponse = transferState.get(storeKey, null);
 

--- a/packages/router/src/lib/request-context.ts
+++ b/packages/router/src/lib/request-context.ts
@@ -82,10 +82,9 @@ export function requestContextInterceptor(
     (req.url.startsWith('/') || req.url.includes('/_analog/'))
   ) {
     // /_analog/ requests are full URLs
-    const toAbsoluteUrl = (url: string) =>
-      url.includes('/_analog/') ? url : `${window.location.origin}${url}`;
-    const requestUrl = toAbsoluteUrl(req.url);
-    const { pathname, search } = new URL(toAbsoluteUrl(req.urlWithParams));
+    const toAbsoluteUrl = (url: string) => new URL(url, window.location.origin);
+    const requestUrl = toAbsoluteUrl(req.url).href;
+    const { pathname, search } = toAbsoluteUrl(req.urlWithParams);
     const cacheKey = makeCacheKey(req, `${pathname}${search}`);
     const storeKey = makeStateKey<unknown>(`analog_${cacheKey}`);
     const cacheRestoreResponse = transferState.get(storeKey, null);

--- a/packages/router/src/lib/route-config.ts
+++ b/packages/router/src/lib/route-config.ts
@@ -45,7 +45,7 @@ export function toRouteConfig(routeMeta: RouteMeta | undefined): RouteConfig {
           !!import.meta.env['VITE_ANALOG_PUBLIC_BASE_URL'] &&
           (globalThis as any).$fetch
         ) {
-          return (globalThis as any).$fetch(url.pathname);
+          return (globalThis as any).$fetch(`${url.pathname}${url.search}`);
         }
 
         return firstValueFrom(http.get(`${url.href}`));


### PR DESCRIPTION
## PR Checklist

During SSR, page server loads (`.server.ts`) and any query-carrying `HttpClient` GET forwarded by `requestContextInterceptor` executed with an empty query. The generated load endpoint is correct when hit directly — the query was lost on the way to it. The damage is silent: wrong SSR HTML, a hydration mismatch flash, and a wrong response cached in `TransferState`.

Closes #2479

## Affected scope

- Primary scope: `router`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

**1. `requestContextInterceptor` — query dropped by ofetch.** The SSR/prerender branch stripped the search from the fetched path and passed `requestUrl.searchParams` as `params`. ofetch spreads `params` into a plain object before handing it to ufo's `withQuery()`, and a `URLSearchParams` instance has no own enumerable keys, so the query serialized to nothing.

The fix builds the internal fetch URL from `req.urlWithParams` and keeps the search in the path itself, dropping the `params` option. Passing the URL string rather than `Object.fromEntries(searchParams)` also preserves repeated keys (`?level=a&level=b`), and using `urlWithParams` covers the parallel case where the query came from `HttpParams` — those never reached `req.url`, so they were dropped too.

**2. Load resolver discarded the search.** The `VITE_ANALOG_PUBLIC_BASE_URL` branch called `$fetch(url.pathname)`, throwing away `url.search` on a URL that was built correctly two lines earlier. Now `$fetch(\`${url.pathname}${url.search}\`)`.

**3. Transfer state key collision.** `makeCacheKey` keyed on pathname plus `request.params`, but the resolver embeds the query in the URL string, so `/week?start=A` and `/week?start=B` hashed to the same key. The key now includes the search, derived from `req.urlWithParams` on both the server and client branches so the two stay symmetric and hydration reuse keeps working.

Added `packages/router/src/lib/request-context.spec.ts` covering query-string forwarding (including repeated keys), `HttpParams` forwarding, and transfer state restoring only for the matching query.

## Test plan

- [x] `nx format:check`
- [x] `nx build router`
- [x] `nx test router` — 156 tests passed across 14 files
- [ ] Manual verification — not run end-to-end against a built Nitro server; the new unit tests assert the fetch URL and cache-key behavior directly.

Note: `nx lint router` was still running locally when this was opened; leaving it to CI.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Cache keys change shape, so a `TransferState` payload produced by an older build won't be read by a newer client. That only matters within a single render/hydration pair, which always ships the same version.

## Other information

`form-action.directive.ts` also posts to `injectRouteEndpointURL(...).pathname` without the search. Out of scope here, but likely worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)