### PR TITLE
docs: add "Copy page" dropdown to docs pages

### DIFF
--- a/apps/docs-analog/src/app/docs/components/copy-page.spec.ts
+++ b/apps/docs-analog/src/app/docs/components/copy-page.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it, vi } from 'vitest';
+import { CopyPage, markdownForCopy } from './copy-page';
+
+describe('markdownForCopy', () => {
+  it('prepends the page title as an H1', () => {
+    expect(markdownForCopy('Body text', 'Intro')).toBe('# Intro\n\nBody text');
+  });
+
+  it('keeps an existing leading H1 instead of doubling it', () => {
+    expect(markdownForCopy('# Contributing\n\nBody', 'Contributing')).toBe(
+      '# Contributing\n\nBody',
+    );
+  });
+});
+
+describe('CopyPage', () => {
+  function setup() {
+    const fixture = TestBed.createComponent(CopyPage);
+    fixture.componentRef.setInput('markdown', 'Body');
+    fixture.componentRef.setInput('pageTitle', 'Intro');
+    fixture.componentRef.setInput('slug', 'introduction');
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('copies the prepared markdown to the clipboard', async () => {
+    const writeText = vi.fn<(text: string) => Promise<void>>(() =>
+      Promise.resolve(),
+    );
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    const fixture = setup();
+
+    (
+      fixture.nativeElement.querySelector('button') as HTMLButtonElement
+    ).click();
+
+    expect(writeText).toHaveBeenCalledWith('# Intro\n\nBody');
+  });
+
+  it('links to the .md URL of the current page', () => {
+    const fixture = setup();
+    const buttons = (
+      fixture.nativeElement as HTMLElement
+    ).querySelectorAll<HTMLButtonElement>('button');
+    buttons[1].click();
+    fixture.detectChanges();
+
+    const link = fixture.nativeElement.querySelector(
+      'ul[role="menu"] a',
+    ) as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('/docs/introduction.md');
+  });
+});

--- a/apps/docs-analog/src/app/docs/components/copy-page.spec.ts
+++ b/apps/docs-analog/src/app/docs/components/copy-page.spec.ts
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { CopyPage, markdownForCopy } from './copy-page';
 
 describe('markdownForCopy', () => {
-  it('prepends the page title as an H1', () => {
-    expect(markdownForCopy('Body text', 'Intro')).toBe('# Intro\n\nBody text');
+  it('strips frontmatter and prepends the page title as an H1', () => {
+    expect(
+      markdownForCopy('---\ntitle: Intro\n---\n\nBody text', 'Intro'),
+    ).toBe('# Intro\n\nBody text');
   });
 
   it('keeps an existing leading H1 instead of doubling it', () => {
@@ -17,14 +19,13 @@ describe('markdownForCopy', () => {
 describe('CopyPage', () => {
   function setup() {
     const fixture = TestBed.createComponent(CopyPage);
-    fixture.componentRef.setInput('markdown', 'Body');
     fixture.componentRef.setInput('pageTitle', 'Intro');
     fixture.componentRef.setInput('slug', 'introduction');
     fixture.detectChanges();
     return fixture;
   }
 
-  it('copies the prepared markdown to the clipboard', async () => {
+  it('fetches the .md asset and copies the prepared markdown', async () => {
     const writeText = vi.fn<(text: string) => Promise<void>>(() =>
       Promise.resolve(),
     );
@@ -32,13 +33,44 @@ describe('CopyPage', () => {
       value: { writeText },
       configurable: true,
     });
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response('---\ntitle: Intro\n---\n\nBody', { status: 200 }),
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
     const fixture = setup();
 
     (
       fixture.nativeElement.querySelector('button') as HTMLButtonElement
     ).click();
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalled());
 
+    expect(fetchMock).toHaveBeenCalledWith('/docs/introduction.md');
     expect(writeText).toHaveBeenCalledWith('# Intro\n\nBody');
+    vi.unstubAllGlobals();
+  });
+
+  it('does not copy when the .md asset is unavailable', async () => {
+    const writeText = vi.fn<(text: string) => Promise<void>>(() =>
+      Promise.resolve(),
+    );
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    vi.stubGlobal('fetch', () =>
+      Promise.resolve(new Response('<html></html>', { status: 200 })),
+    );
+    const fixture = setup();
+
+    (
+      fixture.nativeElement.querySelector('button') as HTMLButtonElement
+    ).click();
+    await new Promise((r) => setTimeout(r));
+
+    expect(writeText).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
   });
 
   it('links to the .md URL of the current page', () => {

--- a/apps/docs-analog/src/app/docs/components/copy-page.ts
+++ b/apps/docs-analog/src/app/docs/components/copy-page.ts
@@ -96,7 +96,7 @@ export function markdownForCopy(markdown: string, title?: string): string {
       @if (open()) {
         <ul
           role="menu"
-          class="absolute right-0 top-full z-10 mt-1 min-w-[13rem] rounded border py-1 shadow-lg"
+          class="absolute left-0 top-full z-10 mt-1 min-w-[13rem] rounded border py-1 shadow-lg"
           style="border-color: var(--border); background: var(--bg-elevated)"
         >
           <li>

--- a/apps/docs-analog/src/app/docs/components/copy-page.ts
+++ b/apps/docs-analog/src/app/docs/components/copy-page.ts
@@ -1,0 +1,154 @@
+import { Component, computed, inject, input, signal } from '@angular/core';
+import { CONTENT_LOCALE } from '@analogjs/content';
+
+/**
+ * Prepares the doc source for the clipboard. Content arrives with
+ * frontmatter already stripped, so a leading H1 from the page title is
+ * prepended unless the body brings its own (e.g. synced README pages).
+ */
+export function markdownForCopy(markdown: string, title?: string): string {
+  return title && !markdown.startsWith('# ')
+    ? `# ${title}\n\n${markdown}`
+    : markdown;
+}
+
+/**
+ * "Copy page" split button shown next to the docs page title. The main
+ * segment copies the page's raw Markdown to the clipboard; the dropdown
+ * repeats that action and links to the page's `.md` URL (emitted at
+ * prerender via the `outputSourceFile` option).
+ */
+@Component({
+  selector: 'docs-copy-page',
+  template: `
+    <div class="relative inline-flex text-sm">
+      <button
+        type="button"
+        class="flex items-center gap-1.5 rounded-l border px-2.5 py-1.5 hover:bg-[var(--bg-subtle)]"
+        style="border-color: var(--border)"
+        (click)="copy()"
+      >
+        @if (copied()) {
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+          Copied
+        } @else {
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+            />
+          </svg>
+          Copy page
+        }
+      </button>
+      <button
+        type="button"
+        class="flex items-center rounded-r border border-l-0 px-1.5 hover:bg-[var(--bg-subtle)]"
+        style="border-color: var(--border)"
+        aria-haspopup="menu"
+        aria-label="Copy page options"
+        [attr.aria-expanded]="open()"
+        (click)="open.set(!open())"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+      @if (open()) {
+        <ul
+          role="menu"
+          class="absolute right-0 top-full z-10 mt-1 min-w-[13rem] rounded border py-1 shadow-lg"
+          style="border-color: var(--border); background: var(--bg-elevated)"
+        >
+          <li>
+            <button
+              type="button"
+              role="menuitem"
+              class="block w-full px-3 py-1.5 text-left hover:bg-[var(--bg-subtle)]"
+              (click)="copy()"
+            >
+              Copy page as Markdown
+            </button>
+          </li>
+          <li>
+            <a
+              role="menuitem"
+              class="block px-3 py-1.5 hover:bg-[var(--bg-subtle)]"
+              [href]="mdUrl()"
+              target="_blank"
+              rel="noopener"
+              (click)="open.set(false)"
+            >
+              View as Markdown
+            </a>
+          </li>
+        </ul>
+      }
+    </div>
+  `,
+})
+export class CopyPage {
+  readonly markdown = input.required<string>();
+  readonly pageTitle = input<string>();
+  readonly slug = input.required<string>();
+
+  private readonly locale = inject(CONTENT_LOCALE, { optional: true });
+
+  protected readonly open = signal(false);
+  protected readonly copied = signal(false);
+  private copiedTimer: ReturnType<typeof setTimeout> | undefined;
+
+  protected readonly mdUrl = computed(() =>
+    this.locale
+      ? `/${this.locale}/docs/${this.slug()}.md`
+      : `/docs/${this.slug()}.md`,
+  );
+
+  protected async copy(): Promise<void> {
+    this.open.set(false);
+    await navigator.clipboard?.writeText(
+      markdownForCopy(this.markdown(), this.pageTitle()),
+    );
+    this.copied.set(true);
+    clearTimeout(this.copiedTimer);
+    this.copiedTimer = setTimeout(() => this.copied.set(false), 2000);
+  }
+}

--- a/apps/docs-analog/src/app/docs/components/copy-page.ts
+++ b/apps/docs-analog/src/app/docs/components/copy-page.ts
@@ -2,21 +2,22 @@ import { Component, computed, inject, input, signal } from '@angular/core';
 import { CONTENT_LOCALE } from '@analogjs/content';
 
 /**
- * Prepares the doc source for the clipboard. Content arrives with
- * frontmatter already stripped, so a leading H1 from the page title is
- * prepended unless the body brings its own (e.g. synced README pages).
+ * Prepares raw doc source for the clipboard: strips frontmatter and
+ * prepends an H1 from the page title unless the body brings its own
+ * (e.g. synced README pages).
  */
 export function markdownForCopy(markdown: string, title?: string): string {
-  return title && !markdown.startsWith('# ')
-    ? `# ${title}\n\n${markdown}`
-    : markdown;
+  const body = markdown.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n+/, '');
+  return title && !body.startsWith('# ') ? `# ${title}\n\n${body}` : body;
 }
 
 /**
  * "Copy page" split button shown next to the docs page title. The main
  * segment copies the page's raw Markdown to the clipboard; the dropdown
- * repeats that action and links to the page's `.md` URL (emitted at
- * prerender via the `outputSourceFile` option).
+ * repeats that action and links to the page's `.md` URL. Both are backed
+ * by the `.md` asset emitted at prerender via the `outputSourceFile`
+ * option (the runtime `doc.content` is already rendered HTML), so the
+ * copy action fetches that asset on first use.
  */
 @Component({
   selector: 'docs-copy-page',
@@ -126,7 +127,6 @@ export function markdownForCopy(markdown: string, title?: string): string {
   `,
 })
 export class CopyPage {
-  readonly markdown = input.required<string>();
   readonly pageTitle = input<string>();
   readonly slug = input.required<string>();
 
@@ -144,8 +144,13 @@ export class CopyPage {
 
   protected async copy(): Promise<void> {
     this.open.set(false);
+    const res = await fetch(this.mdUrl());
+    const text = res.ok ? await res.text() : '';
+    // The .md assets only exist in prerendered output; a dev server may
+    // answer with the SPA shell instead. Treat both as "nothing to copy".
+    if (!text || text.trimStart().startsWith('<')) return;
     await navigator.clipboard?.writeText(
-      markdownForCopy(this.markdown(), this.pageTitle()),
+      markdownForCopy(text, this.pageTitle()),
     );
     this.copied.set(true);
     clearTimeout(this.copiedTimer);

--- a/apps/docs-analog/src/app/docs/index.ts
+++ b/apps/docs-analog/src/app/docs/index.ts
@@ -26,6 +26,7 @@ export {
 export { useLocaleSignal } from './locale';
 export { DocsLayoutShell, redirectDocsRoot } from './docs-layout';
 
+export { CopyPage, markdownForCopy } from './components/copy-page';
 export { DocFooter } from './components/doc-footer';
 export { EnhanceCode } from './components/enhance-code';
 export { Footer } from './components/footer';

--- a/apps/docs-analog/src/app/pages/docs/[[...slug]].page.ts
+++ b/apps/docs-analog/src/app/pages/docs/[[...slug]].page.ts
@@ -14,7 +14,13 @@ import {
   injectContent,
   MarkdownComponent,
 } from '@analogjs/content';
-import { DocFooter, EnhanceCode, extractHeadings, Toc } from '../../docs';
+import {
+  CopyPage,
+  DocFooter,
+  EnhanceCode,
+  extractHeadings,
+  Toc,
+} from '../../docs';
 import { DocSeo } from '../../seo';
 
 interface DocAttributes {
@@ -23,20 +29,32 @@ interface DocAttributes {
 }
 
 @Component({
-  imports: [MarkdownComponent, DocFooter, EnhanceCode, Toc],
+  imports: [MarkdownComponent, CopyPage, DocFooter, EnhanceCode, Toc],
   template: `
     <div class="flex gap-8">
       <div #article docsEnhanceCode class="flex-1 min-w-0 min-h-screen">
         @if (doc(); as doc) {
           <header class="mb-6">
-            @if (doc.attributes.title) {
-              <h1
-                class="text-5xl font-bold leading-tight tracking-tight"
-                style="letter-spacing: -0.02em"
-              >
-                {{ doc.attributes.title }}
-              </h1>
-            }
+            <div class="flex items-start justify-between gap-4">
+              @if (doc.attributes.title) {
+                <h1
+                  class="text-5xl font-bold leading-tight tracking-tight"
+                  style="letter-spacing: -0.02em"
+                >
+                  {{ doc.attributes.title }}
+                </h1>
+              }
+              @if (markdown(); as md) {
+                @if (slug(); as s) {
+                  <docs-copy-page
+                    class="ml-auto shrink-0 pt-2"
+                    [markdown]="md"
+                    [pageTitle]="doc.attributes.title"
+                    [slug]="s"
+                  />
+                }
+              }
+            </div>
             @if (doc.attributes.description) {
               <p class="mt-3 text-lg" style="color: var(--fg-muted)">
                 {{ doc.attributes.description }}
@@ -92,9 +110,13 @@ export default class DocPage {
   );
 
   protected readonly doc = toSignal(this.doc$);
-  protected readonly headings = computed(() => {
+  protected readonly markdown = computed(() => {
     const c = this.doc()?.content;
-    return typeof c === 'string' ? extractHeadings(c) : [];
+    return typeof c === 'string' ? c : undefined;
+  });
+  protected readonly headings = computed(() => {
+    const md = this.markdown();
+    return md ? extractHeadings(md) : [];
   });
   private readonly locale = inject(CONTENT_LOCALE, { optional: true });
   private readonly seo = inject(DocSeo);

--- a/apps/docs-analog/src/app/pages/docs/[[...slug]].page.ts
+++ b/apps/docs-analog/src/app/pages/docs/[[...slug]].page.ts
@@ -44,15 +44,12 @@ interface DocAttributes {
                   {{ doc.attributes.title }}
                 </h1>
               }
-              @if (markdown(); as md) {
-                @if (slug(); as s) {
-                  <docs-copy-page
-                    class="ml-auto shrink-0 pt-2"
-                    [markdown]="md"
-                    [pageTitle]="doc.attributes.title"
-                    [slug]="s"
-                  />
-                }
+              @if (slug(); as s) {
+                <docs-copy-page
+                  class="ml-auto shrink-0 pt-2"
+                  [pageTitle]="doc.attributes.title"
+                  [slug]="s"
+                />
               }
             </div>
             @if (doc.attributes.description) {
@@ -110,13 +107,9 @@ export default class DocPage {
   );
 
   protected readonly doc = toSignal(this.doc$);
-  protected readonly markdown = computed(() => {
-    const c = this.doc()?.content;
-    return typeof c === 'string' ? c : undefined;
-  });
   protected readonly headings = computed(() => {
-    const md = this.markdown();
-    return md ? extractHeadings(md) : [];
+    const c = this.doc()?.content;
+    return typeof c === 'string' ? extractHeadings(c) : [];
   });
   private readonly locale = inject(CONTENT_LOCALE, { optional: true });
   private readonly seo = inject(DocSeo);

--- a/apps/docs-analog/src/app/pages/docs/[[...slug]].page.ts
+++ b/apps/docs-analog/src/app/pages/docs/[[...slug]].page.ts
@@ -35,7 +35,7 @@ interface DocAttributes {
       <div #article docsEnhanceCode class="flex-1 min-w-0 min-h-screen">
         @if (doc(); as doc) {
           <header class="mb-6">
-            <div class="flex items-start justify-between gap-4">
+            <div class="flex items-start gap-4">
               @if (doc.attributes.title) {
                 <h1
                   class="text-5xl font-bold leading-tight tracking-tight"
@@ -46,7 +46,7 @@ interface DocAttributes {
               }
               @if (slug(); as s) {
                 <docs-copy-page
-                  class="ml-auto shrink-0 pt-2"
+                  class="shrink-0 pt-2"
                   [pageTitle]="doc.attributes.title"
                   [slug]="s"
                 />

--- a/apps/docs-analog/src/content/integrations/ai/index.md
+++ b/apps/docs-analog/src/content/integrations/ai/index.md
@@ -46,6 +46,8 @@ Use it when you want:
 - an addressable source an agent can fetch on demand
 - Markdown without the site navigation and other page chrome
 
+Every docs page also has a **Copy page** button next to its title that copies the page as Markdown to the clipboard — handy for pasting into an AI assistant with formatting intact — with a dropdown to view the raw Markdown at the page's `.md` URL.
+
 ## Section indexes
 
 In addition to the site-wide `llms.txt`, each multi-page docs section publishes its own scoped index at `llms.txt` under the section path, for example:

--- a/apps/docs-analog/src/content/packages/vite-plugin-angular/overview.md
+++ b/apps/docs-analog/src/content/packages/vite-plugin-angular/overview.md
@@ -64,7 +64,7 @@ export default defineConfig({
 });
 ```
 
-When `fastCompile` is enabled, template and input type errors will not surface during compilation — run `ngc -p tsconfig.app.json --noEmit` as a separate step in your build script to keep full type safety:
+When `fastCompile` is enabled, template and input type errors will not surface during compilation. Run `ngc -p tsconfig.app.json --noEmit` as a separate step in your build script to keep full type safety:
 
 ```json
 {
@@ -75,6 +75,21 @@ When `fastCompile` is enabled, template and input type errors will not surface d
 ```
 
 The fast compile path currently passes ~91% of Angular's conformance suite. Behavior and output may change between minor releases.
+
+## Vendor Sourcemaps
+
+The sourcemaps of dependencies and prebuilt libraries are preserved whenever `build.sourcemap` is enabled.
+
+```ts
+export default defineConfig({
+  plugins: [angular()],
+  build: { sourcemap: true },
+});
+```
+
+Expect larger sourcemap files, since they now include the mappings for dependency code. The application bundles are unchanged, and builds without `build.sourcemap` are unaffected.
+
+Angular's own packages are compiled through a separate path that always discards their sourcemaps, so mappings are not restored for `@angular/*`.
 
 ## Setting up the TypeScript config
 

--- a/apps/docs-analog/src/content/packages/vite-plugin-angular/overview.md
+++ b/apps/docs-analog/src/content/packages/vite-plugin-angular/overview.md
@@ -64,7 +64,7 @@ export default defineConfig({
 });
 ```
 
-When `fastCompile` is enabled, template and input type errors will not surface during compilation. Run `ngc -p tsconfig.app.json --noEmit` as a separate step in your build script to keep full type safety:
+When `fastCompile` is enabled, template and input type errors will not surface during compilation — run `ngc -p tsconfig.app.json --noEmit` as a separate step in your build script to keep full type safety:
 
 ```json
 {
@@ -75,21 +75,6 @@ When `fastCompile` is enabled, template and input type errors will not surface d
 ```
 
 The fast compile path currently passes ~91% of Angular's conformance suite. Behavior and output may change between minor releases.
-
-## Vendor Sourcemaps
-
-The sourcemaps of dependencies and prebuilt libraries are preserved whenever `build.sourcemap` is enabled.
-
-```ts
-export default defineConfig({
-  plugins: [angular()],
-  build: { sourcemap: true },
-});
-```
-
-Expect larger sourcemap files, since they now include the mappings for dependency code. The application bundles are unchanged, and builds without `build.sourcemap` are unaffected.
-
-Angular's own packages are compiled through a separate path that always discards their sourcemaps, so mappings are not restored for `@angular/*`.
 
 ## Setting up the TypeScript config
 


### PR DESCRIPTION
## PR Checklist

Docs pages had no quick way to grab a page's Markdown source for pasting into LLMs, issues, or discussions — the `.md` URLs emitted at prerender existed but were not surfaced in the UI.

Closes #2486

## Affected scope

- Primary scope: docs (`apps/docs-analog`)
- Secondary scopes: none (no package code changed)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A — squash is fine.

## What is the new behavior?

Each docs page now shows a **Copy page** split button next to the page title:

- **Copy page** / **Copy page as Markdown** — fetches the page's prerendered `.md` asset (emitted via the existing `outputSourceFile` prerender option), strips frontmatter, prepends `# {title}` when the body has no leading H1, and writes it to the clipboard. The button flips to a "Copied" check for 2 seconds. The copy fetches the `.md` asset because the runtime `doc.content` is already rendered HTML, not raw Markdown.
- **View as Markdown** — opens the page's raw `.md` URL (locale-aware: `/es/docs/...` pages link to `/es/docs/....md`).

The component (`docs-copy-page`) is standalone, styled with Tailwind utilities and the docs theme variables, works in light and dark themes, and renders on both the default-locale and `[locale]` doc routes (they share the same page component). The "Per-page Markdown" section of the AI integration guide mentions the new button (English doc only; translations left to the usual translation flow).

Screenshots (from the prerendered build, driven with Playwright):

| Light, menu open | Dark, menu open | Copied state |
| --- | --- | --- |
| dropdown with "Copy page as Markdown" / "View as Markdown" | same in dark theme | button shows a check + "Copied" |

## Test plan

- [x] `nx format:check` (docs-analog files)
- [ ] `pnpm build` (ran `nx build docs-analog` instead — full workspace build left to CI)
- [ ] `pnpm test` (ran `nx test docs-analog` instead — 23 tests passing, including 5 new copy-page tests)
- [x] Manual verification — served the prerendered output and drove it with Playwright/Chromium: verified the button renders on English and localized pages in light and dark themes, the dropdown opens, "View as Markdown" links to `/docs/introduction.md`, and the clipboard receives raw Markdown (`# Introduction\n\nAnalog is a fullstack meta-framework … [Angular](https://angular.dev)`)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

In dev mode the `.md` assets are not emitted, so the copy action quietly no-ops there (the fetch guard treats an SPA-shell response as "nothing to copy"); the feature is fully functional in the prerendered build. The dropdown leaves room for future entries (e.g. "Open in ChatGPT/Claude" deep links) as noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6LgqUAorY2iNsEPUKDxjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6LgqUAorY2iNsEPUKDxjg)_