### PR TITLE
fix(content): resolve fragment-only anchor hrefs against the current document, not <base href>

### DIFF
--- a/packages/content/src/lib/anchor-navigation.directive.spec.ts
+++ b/packages/content/src/lib/anchor-navigation.directive.spec.ts
@@ -118,6 +118,34 @@ describe('AnchorNavigationDirective', () => {
     expect(handleNavigation.mock.results[0].value).toEqual(false);
     expect(router.navigateByUrl).toBeCalledWith('/page?query=analog#section1');
   }));
+
+  it('navigates to a fragment-only anchor using the current page path and search when a <base> element is present', fakeAsync(() => {
+    // A <base> element makes the browser resolve a fragment-only href
+    // (e.g. href="#section1") against the base URL, not the current
+    // document -- so a naive read of `pathname`/`search` off the anchor
+    // resolves to the base's ("/"), not the page the link actually lives
+    // on. Reproduce that here with a real <base> element plus a pushState
+    // move to a nested path with a query string.
+    const baseEl = document.createElement('base');
+    baseEl.setAttribute('href', '/');
+    document.head.appendChild(baseEl);
+    window.history.pushState({}, '', '/blog/post?query=analog');
+
+    try {
+      const { router, handleNavigation, selectById } = setup();
+
+      selectById('fragment-only').click();
+      tick();
+
+      expect(handleNavigation.mock.results[0].value).toEqual(false);
+      expect(router.navigateByUrl).toBeCalledWith(
+        '/blog/post?query=analog#section1',
+      );
+    } finally {
+      document.head.removeChild(baseEl);
+      window.history.pushState({}, '', '/');
+    }
+  }));
 });
 
 function setup() {
@@ -172,6 +200,7 @@ function setup() {
         >
           Page with Search, Hash, and Trailing Slash
         </a>
+        <a id="fragment-only" href="#section1">Fragment Only</a>
       </div>
     `,
   })

--- a/packages/content/src/lib/anchor-navigation.directive.ts
+++ b/packages/content/src/lib/anchor-navigation.directive.ts
@@ -20,7 +20,22 @@ export class AnchorNavigationDirective {
       !hasDownloadAttribute(element)
     ) {
       const { pathname, search, hash } = element;
-      const url = this.location.normalize(`${pathname}${search}${hash}`);
+      // A `<base>` element makes the browser resolve fragment-only hrefs
+      // (e.g. `href="#some-id"`) against the base URL rather than the
+      // current document, so `pathname`/`search` come back as the base's
+      // rather than the current page's. Fall back to the document's own
+      // location in that case, or an in-page anchor link would navigate
+      // to the base route and lose the fragment there.
+      const isFragmentOnly = element.getAttribute('href')?.startsWith('#');
+      const resolvedPathname = isFragmentOnly
+        ? this.document.location.pathname
+        : pathname;
+      const resolvedSearch = isFragmentOnly
+        ? this.document.location.search
+        : search;
+      const url = this.location.normalize(
+        `${resolvedPathname}${resolvedSearch}${hash}`,
+      );
       this.router.navigateByUrl(url);
 
       return false;


### PR DESCRIPTION
## What

`AnchorNavigationDirective` intercepts clicks on internal links rendered by `analog-markdown` (and its route variant) and re-navigates via the Angular Router. It builds the target URL from `pathname`/`search`/`hash` read straight off the clicked `HTMLAnchorElement`.

When a `<base href="...">` element is present on the page (a common SPA setup so relative asset URLs resolve consistently across routes), the browser resolves **fragment-only hrefs** like `href="#introduction"` against that base URL, not the current document. So on a page at `/blog/my-post` with `<base href="/">`, an in-page anchor link's `pathname` comes back as `"/"` and `search` comes back empty — the directive then calls `router.navigateByUrl("/#introduction")`, which lands on the app's root route instead of scrolling to the heading on the current page, and drops any existing query string.

## Fix

Fall back to `document.location.pathname`/`document.location.search` when the raw `href` attribute is fragment-only (`getAttribute('href')?.startsWith('#')`), since those aren't affected by `<base>`.

## Test plan

- Added a regression test using a real `<base>` element plus `history.pushState` to a nested path with a query string, asserting `router.navigateByUrl` is called with the current page's path preserved (`/blog/post?query=analog#section1`).
- Confirmed the new test fails on the pre-fix code (`router.navigateByUrl` called with just `#section1`) and passes with the fix.
- `nx test content` — all 47 tests pass (12 in `anchor-navigation.directive.spec.ts`, up from 11).
- `eslint` and `prettier` clean on the changed files.

This surfaced from a real-world blog built on `@analogjs/content`: an in-page anchor link (`[section](#heading)` inside rendered markdown) was silently sending readers to the site's home page instead of scrolling to the target heading.
