### PR TITLE
docs(vitest-angular): expand Zone.js test setup for fakeAsync

### DIFF
--- a/apps/docs-analog/src/content/features/testing/vitest.md
+++ b/apps/docs-analog/src/content/features/testing/vitest.md
@@ -116,18 +116,39 @@ As of Angular v21, `Zoneless` change detection is the default for new projects.
 Use the following setup:
 
 ```ts
+// src/test-setup.ts
+import '@angular/compiler';
+
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
 setupTestBed();
 ```
 
 ### Zone.js setup
 
-If you are using `Zone.js` for change detection, import the `setup-zone` script. This script automatically includes support for setting up snapshot tests.
+If you are using `Zone.js` for change detection, import the `setup-zone` script before setting up the `TestBed`. This script patches the test environment for `Zone.js` helpers such as `fakeAsync`, and automatically includes support for setting up snapshot tests.
 
 ```ts
+// src/test-setup.ts
+import '@angular/compiler';
+import '@analogjs/vitest-angular/setup-zone';
+
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
 setupTestBed({
   zoneless: false,
 });
 ```
+
+The two side effect imports must come first. If your formatter sorts side effect imports below named imports, keep them in a separate import group with a blank line, or exclude `src/test-setup.ts` from import sorting.
+
+:::warning
+
+With `Zone.js`, use Vitest's global test functions, with `globals: true` set in the `vite.config.ts`, and `vitest/globals` added to the `types` array in the `tsconfig.spec.json`. Importing `describe`, `it`, `beforeEach`, and other functions from `vitest` directly bypasses the `Zone.js` patching, and `fakeAsync` fails with the error `Expected to be running in 'ProxyZone', but it was not found`.
+
+Zoneless tests have no such restriction. When migrating to zoneless change detection, you can switch back to importing the functions from `vitest`.
+
+:::
 
 ### Configuration Options
 

--- a/packages/vitest-angular/README.md
+++ b/packages/vitest-angular/README.md
@@ -99,9 +99,11 @@ As of Angular v21, `Zoneless` change detection is the default for new projects.
 Use the following setup:
 
 ```ts
+// src/test-setup.ts
 import '@angular/compiler';
 import '@analogjs/vitest-angular/setup-snapshots';
 import '@analogjs/vitest-angular/setup-serializers';
+
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 setupTestBed();
@@ -109,17 +111,23 @@ setupTestBed();
 
 ### Zone.js setup
 
-If you are using `Zone.js` for change detection, import the `setup-zone` script. This script automatically includes support for setting up snapshot tests.
+If you are using `Zone.js` for change detection, import the `setup-zone` script before setting up the `TestBed`. This script patches the test environment for `Zone.js` helpers such as `fakeAsync`, and automatically includes support for setting up snapshot tests.
 
 ```ts
+// src/test-setup.ts
 import '@angular/compiler';
 import '@analogjs/vitest-angular/setup-zone';
+
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 setupTestBed({
   zoneless: false,
 });
 ```
+
+The side effect imports must come first. If your formatter sorts side effect imports below named imports, keep them in a separate import group with a blank line, or exclude `src/test-setup.ts` from import sorting.
+
+> **Note:** With `Zone.js`, use Vitest's global test functions, with `globals: true` set in the `vite.config.mts`, and `vitest/globals` added to the `types` array in the `tsconfig.spec.json`. Importing `describe`, `it`, `beforeEach`, and other functions from `vitest` directly bypasses the `Zone.js` patching, and `fakeAsync` fails with the error `Expected to be running in 'ProxyZone', but it was not found`. Zoneless tests have no such restriction — when migrating to zoneless change detection, you can switch back to importing the functions from `vitest`.
 
 ### Configuration Options
 


### PR DESCRIPTION
## PR Checklist

The docs and README for `@analogjs/vitest-angular` describe the Zone.js test setup incompletely. The docs page's Zone.js snippet shows only `setupTestBed({ zoneless: false })` with no imports, so following it produces `Error: zone-testing.js is needed for the fakeAsync() test helper but could not be found`. Neither the docs nor the README mention that Zone.js mode requires Vitest's global test functions — importing `describe`/`it`/`beforeEach` from `vitest` bypasses the zone patching and `fakeAsync` fails with `Expected to be running in 'ProxyZone', but it was not found`. Both issues came up in a real migration support thread.

Closes #

## Affected scope

- Primary scope: vitest-angular
- Secondary scopes: docs

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

- The zoneless and Zone.js `test-setup.ts` snippets on the docs testing page are complete, copy-pasteable files including the `@angular/compiler` and `setup-zone` side effect imports.
- Both the docs page and the package README note that the side effect imports must come first, with a tip for formatters that sort side effect imports below named imports.
- A warning callout (docs) / note (README) explains that Zone.js mode requires Vitest's global test functions (`globals: true` + `vitest/globals` types), that importing them from `vitest` causes the ProxyZone error with `fakeAsync`, and that zoneless tests have no such restriction.

Docs-only change — no code or behavior changes.

## Test plan

- [x] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [x] Manual verification

Prettier ran on the changed files via the pre-commit hook. Build/test suites not run since this only touches markdown; CI will verify. The `:::warning` admonition and heading anchors were checked against the docs app's supported admonition styles and slug scheme.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RbaJR79jpB1oPwjLLyo73