### PR TITLE
fix(router): guard import.meta.env access in streaming SSR renderer

### DIFF
--- a/packages/router/server/src/render-stream.ts
+++ b/packages/router/server/src/render-stream.ts
@@ -52,7 +52,9 @@ import { afterBodyOpen, bodyInner, headInner } from './utils/stream-html';
 import { isLikelyBot, streamingDisabledByRoute } from './utils/stream-request';
 import { DEFER_RECONCILE_RUNTIME } from './defer-reconcile-runtime';
 
-if (import.meta.env.PROD) {
+// Optional chaining: the server-function dispatch endpoint imports this entry
+// from a Nitro bundle, where `import.meta.env` is not defined at all.
+if (import.meta.env?.PROD) {
   enableProdMode();
 }
 
@@ -116,7 +118,7 @@ function installCaptureDispatcher(): void {
 
 let warnedMissingPrimitive = false;
 function warnMissingPrimitiveOnce(): void {
-  if (warnedMissingPrimitive || !import.meta.env.DEV) return;
+  if (warnedMissingPrimitive || !import.meta.env?.DEV) return;
   warnedMissingPrimitive = true;
   console.warn(
     '[@analogjs/router] renderStream: the streaming hook was not found on ' +


### PR DESCRIPTION
## PR Checklist

Closes #2494

## Affected scope

- Primary scope: router
- Secondary scopes:

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## What is the new behavior?

`render-stream.ts` accessed `import.meta.env.PROD` / `import.meta.env.DEV` unguarded at module top-level. `render.ts` (co-exported from the same `server/src/index.ts` barrel into a single FESM bundle) was already patched for this exact case in #2433, with the comment explaining that the server-function dispatch endpoint loads this entry from a Nitro bundle where `import.meta.env` is not defined at all. `render-stream.ts` was added the same day in #2419 (Streaming SSR) and never received the same fix.

Because `getServerFnHandlers` (in `vite-plugin-nitro`) globs `**/*.server.ts` and only excludes `app.config.server.ts`, any project using the standard `PageServerLoad` `.server.ts` convention (not just actual Server Functions) causes `hasServerFns` to be `true`, wiring up the `/_analog/fn/:id` dispatch endpoint. That endpoint imports `@analogjs/router/server`, which crashes the whole SSR process at boot before serving any request — see #2494 for the full repro and root-cause writeup.

This PR applies the same optional-chaining guard already established in `render.ts` to `render-stream.ts`, at both call sites.

## Test plan

- [x] `nx build router` (builds clean, verified the guard is present in the emitted FESM output)
- [x] `nx format:check` on the changed file
- [ ] `pnpm test` (not run for this narrow change; happy for CI to confirm)
- [x] Manual verification: reproduced the crash against the monorepo's own `analog-app` (which has both `.server.ts` load files and Server Functions), rebuilt `@analogjs/router`, confirmed the guarded code path in the emitted bundle

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Minimal, targeted fix mirroring the existing pattern in `render.ts`. Filed #2494 with the full root-cause analysis, including why this affects any SSR project with a `.server.ts` load file, not just Server Functions users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)