### PR TITLE
ci: apply PR scope metadata on fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/pr-scope-governance.yml
+++ b/.github/workflows/pr-scope-governance.yml
@@ -1,7 +1,10 @@
 name: pr-scope-governance
 
+# pull_request_target so the GITHUB_TOKEN keeps write permissions on fork PRs.
+# Safe because the job only checks out the trusted base sha and never runs PR
+# code — it reads changed filenames from the API and applies labels/comments.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, edited, synchronize, ready_for_review]
 
 permissions:


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features) — n/a, CI config
- [ ] Docs have been added / updated (for bug fixes / features) — n/a

## PR Type

- [x] Build related changes (CI)

## What is the current behavior?

`apply-scope-metadata` fails on every PR from a fork with `Resource not accessible by integration` when adding labels — the `pull_request` event's `GITHUB_TOKEN` is always read-only for fork PRs, regardless of the workflow's `permissions` block (see #2481, #2477, #2482).

## What is the new behavior?

The workflow triggers on `pull_request_target`, which grants write permissions on fork PRs. This is safe for this workflow: the job checks out only the trusted `base.sha`, never executes PR code, and only reads changed *filenames* from the API to apply labels and a scope comment.

Note: `pull_request_target` runs the workflow definition from the base branch, so this takes effect for all open PRs immediately after merge (this PR's own check still runs the old version).

## Other information

Recommended merge strategy: Squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNfBnK37ufoN1QYw1fA837