### PR TITLE
fix(vitest-angular): skip zone patching when setup re-executes in a reused worker

### DIFF
--- a/packages/vitest-angular/setup-vitest.ts
+++ b/packages/vitest-angular/setup-vitest.ts
@@ -14,155 +14,159 @@ if (Zone === undefined) {
   throw new Error('Missing: Zone (zone.js)');
 }
 
-if ((globalThis as any)['__vitest_zone_patch__'] === true) {
-  throw new Error("'vitest' has already been patched with 'Zone'.");
-}
+// Setup files are re-executed for every test file in a reused worker
+// (e.g. isolate: false, or bundled setup entries). The patched functions
+// live on the same globalThis as this flag, so skip instead of re-patching.
+if ((globalThis as any)['__vitest_zone_patch__'] !== true) {
+  (globalThis as any)['__vitest_zone_patch__'] = true;
+  const SyncTestZoneSpec = Zone['SyncTestZoneSpec'];
+  const ProxyZoneSpec = Zone['ProxyZoneSpec'];
 
-(globalThis as any)['__vitest_zone_patch__'] = true;
-const SyncTestZoneSpec = Zone['SyncTestZoneSpec'];
-const ProxyZoneSpec = Zone['ProxyZoneSpec'];
-
-if (SyncTestZoneSpec === undefined) {
-  throw new Error('Missing: SyncTestZoneSpec (zone.js/plugins/sync-test)');
-}
-if (ProxyZoneSpec === undefined) {
-  throw new Error('Missing: ProxyZoneSpec (zone.js/plugins/proxy.js)');
-}
-
-const env = globalThis as any;
-const ambientZone = Zone.current;
-
-// Create a synchronous-only zone in which to run `describe` blocks in order to
-// raise an error if any asynchronous operations are attempted
-// inside of a `describe` but outside of a `beforeEach` or `it`.
-const syncZone = ambientZone.fork(new SyncTestZoneSpec('vitest.describe'));
-function wrapDescribeInZone(describeBody: any) {
-  return function (...args: any) {
-    return syncZone.run(describeBody, null, args);
-  };
-}
-
-// Create a proxy zone in which to run `test` blocks so that the tests function
-// can retroactively install different zones.
-const testProxyZone = ambientZone.fork(new ProxyZoneSpec());
-function wrapTestInZone(testBody: string | any[] | undefined) {
-  if (testBody === undefined) {
-    return;
+  if (SyncTestZoneSpec === undefined) {
+    throw new Error('Missing: SyncTestZoneSpec (zone.js/plugins/sync-test)');
+  }
+  if (ProxyZoneSpec === undefined) {
+    throw new Error('Missing: ProxyZoneSpec (zone.js/plugins/proxy.js)');
   }
 
-  const wrappedFunc = function () {
-    return testProxyZone.run(testBody, null, arguments);
-  };
-  try {
-    Object.defineProperty(wrappedFunc, 'length', {
-      configurable: true,
-      writable: true,
-      enumerable: false,
-    });
-    wrappedFunc.length = testBody.length;
-  } catch (e) {
-    return testBody.length === 0
-      ? () => testProxyZone.run(testBody, null)
-      : (done: any) => testProxyZone.run(testBody, null, [done]);
-  }
+  const env = globalThis as any;
+  const ambientZone = Zone.current;
 
-  return wrappedFunc;
-}
-
-/**
- * bind describe method to wrap describe.each function
- */
-const bindDescribe = (
-  self: any,
-  originalVitestFn: {
-    apply: (
-      arg0: any,
-      arg1: any[],
-    ) => {
-      (): any;
-      new (): any;
-      apply: { (arg0: any, arg1: any[]): any; new (): any };
+  // Create a synchronous-only zone in which to run `describe` blocks in order to
+  // raise an error if any asynchronous operations are attempted
+  // inside of a `describe` but outside of a `beforeEach` or `it`.
+  const syncZone = ambientZone.fork(new SyncTestZoneSpec('vitest.describe'));
+  const wrapDescribeInZone = function (describeBody: any) {
+    return function (...args: any) {
+      return syncZone.run(describeBody, null, args);
     };
-  },
-) =>
-  function (...eachArgs: any) {
-    return function (...args: any[]) {
+  };
+
+  // Create a proxy zone in which to run `test` blocks so that the tests function
+  // can retroactively install different zones.
+  const testProxyZone = ambientZone.fork(new ProxyZoneSpec());
+  const wrapTestInZone = function (testBody: string | any[] | undefined) {
+    if (testBody === undefined) {
+      return;
+    }
+
+    const wrappedFunc = function () {
+      return testProxyZone.run(testBody, null, arguments);
+    };
+    try {
+      Object.defineProperty(wrappedFunc, 'length', {
+        configurable: true,
+        writable: true,
+        enumerable: false,
+      });
+      wrappedFunc.length = testBody.length;
+    } catch (e) {
+      return testBody.length === 0
+        ? () => testProxyZone.run(testBody, null)
+        : (done: any) => testProxyZone.run(testBody, null, [done]);
+    }
+
+    return wrappedFunc;
+  };
+
+  /**
+   * bind describe method to wrap describe.each function
+   */
+  const bindDescribe = (
+    self: any,
+    originalVitestFn: {
+      apply: (
+        arg0: any,
+        arg1: any[],
+      ) => {
+        (): any;
+        new (): any;
+        apply: { (arg0: any, arg1: any[]): any; new (): any };
+      };
+    },
+  ) =>
+    function (...eachArgs: any) {
+      return function (...args: any[]) {
+        args[1] = wrapDescribeInZone(args[1]);
+
+        // @ts-ignore
+        return originalVitestFn.apply(self, eachArgs).apply(self, args);
+      };
+    };
+
+  /**
+   * bind test method to wrap test.each function
+   */
+  const bindTest = (
+    self: any,
+    originalVitestFn: {
+      apply: (
+        arg0: any,
+        arg1: any[],
+      ) => {
+        (): any;
+        new (): any;
+        apply: { (arg0: any, arg1: any[]): any; new (): any };
+      };
+    },
+  ) =>
+    function (...eachArgs: any) {
+      return function (...args: any[]) {
+        args[1] = wrapTestInZone(args[1]);
+
+        // @ts-ignore
+        return originalVitestFn.apply(self, eachArgs).apply(self, args);
+      };
+    };
+
+  ['describe'].forEach((methodName) => {
+    const originalvitestFn = env[methodName];
+    env[methodName] = function (...args: any[]) {
       args[1] = wrapDescribeInZone(args[1]);
 
-      // @ts-ignore
-      return originalVitestFn.apply(self, eachArgs).apply(self, args);
+      return originalvitestFn.apply(this, args);
     };
-  };
+    env[methodName].each = bindDescribe(
+      originalvitestFn,
+      originalvitestFn.each,
+    );
+    if (methodName === 'describe') {
+      env[methodName].only = bindDescribe(
+        originalvitestFn,
+        originalvitestFn.only,
+      );
+      env[methodName].skip = bindDescribe(
+        originalvitestFn,
+        originalvitestFn.skip,
+      );
+    }
+  });
 
-/**
- * bind test method to wrap test.each function
- */
-const bindTest = (
-  self: any,
-  originalVitestFn: {
-    apply: (
-      arg0: any,
-      arg1: any[],
-    ) => {
-      (): any;
-      new (): any;
-      apply: { (arg0: any, arg1: any[]): any; new (): any };
-    };
-  },
-) =>
-  function (...eachArgs: any) {
-    return function (...args: any[]) {
+  ['test', 'it'].forEach((methodName) => {
+    const originalvitestFn = env[methodName];
+    env[methodName] = function (...args: any[]) {
       args[1] = wrapTestInZone(args[1]);
 
-      // @ts-ignore
-      return originalVitestFn.apply(self, eachArgs).apply(self, args);
+      return originalvitestFn.apply(this, args);
     };
-  };
+    env[methodName].each = bindTest(originalvitestFn, originalvitestFn.each);
+    env[methodName].only = bindTest(originalvitestFn, originalvitestFn.only);
+    env[methodName].skip = bindTest(originalvitestFn, originalvitestFn.skip);
 
-['describe'].forEach((methodName) => {
-  const originalvitestFn = env[methodName];
-  env[methodName] = function (...args: any[]) {
-    args[1] = wrapDescribeInZone(args[1]);
+    if (methodName === 'test' || methodName === 'it') {
+      env[methodName].todo = function (...args: any) {
+        return originalvitestFn.todo.apply(this, args);
+      };
+    }
+  });
 
-    return originalvitestFn.apply(this, args);
-  };
-  env[methodName].each = bindDescribe(originalvitestFn, originalvitestFn.each);
-  if (methodName === 'describe') {
-    env[methodName].only = bindDescribe(
-      originalvitestFn,
-      originalvitestFn.only,
-    );
-    env[methodName].skip = bindDescribe(
-      originalvitestFn,
-      originalvitestFn.skip,
-    );
-  }
-});
+  ['beforeEach', 'afterEach', 'beforeAll', 'afterAll'].forEach((methodName) => {
+    const originalvitestFn = env[methodName];
 
-['test', 'it'].forEach((methodName) => {
-  const originalvitestFn = env[methodName];
-  env[methodName] = function (...args: any[]) {
-    args[1] = wrapTestInZone(args[1]);
+    env[methodName] = function (...args: any[]) {
+      args[0] = wrapTestInZone(args[0]);
 
-    return originalvitestFn.apply(this, args);
-  };
-  env[methodName].each = bindTest(originalvitestFn, originalvitestFn.each);
-  env[methodName].only = bindTest(originalvitestFn, originalvitestFn.only);
-  env[methodName].skip = bindTest(originalvitestFn, originalvitestFn.skip);
-
-  if (methodName === 'test' || methodName === 'it') {
-    env[methodName].todo = function (...args: any) {
-      return originalvitestFn.todo.apply(this, args);
+      return originalvitestFn.apply(this, args);
     };
-  }
-});
-
-['beforeEach', 'afterEach', 'beforeAll', 'afterAll'].forEach((methodName) => {
-  const originalvitestFn = env[methodName];
-
-  env[methodName] = function (...args: any[]) {
-    args[0] = wrapTestInZone(args[0]);
-
-    return originalvitestFn.apply(this, args);
-  };
-});
+  });
+}

--- a/packages/vitest-angular/setup-zone.ts
+++ b/packages/vitest-angular/setup-zone.ts
@@ -15,155 +15,159 @@ if (Zone === undefined) {
   throw new Error('Missing: Zone (zone.js)');
 }
 
-if ((globalThis as any)['__vitest_zone_patch__'] === true) {
-  throw new Error("'vitest' has already been patched with 'Zone'.");
-}
+// Setup files are re-executed for every test file in a reused worker
+// (e.g. isolate: false, or bundled setup entries). The patched functions
+// live on the same globalThis as this flag, so skip instead of re-patching.
+if ((globalThis as any)['__vitest_zone_patch__'] !== true) {
+  (globalThis as any)['__vitest_zone_patch__'] = true;
+  const SyncTestZoneSpec = Zone['SyncTestZoneSpec'];
+  const ProxyZoneSpec = Zone['ProxyZoneSpec'];
 
-(globalThis as any)['__vitest_zone_patch__'] = true;
-const SyncTestZoneSpec = Zone['SyncTestZoneSpec'];
-const ProxyZoneSpec = Zone['ProxyZoneSpec'];
-
-if (SyncTestZoneSpec === undefined) {
-  throw new Error('Missing: SyncTestZoneSpec (zone.js/plugins/sync-test)');
-}
-if (ProxyZoneSpec === undefined) {
-  throw new Error('Missing: ProxyZoneSpec (zone.js/plugins/proxy.js)');
-}
-
-const env = globalThis as any;
-const ambientZone = Zone.current;
-
-// Create a synchronous-only zone in which to run `describe` blocks in order to
-// raise an error if any asynchronous operations are attempted
-// inside of a `describe` but outside of a `beforeEach` or `it`.
-const syncZone = ambientZone.fork(new SyncTestZoneSpec('vitest.describe'));
-function wrapDescribeInZone(describeBody: any) {
-  return function (...args: any) {
-    return syncZone.run(describeBody, null, args);
-  };
-}
-
-// Create a proxy zone in which to run `test` blocks so that the tests function
-// can retroactively install different zones.
-const testProxyZone = ambientZone.fork(new ProxyZoneSpec());
-function wrapTestInZone(testBody: string | any[] | undefined) {
-  if (testBody === undefined) {
-    return;
+  if (SyncTestZoneSpec === undefined) {
+    throw new Error('Missing: SyncTestZoneSpec (zone.js/plugins/sync-test)');
+  }
+  if (ProxyZoneSpec === undefined) {
+    throw new Error('Missing: ProxyZoneSpec (zone.js/plugins/proxy.js)');
   }
 
-  const wrappedFunc = function () {
-    return testProxyZone.run(testBody, null, arguments);
-  };
-  try {
-    Object.defineProperty(wrappedFunc, 'length', {
-      configurable: true,
-      writable: true,
-      enumerable: false,
-    });
-    wrappedFunc.length = testBody.length;
-  } catch (e) {
-    return testBody.length === 0
-      ? () => testProxyZone.run(testBody, null)
-      : (done: any) => testProxyZone.run(testBody, null, [done]);
-  }
+  const env = globalThis as any;
+  const ambientZone = Zone.current;
 
-  return wrappedFunc;
-}
-
-/**
- * bind describe method to wrap describe.each function
- */
-const bindDescribe = (
-  self: any,
-  originalVitestFn: {
-    apply: (
-      arg0: any,
-      arg1: any[],
-    ) => {
-      (): any;
-      new (): any;
-      apply: { (arg0: any, arg1: any[]): any; new (): any };
+  // Create a synchronous-only zone in which to run `describe` blocks in order to
+  // raise an error if any asynchronous operations are attempted
+  // inside of a `describe` but outside of a `beforeEach` or `it`.
+  const syncZone = ambientZone.fork(new SyncTestZoneSpec('vitest.describe'));
+  const wrapDescribeInZone = function (describeBody: any) {
+    return function (...args: any) {
+      return syncZone.run(describeBody, null, args);
     };
-  },
-) =>
-  function (...eachArgs: any) {
-    return function (...args: any[]) {
+  };
+
+  // Create a proxy zone in which to run `test` blocks so that the tests function
+  // can retroactively install different zones.
+  const testProxyZone = ambientZone.fork(new ProxyZoneSpec());
+  const wrapTestInZone = function (testBody: string | any[] | undefined) {
+    if (testBody === undefined) {
+      return;
+    }
+
+    const wrappedFunc = function () {
+      return testProxyZone.run(testBody, null, arguments);
+    };
+    try {
+      Object.defineProperty(wrappedFunc, 'length', {
+        configurable: true,
+        writable: true,
+        enumerable: false,
+      });
+      wrappedFunc.length = testBody.length;
+    } catch (e) {
+      return testBody.length === 0
+        ? () => testProxyZone.run(testBody, null)
+        : (done: any) => testProxyZone.run(testBody, null, [done]);
+    }
+
+    return wrappedFunc;
+  };
+
+  /**
+   * bind describe method to wrap describe.each function
+   */
+  const bindDescribe = (
+    self: any,
+    originalVitestFn: {
+      apply: (
+        arg0: any,
+        arg1: any[],
+      ) => {
+        (): any;
+        new (): any;
+        apply: { (arg0: any, arg1: any[]): any; new (): any };
+      };
+    },
+  ) =>
+    function (...eachArgs: any) {
+      return function (...args: any[]) {
+        args[1] = wrapDescribeInZone(args[1]);
+
+        // @ts-ignore
+        return originalVitestFn.apply(self, eachArgs).apply(self, args);
+      };
+    };
+
+  /**
+   * bind test method to wrap test.each function
+   */
+  const bindTest = (
+    self: any,
+    originalVitestFn: {
+      apply: (
+        arg0: any,
+        arg1: any[],
+      ) => {
+        (): any;
+        new (): any;
+        apply: { (arg0: any, arg1: any[]): any; new (): any };
+      };
+    },
+  ) =>
+    function (...eachArgs: any) {
+      return function (...args: any[]) {
+        args[1] = wrapTestInZone(args[1]);
+
+        // @ts-ignore
+        return originalVitestFn.apply(self, eachArgs).apply(self, args);
+      };
+    };
+
+  ['describe'].forEach((methodName) => {
+    const originalvitestFn = env[methodName];
+    env[methodName] = function (...args: any[]) {
       args[1] = wrapDescribeInZone(args[1]);
 
-      // @ts-ignore
-      return originalVitestFn.apply(self, eachArgs).apply(self, args);
+      return originalvitestFn.apply(this, args);
     };
-  };
+    env[methodName].each = bindDescribe(
+      originalvitestFn,
+      originalvitestFn.each,
+    );
+    if (methodName === 'describe') {
+      env[methodName].only = bindDescribe(
+        originalvitestFn,
+        originalvitestFn.only,
+      );
+      env[methodName].skip = bindDescribe(
+        originalvitestFn,
+        originalvitestFn.skip,
+      );
+    }
+  });
 
-/**
- * bind test method to wrap test.each function
- */
-const bindTest = (
-  self: any,
-  originalVitestFn: {
-    apply: (
-      arg0: any,
-      arg1: any[],
-    ) => {
-      (): any;
-      new (): any;
-      apply: { (arg0: any, arg1: any[]): any; new (): any };
-    };
-  },
-) =>
-  function (...eachArgs: any) {
-    return function (...args: any[]) {
+  ['test', 'it'].forEach((methodName) => {
+    const originalvitestFn = env[methodName];
+    env[methodName] = function (...args: any[]) {
       args[1] = wrapTestInZone(args[1]);
 
-      // @ts-ignore
-      return originalVitestFn.apply(self, eachArgs).apply(self, args);
+      return originalvitestFn.apply(this, args);
     };
-  };
+    env[methodName].each = bindTest(originalvitestFn, originalvitestFn.each);
+    env[methodName].only = bindTest(originalvitestFn, originalvitestFn.only);
+    env[methodName].skip = bindTest(originalvitestFn, originalvitestFn.skip);
 
-['describe'].forEach((methodName) => {
-  const originalvitestFn = env[methodName];
-  env[methodName] = function (...args: any[]) {
-    args[1] = wrapDescribeInZone(args[1]);
+    if (methodName === 'test' || methodName === 'it') {
+      env[methodName].todo = function (...args: any) {
+        return originalvitestFn.todo.apply(this, args);
+      };
+    }
+  });
 
-    return originalvitestFn.apply(this, args);
-  };
-  env[methodName].each = bindDescribe(originalvitestFn, originalvitestFn.each);
-  if (methodName === 'describe') {
-    env[methodName].only = bindDescribe(
-      originalvitestFn,
-      originalvitestFn.only,
-    );
-    env[methodName].skip = bindDescribe(
-      originalvitestFn,
-      originalvitestFn.skip,
-    );
-  }
-});
+  ['beforeEach', 'afterEach', 'beforeAll', 'afterAll'].forEach((methodName) => {
+    const originalvitestFn = env[methodName];
 
-['test', 'it'].forEach((methodName) => {
-  const originalvitestFn = env[methodName];
-  env[methodName] = function (...args: any[]) {
-    args[1] = wrapTestInZone(args[1]);
+    env[methodName] = function (...args: any[]) {
+      args[0] = wrapTestInZone(args[0]);
 
-    return originalvitestFn.apply(this, args);
-  };
-  env[methodName].each = bindTest(originalvitestFn, originalvitestFn.each);
-  env[methodName].only = bindTest(originalvitestFn, originalvitestFn.only);
-  env[methodName].skip = bindTest(originalvitestFn, originalvitestFn.skip);
-
-  if (methodName === 'test' || methodName === 'it') {
-    env[methodName].todo = function (...args: any) {
-      return originalvitestFn.todo.apply(this, args);
+      return originalvitestFn.apply(this, args);
     };
-  }
-});
-
-['beforeEach', 'afterEach', 'beforeAll', 'afterAll'].forEach((methodName) => {
-  const originalvitestFn = env[methodName];
-
-  env[methodName] = function (...args: any[]) {
-    args[0] = wrapTestInZone(args[0]);
-
-    return originalvitestFn.apply(this, args);
-  };
-});
+  });
+}

--- a/packages/vitest-angular/src/lib/setup-reexecution.spec.ts
+++ b/packages/vitest-angular/src/lib/setup-reexecution.spec.ts
@@ -1,0 +1,23 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+
+// Vitest re-executes setup files for every test file in a reused worker
+// (e.g. isolate: false). Re-evaluating the setup module must be a no-op.
+describe('setup re-execution', () => {
+  it('does not throw when the setup module is evaluated again', async () => {
+    expect((globalThis as any)['__vitest_zone_patch__']).toBe(true);
+    const patchedIt = (globalThis as any)['it'];
+
+    vi.resetModules();
+    await expect(import('../../setup-vitest')).resolves.toBeDefined();
+
+    expect((globalThis as any)['it']).toBe(patchedIt);
+    expect((globalThis as any)['__vitest_zone_patch__']).toBe(true);
+  });
+
+  it('keeps fakeAsync working after re-evaluation', fakeAsync(() => {
+    let elapsed = false;
+    setTimeout(() => (elapsed = true), 100);
+    tick(100);
+    expect(elapsed).toBe(true);
+  }));
+});


### PR DESCRIPTION
## PR Checklist

Closes #2478

## Affected scope

- Primary scope: `vitest-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

n/a

## What is the new behavior?

Vitest evicts setup files from the module cache and re-executes them for every collected test file (`VitestTestRunner.importFile`). When a worker is reused across spec files (`isolate: false`, `fileParallelism: false`, or bundled setup entries as produced by the `vitest-angular:build` builder through `@angular/build`), the one-shot guard in `setup-zone.ts` and `setup-vitest.ts` threw `'vitest' has already been patched with 'Zone'.` and every spec file after the first failed, pushing `fakeAsync`/`waitForAsync` suites toward full per-file isolation and its cost.

The patched `describe`/`it`/hooks live on the same `globalThis` as the guard flag, so when the flag is already set the patch is still in place. The guard now skips re-patching instead of throwing, making setup re-execution a no-op:

- worker reuse in the same global: flag set, patch intact, skip
- fresh globals (`isolate: true`, `vmThreads`): flag fresh, patch applies as before
- a second zone patcher in the same worker: first one wins, second no-ops instead of crashing

## Test plan

- [x] `nx format:check`
- [ ] `pnpm build`
- [x] `pnpm test` (`nx test vitest-angular`, includes a new regression spec that re-evaluates the setup module via `vi.resetModules()` + dynamic import; it fails against the previous guard)
- [x] Manual verification: packed the built `@analogjs/vitest-angular` into an isolated sandbox (vitest 3.2.7, Angular 20.3.25, zone.js 0.15.0, Node 24) and ran the issue's repro with `pool: 'threads'`, `isolate: false` and the setup module body inlined into the setup file (simulating the builder's bundling). Failed with the old guard, passes with this change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Only the guard changed; the patching body is unchanged apart from being wrapped in the conditional (function declarations became `const` expressions inside the block). The nuance from investigating #2478: with a plain vitest config the package module stays cached and the guard never re-fires, so the crash specifically needs the patch code to execute as part of the setup entry itself, which is what the builder's bundling produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsqLsBiiqDEtarQiVKhvzS