### PR TITLE
ci: run external PRs tokenless against Nx Cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,10 @@ on:
 
 env:
   NODE_OPTIONS: --max-old-space-size=16384
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN || 'NDRkYzdkYmMtNDI3NS00MDI0LWFkMGQtMmI0Zjc2MTY2YzU0fHJlYWQtb25seQ==' }}
+  # Fork PRs get no secrets; they run tokenless and authenticate through the
+  # workspace's nxCloudId + connected GitHub repository as untrusted runs with
+  # an isolated cache.
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_VERBOSE_LOGGING: ${{ vars.NX_VERBOSE_LOGGING }}
   # Lets the coordinator keep handing tasks to already-running agents across the
   # sequential nx commands below instead of re-provisioning between them.

--- a/nx.json
+++ b/nx.json
@@ -57,7 +57,6 @@
     ],
     "projectSpecificFiles": []
   },
-  "nxCloudAccessToken": "NDRkYzdkYmMtNDI3NS00MDI0LWFkMGQtMmI0Zjc2MTY2YzU0fHJlYWQtb25seQ==",
   "defaultBase": "beta",
   "plugins": [
     {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features) — n/a, CI config
- [ ] Docs have been added / updated (for bug fixes / features) — n/a

## PR Type

- [x] Build related changes (CI)

## What is the current behavior?

Every PR from a fork fails the `main` job in ~50s: fork PRs never receive the `NX_CLOUD_ACCESS_TOKEN` secret, and the read-only fallback token added in #2441 cannot start distributed CI runs on Nx Agents, so `nx-cloud start-ci-run` returns 403 before any lint/build/test runs (see #2481, #2477).

## What is the new behavior?

- The legacy read-only `nxCloudAccessToken` is removed from `nx.json` (the workspace `nxCloudId` stays).
- The workflow no longer falls back to the read-only token; fork PRs run tokenless and authenticate via the workspace `nxCloudId` + the connected GitHub repository, as untrusted runs with an isolated cache. Internal PRs keep using the read-write secret. This mirrors how nrwl/nx runs its own fork PRs.

This PR is intentionally opened **from a fork** so its own CI run exercises the exact external-contributor path (no secrets).

## Other information

Local devs who want remote cache reads should use `nx login` (personal access tokens) now that the read-only workspace token is gone from `nx.json`.

Recommended merge strategy: Squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNfBnK37ufoN1QYw1fA837