### PR TITLE
feat(vitest-angular): add errorOnUnknownElements/errorOnUnknownProperties to setupTestBed

### DIFF
--- a/apps/docs-analog/src/content/features/testing/vitest.md
+++ b/apps/docs-analog/src/content/features/testing/vitest.md
@@ -136,6 +136,8 @@ The `setupTestBed()` function accepts an optional configuration object with the 
 - `zoneless` (boolean): Whether to use zoneless change detection (default: `true`)
 - `providers` (`Type<any>[]`): Additional providers to include in the test environment (default: `[]`)
 - `teardown.destroyAfterEach` (boolean): Whether to destroy the test environment after each test. Set to `false` to keep the component rendered, allowing you to inspect its final state. (default: `true`)
+- `errorOnUnknownElements` (boolean): Whether to throw when unknown elements are present in a component's template. Set to `false` (default) to log the error instead of throwing.
+- `errorOnUnknownProperties` (boolean): Whether to throw when unknown properties are present in a component's template. Set to `false` (default) to log the error instead of throwing.
 
 **Example with options:**
 
@@ -144,6 +146,8 @@ setupTestBed({
   zoneless: true,
   providers: [],
   teardown: { destroyAfterEach: false },
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
 });
 ```
 

--- a/packages/vitest-angular/README.md
+++ b/packages/vitest-angular/README.md
@@ -128,6 +128,8 @@ The `setupTestBed()` function accepts an optional configuration object with the 
 - `zoneless` (boolean): Whether to use zoneless change detection (default: `true`)
 - `providers` (`Type<any>[]`): Additional providers to include in the test environment (default: `[]`)
 - `teardown.destroyAfterEach` (boolean): Whether to destroy the test environment after each test. Set to `false` to keep the component rendered, allowing you to inspect its final state. (default: `true`)
+- `errorOnUnknownElements` (boolean): Whether to throw when unknown elements are present in a component's template. Set to `false` (default) to log the error instead of throwing.
+- `errorOnUnknownProperties` (boolean): Whether to throw when unknown properties are present in a component's template. Set to `false` (default) to log the error instead of throwing.
 
 **Example with options:**
 
@@ -136,6 +138,8 @@ setupTestBed({
   zoneless: true,
   providers: [],
   teardown: { destroyAfterEach: false },
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
 });
 ```
 

--- a/packages/vitest-angular/setup-testbed.ts
+++ b/packages/vitest-angular/setup-testbed.ts
@@ -27,6 +27,8 @@ type TestBedSetupOptions = {
   teardown?: {
     destroyAfterEach: boolean;
   };
+  errorOnUnknownElements?: boolean;
+  errorOnUnknownProperties?: boolean;
 };
 
 export function setupTestBed({
@@ -34,6 +36,8 @@ export function setupTestBed({
   providers = [],
   browserMode = false,
   teardown,
+  errorOnUnknownElements,
+  errorOnUnknownProperties,
 }: TestBedSetupOptions = {}) {
   beforeEach(getCleanupHook(false));
   afterEach(getCleanupHook(true));
@@ -57,6 +61,8 @@ export function setupTestBed({
           ...{ destroyAfterEach: !browserMode },
           ...teardown,
         },
+        errorOnUnknownElements,
+        errorOnUnknownProperties,
       },
     );
   }


### PR DESCRIPTION
## PR Checklist

Adds `errorOnUnknownElements` and `errorOnUnknownProperties` options to `setupTestBed`, mirroring the same options on Angular's `TestBed.initTestEnvironment`, and threads them through to that call.

Closes #

## Affected scope

- Primary scope: vitest-angular
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

`setupTestBed({ errorOnUnknownElements: true, errorOnUnknownProperties: true })` now forwards these flags into `TestBed.initTestEnvironment`'s `TestEnvironmentOptions`, so consumers can opt into throwing on `NG8001`/`NG8002` during tests instead of only logging.

## Test plan

- [x] `nx format:check`
- [x] `pnpm build` (`nx build vitest-angular`)
- [x] `pnpm test` (`nx test vitest-angular`)
- [ ] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

🤖 Generated with [Claude Code](https://claude.com/claude-code)