### PR TITLE
fix(vite-plugin-angular): return worker path unchanged from processWebWorker

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -977,8 +977,12 @@ export function angular(options?: PluginOptions): Plugin[] {
 
           return stylesheetResult?.code || '';
         },
-        processWebWorker(workerFile, containingFile) {
-          return '';
+        // Angular's worker transformer only rewrites the `new URL()` specifier
+        // when the returned path differs from the input, so returning it
+        // unchanged opts out and lets Vite handle the worker natively.
+        // Returning '' rewrote every worker URL to `new URL('', import.meta.url)`.
+        processWebWorker(workerFile) {
+          return workerFile;
         },
       },
       (tsCompilerOptions) => {


### PR DESCRIPTION
## PR Checklist

Closes #2487

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

`processWebWorker` returned `''` for every worker. Angular's worker transformer rewrites the `new URL()` argument whenever the returned path differs from the one passed in, so every worker URL became `new URL('', import.meta.url)`, which resolves to the importing chunk rather than the worker file.

This returns the path unchanged instead, which is how the transformer is opted out of. `@angular/build` does the same in its own esbuild plugin when a worker bundle fails ("Return the original path if the build failed"). With the path left alone, Vite handles `new Worker(new URL(..., import.meta.url))` natively.

Running Angular's transformer directly against a service that creates a worker:

```
returning ''         -> new SharedWorker(new URL("", import.meta.url), ...)
returning workerFile -> new SharedWorker(new URL('./cache.worker', import.meta.url), ...)
```

The hook can't just be dropped. `AngularHostOptions` declares it as required and the AOT and JIT compilations both call `.bind()` on it.

On blast radius: the `''` stub dates back to #1957 (v2.1.0), not 2.7.0. Before #2452 the plugin used a decorator regex to decide whether to serve Angular's output, so a worker created inside a decorated class was already affected, while one in a plain `.ts` file was not. #2452 switched that to emitted-content presence, which is correct and is not touched here, and it widened the set of affected files.

## Test plan

- [x] `nx format:check`
- [x] `nx build vite-plugin-angular`
- [x] `nx test vite-plugin-angular` (690 passed, 6 skipped)
- [x] Manual verification

Manual check: ran Angular's worker transformer against both versions of the hook and compared the emitted code, as above. Also confirmed on a production build of an app using a SharedWorker, where the URL in the bundle now points at the worker and a cross-tab test that was failing passes on repeated runs.

No unit test added. The hook is now an identity function and the bug was in how its return value is read by Angular's transformer, which a test on a one-line function wouldn't catch.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The only people who could see a difference are those expecting Angular to bundle their workers, which never worked here since `''` produced a broken URL rather than a working bundle.

The branch is based on a slightly older `beta` commit (`adc387ce4`, 2.7.0-beta.12) rather than current `beta`. The change is a single line in a file untouched since, so it merges cleanly; happy to rebase if you'd prefer it on the tip.
