### PR TITLE
fix(router): harden TransferState cache keys and escape markdown code renderer

### DIFF
--- a/packages/content/src/lib/markdown-content-renderer.service.spec.ts
+++ b/packages/content/src/lib/markdown-content-renderer.service.spec.ts
@@ -76,6 +76,7 @@ Lorem ipsum 2....
       '```\n<img src=x onerror=alert(2)>\n```',
     );
     expect(noLang.content).not.toContain('<img src=x onerror=');
+    expect(noLang.content).toContain('&lt;img');
 
     const span = await service.render(
       'text `<img src=x onerror=alert(3)>` end',

--- a/packages/content/src/lib/markdown-content-renderer.service.spec.ts
+++ b/packages/content/src/lib/markdown-content-renderer.service.spec.ts
@@ -64,6 +64,26 @@ Lorem ipsum 2....
     );
   });
 
+  it('escapes html in code blocks, code spans, and language names', async () => {
+    const { service } = setup();
+
+    const fence = await service.render(
+      '```html"><img src=x onerror=alert(1)>\nhello\n```',
+    );
+    expect(fence.content).not.toContain('<img src=x onerror=');
+
+    const noLang = await service.render(
+      '```\n<img src=x onerror=alert(2)>\n```',
+    );
+    expect(noLang.content).not.toContain('<img src=x onerror=');
+
+    const span = await service.render(
+      'text `<img src=x onerror=alert(3)>` end',
+    );
+    expect(span.content).not.toContain('<img src=x onerror=');
+    expect(span.content).toContain('&lt;img');
+  });
+
   it('should expose getContentHeadings for backward compatibility', () => {
     const { service } = setup();
     const toc = service.getContentHeadings(`# Hello\n## World`);

--- a/packages/content/src/lib/marked-setup.service.ts
+++ b/packages/content/src/lib/marked-setup.service.ts
@@ -7,6 +7,7 @@ import { marked } from 'marked';
 import { gfmHeadingId } from 'marked-gfm-heading-id';
 import { mangle } from 'marked-mangle';
 import { MarkedContentHighlighter } from './marked-content-highlighter';
+import { escapeHtml, sanitizeLanguage } from './utils/escape-html';
 
 @Injectable()
 export class MarkedSetupService {
@@ -20,19 +21,20 @@ export class MarkedSetupService {
     renderer.code = ({ text, lang }) => {
       // Let's do a language based detection like on GitHub
       // So we can still have non-interpreted mermaid code
-      if (lang === 'mermaid') {
-        return '<pre class="mermaid">' + text + '</pre>';
+      const language = sanitizeLanguage(lang);
+      if (language === 'mermaid') {
+        return '<pre class="mermaid">' + escapeHtml(text) + '</pre>';
       }
 
-      if (!lang) {
-        return '<pre><code>' + text + '</code></pre>';
+      if (!language) {
+        return '<pre><code>' + escapeHtml(text) + '</code></pre>';
       }
 
       if (this.highlighter?.augmentCodeBlock) {
-        return this.highlighter?.augmentCodeBlock(text, lang);
+        return this.highlighter?.augmentCodeBlock(text, language);
       }
 
-      return `<pre class="language-${lang}"><code class="language-${lang}">${text}</code></pre>`;
+      return `<pre class="language-${language}"><code class="language-${language}">${escapeHtml(text)}</code></pre>`;
     };
 
     const extensions = [gfmHeadingId(), mangle()];

--- a/packages/content/src/lib/utils/escape-html.ts
+++ b/packages/content/src/lib/utils/escape-html.ts
@@ -1,0 +1,17 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+/**
+ * Reduces a fenced code-block info string to a safe language identifier so it
+ * cannot break out of the `class="language-..."` attribute it is interpolated
+ * into.
+ */
+export function sanitizeLanguage(lang: string | undefined): string {
+  return (lang ?? '').match(/^[a-zA-Z0-9-+#.]*/)?.[0] ?? '';
+}

--- a/packages/platform/src/lib/content/marked/marked-setup.service.ts
+++ b/packages/platform/src/lib/content/marked/marked-setup.service.ts
@@ -4,6 +4,7 @@ import { mangle } from 'marked-mangle';
 
 import { MarkedContentHighlighter } from './marked-content-highlighter.js';
 import { WithMarkedOptions } from './index.js';
+import { escapeHtml, sanitizeLanguage } from '../utils/escape-html.js';
 
 export class MarkedSetupService {
   private readonly marked: typeof marked;
@@ -20,22 +21,23 @@ export class MarkedSetupService {
         code({ text, lang }) {
           // Let's do a language based detection like on GitHub
           // So we can still have non-interpreted mermaid code
-          if (lang === 'mermaid') {
-            return '<pre class="mermaid">' + text + '</pre>';
+          const language = sanitizeLanguage(lang);
+          if (language === 'mermaid') {
+            return '<pre class="mermaid">' + escapeHtml(text) + '</pre>';
           }
 
-          if (!lang) {
-            return '<pre><code>' + text + '</code></pre>';
+          if (!language) {
+            return '<pre><code>' + escapeHtml(text) + '</code></pre>';
           }
 
           if (highlighter?.augmentCodeBlock) {
-            return highlighter?.augmentCodeBlock(text, lang);
+            return highlighter?.augmentCodeBlock(text, language);
           }
 
-          return `<pre class="language-${lang}"><code class="language-${lang}">${text}</code></pre>`;
+          return `<pre class="language-${language}"><code class="language-${language}">${escapeHtml(text)}</code></pre>`;
         },
         codespan({ text }) {
-          return `<code>${text}</code>`;
+          return `<code>${escapeHtml(text)}</code>`;
         },
         paragraph({ tokens }) {
           const text = this.parser.parseInline(tokens);

--- a/packages/platform/src/lib/content/shiki/index.spec.ts
+++ b/packages/platform/src/lib/content/shiki/index.spec.ts
@@ -113,4 +113,31 @@ describe('getShikiHighlighter', () => {
       '<pre class="mermaid">graph TD;</pre>',
     );
   });
+
+  it('escapes HTML in the mermaid render path', async () => {
+    const highlighter = getShikiHighlighter({
+      highlighter: {
+        additionalLangs: ['mermaid'],
+      },
+    });
+
+    const extension = highlighter.getHighlightExtension() as {
+      highlight: (
+        code: string,
+        lang: string,
+        props: string[],
+      ) => Promise<string>;
+    };
+
+    const result = await extension.highlight(
+      '</pre><img src=x onerror=alert(1)>',
+      'mermaid',
+      [],
+    );
+
+    expect(result).not.toContain('<img src=x onerror=');
+    expect(result).toBe(
+      '<pre class="mermaid">&lt;/pre&gt;&lt;img src=x onerror=alert(1)&gt;</pre>',
+    );
+  });
 });

--- a/packages/platform/src/lib/content/shiki/shiki-highlighter.ts
+++ b/packages/platform/src/lib/content/shiki/shiki-highlighter.ts
@@ -52,7 +52,7 @@ export class ShikiHighlighter extends MarkedContentHighlighter {
       container: this.container,
       highlight: async (code, lang, props) => {
         if (this.hasLoadMermaid && lang === 'mermaid') {
-          return `<pre class="mermaid">${code}</pre>`;
+          return `<pre class="mermaid">${escapeHtml(code)}</pre>`;
         }
 
         if (this.skipLangs.includes(lang as string)) {

--- a/packages/platform/src/lib/content/shiki/shiki-highlighter.ts
+++ b/packages/platform/src/lib/content/shiki/shiki-highlighter.ts
@@ -10,6 +10,7 @@ import {
 } from 'shiki';
 
 import { MarkedContentHighlighter } from '../marked/marked-content-highlighter.js';
+import { escapeHtml } from '../utils/escape-html.js';
 
 export type ShikiHighlighterOptions = Parameters<typeof createHighlighter>[0];
 export type ShikiHighlightOptions = Partial<
@@ -33,15 +34,6 @@ export const defaultHighlighterOptions = {
   ],
   themes: ['github-dark', 'github-light'],
 };
-
-function escapeHtml(code: string): string {
-  return code
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
 
 export class ShikiHighlighter extends MarkedContentHighlighter {
   private readonly highlighter = createHighlighter(this.highlighterOptions);

--- a/packages/platform/src/lib/content/utils/escape-html.ts
+++ b/packages/platform/src/lib/content/utils/escape-html.ts
@@ -1,0 +1,17 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+/**
+ * Reduces a fenced code-block info string to a safe language identifier so it
+ * cannot break out of the `class="language-..."` attribute it is interpolated
+ * into.
+ */
+export function sanitizeLanguage(lang: string | undefined): string {
+  return (lang ?? '').match(/^[a-zA-Z0-9-+#.]*/)?.[0] ?? '';
+}

--- a/packages/router/src/lib/cache-key.spec.ts
+++ b/packages/router/src/lib/cache-key.spec.ts
@@ -1,0 +1,45 @@
+import { HttpParams, HttpRequest } from '@angular/common/http';
+
+import { makeCacheKey } from './cache-key';
+
+describe('makeCacheKey', () => {
+  it('is deterministic for the same request', () => {
+    const req = new HttpRequest('GET', '/api/todos');
+
+    expect(makeCacheKey(req, '/api/todos')).toEqual(
+      makeCacheKey(req, '/api/todos'),
+    );
+  });
+
+  it('produces distinct keys for distinct requests', () => {
+    const a = makeCacheKey(new HttpRequest('GET', '/api/a'), '/api/a');
+    const b = makeCacheKey(new HttpRequest('GET', '/api/b'), '/api/b');
+
+    expect(a).not.toEqual(b);
+  });
+
+  it('does not collide on inputs that broke the previous 32-bit hash', () => {
+    // "Aa" and "BB" collide under DJB2; the mapped URL flows into the key.
+    const a = makeCacheKey(new HttpRequest('GET', '/Aa'), '/Aa');
+    const b = makeCacheKey(new HttpRequest('GET', '/BB'), '/BB');
+
+    expect(a).not.toEqual(b);
+  });
+
+  it('keys on method, params, and body', () => {
+    const base = makeCacheKey(new HttpRequest('GET', '/api'), '/api');
+    const withParams = makeCacheKey(
+      new HttpRequest('GET', '/api', {
+        params: new HttpParams({ fromString: 'q=1' }),
+      }),
+      '/api',
+    );
+    const post = makeCacheKey(
+      new HttpRequest('POST', '/api', { a: 1 }),
+      '/api',
+    );
+
+    expect(base).not.toEqual(withParams);
+    expect(base).not.toEqual(post);
+  });
+});

--- a/packages/router/src/lib/cache-key.spec.ts
+++ b/packages/router/src/lib/cache-key.spec.ts
@@ -27,21 +27,40 @@ describe('makeCacheKey', () => {
   });
 
   it('produces SHA-256 digests, including for unicode and multi-block input', () => {
-    // Digests of the composed key string `GET|json|<url>||`, from an independent
-    // SHA-256, covering utf-8 encoding and more than one 64-byte padding block.
+    // Digests of the length-delimited composed key, from an independent SHA-256,
+    // covering utf-8 encoding and more than one 64-byte padding block.
     const unicode = makeCacheKey(
       new HttpRequest('GET', '/api/tôdôs'),
       '/api/tôdôs',
     );
     expect(unicode).toEqual(
-      'ba4bec59cdb7ceb3b8228e3c71e0aa49f6c6812c4a792ad963da1dbf0263e4b0',
+      'dee8a1da8cecc1aa25d6a788bb81edf94ca3872452a04601dcef5c916f6c0b61',
     );
 
     const longUrl = `/api/${'a'.repeat(100)}`;
     const long = makeCacheKey(new HttpRequest('GET', longUrl), longUrl);
     expect(long).toEqual(
-      '640396e812e78b5c8e1de7cf5fc2e2b6237aad36e3fca5fb26b7812a68d408fe',
+      '2b6caca02694b21b4395374edf234f16b85abdf66845060d4fdb4f367125d682',
     );
+  });
+
+  it('does not collide on ambiguous parameter serialization', () => {
+    // `?tag=x&tag=y` and `?tag=x,y` both stringify to `tag=x,y` under the old
+    // serialization, so distinct requests shared a cache slot.
+    const repeated = makeCacheKey(
+      new HttpRequest('GET', '/api', {
+        params: new HttpParams({ fromString: 'tag=x&tag=y' }),
+      }),
+      '/api',
+    );
+    const comma = makeCacheKey(
+      new HttpRequest('GET', '/api', {
+        params: new HttpParams({ fromString: 'tag=x,y' }),
+      }),
+      '/api',
+    );
+
+    expect(repeated).not.toEqual(comma);
   });
 
   it('keys on method, params, and body', () => {

--- a/packages/router/src/lib/cache-key.spec.ts
+++ b/packages/router/src/lib/cache-key.spec.ts
@@ -26,6 +26,24 @@ describe('makeCacheKey', () => {
     expect(a).not.toEqual(b);
   });
 
+  it('produces SHA-256 digests, including for unicode and multi-block input', () => {
+    // Digests of the composed key string `GET|json|<url>||`, from an independent
+    // SHA-256, covering utf-8 encoding and more than one 64-byte padding block.
+    const unicode = makeCacheKey(
+      new HttpRequest('GET', '/api/tôdôs'),
+      '/api/tôdôs',
+    );
+    expect(unicode).toEqual(
+      'ba4bec59cdb7ceb3b8228e3c71e0aa49f6c6812c4a792ad963da1dbf0263e4b0',
+    );
+
+    const longUrl = `/api/${'a'.repeat(100)}`;
+    const long = makeCacheKey(new HttpRequest('GET', longUrl), longUrl);
+    expect(long).toEqual(
+      '640396e812e78b5c8e1de7cf5fc2e2b6237aad36e3fca5fb26b7812a68d408fe',
+    );
+  });
+
   it('keys on method, params, and body', () => {
     const base = makeCacheKey(new HttpRequest('GET', '/api'), '/api');
     const withParams = makeCacheKey(

--- a/packages/router/src/lib/cache-key.ts
+++ b/packages/router/src/lib/cache-key.ts
@@ -1,18 +1,29 @@
 import { HttpParams, HttpRequest } from '@angular/common/http';
 import { StateKey, makeStateKey } from '@angular/core';
 
+// Length-prefix each atom (netstring style) so no field, parameter key, or
+// parameter value can be crafted to shift another's boundary. Without this a
+// hash over delimiter-joined fields still collides on ambiguous inputs, e.g.
+// `?tag=x&tag=y` and `?tag=x,y` both serialize to `tag=x,y`.
+function encodeAtom(value: string): string {
+  return `${value.length}:${value}`;
+}
+
 function sortAndConcatParams(params: HttpParams | URLSearchParams): string {
-  return [...params.keys()]
-    .sort()
-    .map((k) => `${k}=${params.getAll(k)}`)
-    .join('&');
+  const keys = [...new Set(params.keys())].sort();
+  const atoms: string[] = [];
+  for (const key of keys) {
+    for (const value of params.getAll(key) ?? []) {
+      atoms.push(encodeAtom(key), encodeAtom(value));
+    }
+  }
+  return atoms.join('');
 }
 
 export function makeCacheKey(
   request: HttpRequest<any>,
   mappedRequestUrl: string,
 ): StateKey<unknown> {
-  // make the params encoded same as a url so it's easy to identify
   const { params, method, responseType } = request;
   const encodedParams = sortAndConcatParams(params);
 
@@ -29,7 +40,9 @@ export function makeCacheKey(
     mappedRequestUrl,
     serializedBody,
     encodedParams,
-  ].join('|');
+  ]
+    .map(encodeAtom)
+    .join('');
 
   const hash = generateHash(key);
 

--- a/packages/router/src/lib/cache-key.ts
+++ b/packages/router/src/lib/cache-key.ts
@@ -36,12 +36,161 @@ export function makeCacheKey(
   return makeStateKey(hash);
 }
 
-function generateHash(str: string) {
-  let hash = 0;
-  for (let i = 0, len = str.length; i < len; i++) {
-    let chr = str.charCodeAt(i);
-    hash = (hash << 5) - hash + chr;
-    hash |= 0; // Convert to 32bit integer
+/**
+ * SHA-256 round constants (first 32 bits of the fractional parts of the cube
+ * roots of the first 64 primes).
+ */
+const SHA256_ROUND_CONSTANTS = /* @__PURE__ */ new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+let textEncoder: TextEncoder | undefined;
+
+/**
+ * Generates a SHA-256 hash of a string. This mirrors Angular's `HttpTransferCache`
+ * key derivation: a synchronous SHA-256 is used because the Web Crypto API is
+ * asynchronous, whereas cache-key derivation in the interceptor must stay
+ * synchronous. The previous 32-bit DJB2 hash had a keyspace small enough for an
+ * attacker to craft colliding requests and poison the transfer cache.
+ */
+function generateHash(value: string): string {
+  textEncoder ??= new TextEncoder();
+  const inputBytes = textEncoder.encode(value);
+
+  // Initial hash values (first 32 bits of the fractional parts of the square
+  // roots of the first 8 primes).
+  let hashState0 = 0x6a09e667;
+  let hashState1 = 0xbb67ae85;
+  let hashState2 = 0x3c6ef372;
+  let hashState3 = 0xa54ff53a;
+  let hashState4 = 0x510e527f;
+  let hashState5 = 0x9b05688c;
+  let hashState6 = 0x1f83d9ab;
+  let hashState7 = 0x5be0cd19;
+
+  const messageLengthInBits = inputBytes.length * 8;
+  const paddedLengthInBytes = (((inputBytes.length + 8) >> 6) + 1) << 6;
+  const paddedBytes = new Uint8Array(paddedLengthInBytes);
+  paddedBytes.set(inputBytes);
+  paddedBytes[inputBytes.length] = 0x80;
+
+  const paddedBytesView = new DataView(paddedBytes.buffer);
+  const lowBits = messageLengthInBits >>> 0;
+  const highBits = (messageLengthInBits / 0x100000000) >>> 0;
+  paddedBytesView.setUint32(paddedLengthInBytes - 8, highBits, false);
+  paddedBytesView.setUint32(paddedLengthInBytes - 4, lowBits, false);
+
+  const messageSchedule = new Uint32Array(64);
+  for (
+    let chunkOffset = 0;
+    chunkOffset < paddedLengthInBytes;
+    chunkOffset += 64
+  ) {
+    for (let i = 0; i < 16; i++) {
+      messageSchedule[i] = paddedBytesView.getUint32(
+        chunkOffset + i * 4,
+        false,
+      );
+    }
+
+    for (let i = 16; i < 64; i++) {
+      const prevWord15 = messageSchedule[i - 15];
+      const sigma0 =
+        (((prevWord15 >>> 7) | (prevWord15 << 25)) ^
+          ((prevWord15 >>> 18) | (prevWord15 << 14)) ^
+          (prevWord15 >>> 3)) >>>
+        0;
+
+      const prevWord2 = messageSchedule[i - 2];
+      const sigma1 =
+        (((prevWord2 >>> 17) | (prevWord2 << 15)) ^
+          ((prevWord2 >>> 19) | (prevWord2 << 13)) ^
+          (prevWord2 >>> 10)) >>>
+        0;
+
+      messageSchedule[i] =
+        (messageSchedule[i - 16] + sigma0 + messageSchedule[i - 7] + sigma1) >>>
+        0;
+    }
+
+    let workingStateA = hashState0;
+    let workingStateB = hashState1;
+    let workingStateC = hashState2;
+    let workingStateD = hashState3;
+    let workingStateE = hashState4;
+    let workingStateF = hashState5;
+    let workingStateG = hashState6;
+    let workingStateH = hashState7;
+
+    for (let i = 0; i < 64; i++) {
+      const capitalSigma1 =
+        (((workingStateE >>> 6) | (workingStateE << 26)) ^
+          ((workingStateE >>> 11) | (workingStateE << 21)) ^
+          ((workingStateE >>> 25) | (workingStateE << 7))) >>>
+        0;
+      const chFunction =
+        ((workingStateE & workingStateF) ^ (~workingStateE & workingStateG)) >>>
+        0;
+      const temp1 =
+        (workingStateH +
+          capitalSigma1 +
+          chFunction +
+          SHA256_ROUND_CONSTANTS[i] +
+          messageSchedule[i]) >>>
+        0;
+
+      const capitalSigma0 =
+        (((workingStateA >>> 2) | (workingStateA << 30)) ^
+          ((workingStateA >>> 13) | (workingStateA << 19)) ^
+          ((workingStateA >>> 22) | (workingStateA << 10))) >>>
+        0;
+      const majFunction =
+        ((workingStateA & workingStateB) ^
+          (workingStateA & workingStateC) ^
+          (workingStateB & workingStateC)) >>>
+        0;
+      const temp2 = (capitalSigma0 + majFunction) >>> 0;
+
+      workingStateH = workingStateG;
+      workingStateG = workingStateF;
+      workingStateF = workingStateE;
+      workingStateE = (workingStateD + temp1) >>> 0;
+      workingStateD = workingStateC;
+      workingStateC = workingStateB;
+      workingStateB = workingStateA;
+      workingStateA = (temp1 + temp2) >>> 0;
+    }
+
+    hashState0 = (hashState0 + workingStateA) >>> 0;
+    hashState1 = (hashState1 + workingStateB) >>> 0;
+    hashState2 = (hashState2 + workingStateC) >>> 0;
+    hashState3 = (hashState3 + workingStateD) >>> 0;
+    hashState4 = (hashState4 + workingStateE) >>> 0;
+    hashState5 = (hashState5 + workingStateF) >>> 0;
+    hashState6 = (hashState6 + workingStateG) >>> 0;
+    hashState7 = (hashState7 + workingStateH) >>> 0;
   }
-  return `${hash}`;
+
+  return [
+    hashState0,
+    hashState1,
+    hashState2,
+    hashState3,
+    hashState4,
+    hashState5,
+    hashState6,
+    hashState7,
+  ]
+    .map((x) => x.toString(16).padStart(8, '0'))
+    .join('');
 }


### PR DESCRIPTION
## PR Checklist

Addresses two triaged security advisories on the repo:

- **GHSA-83pw-83rq-5gh2** — Analog TransferState cache key collision (32-bit DJB2)
- **GHSA-h8wh-3724-5q95** — Stored XSS via the marked code renderer + `bypassSecurityTrustHtml`

Closes #

## Affected scope

- Primary scope: `router`, `content`
- Secondary scopes: `platform`

## Recommended merge strategy for maintainer [optional]

- [ ] Squash merge
- [x] Rebase merge
- [ ] Other

## Commit preservation note [optional]

The two commits are intentionally scoped per concern/package: `fix(router): …` (cache key) and `fix(content): …` (markdown escaping, shared across platform + content). They cover two distinct advisories with distinct root causes, so preserving the boundaries keeps the history bisectable per fix. Squash into a single commit if you prefer — the changes are independent and either order is safe.

## What is the new behavior?

**Router — SHA-256 TransferState cache keys.** `requestContextInterceptor` derived HttpClient TransferState cache keys from a 32-bit DJB2 hash. The small keyspace let distinct requests collide on the same TransferState slot, so a colliding request could hydrate with another request's response body (transfer-cache poisoning). The DJB2 hash is replaced with a synchronous SHA-256, mirroring Angular core's own `HttpTransferCache` key derivation (WebCrypto is async; the interceptor derives keys synchronously, so a JS SHA-256 is required). Verified byte-for-byte against Node's `crypto.createHash('sha256')`.

**Content/platform — escape the marked code renderer.** The custom marked renderer (used by the build-time content plugin and the runtime `MarkdownContentRendererService`) interpolated code-block text, code-span text, and the language name into HTML without escaping, and the result is injected via `bypassSecurityTrustHtml`. Code spans and, without a highlighter, fenced blocks/mermaid produced live markup. The renderer now escapes text before emitting it and reduces the fence info string to a safe language identifier before it flows into the `class="language-…"` attribute. The same fix is applied to both renderers, and a shared `escapeHtml` helper replaces the duplicated one in the shiki highlighter.

> Note: raw HTML written directly in a markdown body still passes through (inherent marked behavior; first-party trusted content on the default blog). This PR closes the code-fence/code-span injection where safe-looking markdown syntax silently produced HTML. Removing `bypassSecurityTrustHtml` / adding DOMPurify would be a separate, breaking change.

## Test plan

- [x] `nx test router` (161 passed, incl. new `cache-key.spec.ts`)
- [x] `nx test content` (46 passed, incl. new XSS regression test)
- [x] `nx test platform` (59 passed)
- [x] `nx build router` / `nx build content` / `nx build platform`
- [x] `nx format:check` on changed files
- [x] Manual verification: reproduced all reported vectors against the real marked pipeline, then confirmed each is inert after the fix across highlighter-last, analog-renderer-last, and no-highlighter compositions; confirmed the SHA-256 output matches Node crypto and the prior `Aa`/`BB` DJB2 collision no longer occurs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

TransferState keys change format (hex SHA-256 instead of a signed 32-bit int), but keys are computed identically on server and client within the same render, so hydration matching is unaffected.

## Other information

Both advisories are currently in triage. Happy to coordinate disclosure timing / advisory linkage as maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)