### PR TITLE
fix(vite-plugin-angular): fix the Angular Compilation API dev path

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -1544,7 +1544,7 @@ export function angular(options?: PluginOptions): Plugin[] {
     routerPlugin(),
     angularFullVersion < 190004 && pendingTasksPlugin(),
     nxFolderPlugin(),
-    encapsulationPlugin(shouldExternalizeStyles),
+    encapsulationPlugin(),
   ].filter(Boolean) as Plugin[];
 
   function resolveTsConfigPath() {

--- a/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.spec.ts
@@ -435,4 +435,67 @@ describe('compilationAPIPlugin', () => {
     expect(result).toBeDefined();
     expect(result.code).toBe('compiled output');
   });
+
+  it('serves emitted output for TypeScript files without Angular decorators', async () => {
+    const configFile = join(tempRoot, 'src/app.config.ts');
+    createAngularCompilationMock.mockResolvedValue({
+      initialize: vi.fn().mockResolvedValue({
+        externalStylesheets: new Map(),
+        templateUpdates: new Map(),
+      }),
+      update: vi.fn(),
+      diagnoseFiles: vi.fn().mockResolvedValue({ errors: [], warnings: [] }),
+      emitAffectedFiles: vi
+        .fn()
+        .mockResolvedValue([
+          { filename: configFile, contents: 'export const appConfig = {};' },
+        ]),
+    });
+
+    const { compilationAPIPlugin } =
+      await import('./compilation-api-plugin.js');
+    const plugin = compilationAPIPlugin({
+      tsconfigGetter: () => join(tempRoot, 'tsconfig.json'),
+      workspaceRoot: tempRoot,
+      inlineStylesExtension: 'css',
+      jit: false,
+      liveReload: true,
+      disableTypeChecking: true,
+      supportedBrowsers: ['safari 15'],
+      fileReplacements: [],
+      hasTailwindCss: false,
+      isTest: false,
+      isAstroIntegration: false,
+      include: [],
+      additionalContentDirs: [],
+    });
+
+    await (plugin.config as any)(
+      { root: tempRoot, mode: 'development' },
+      { command: 'serve', mode: 'development' },
+    );
+    await (plugin.configResolved as any)({
+      cacheDir: join(tempRoot, '.vite'),
+      root: tempRoot,
+      mode: 'development',
+      build: {},
+      server: { hmr: true },
+      plugins: [],
+    });
+    await (plugin.buildStart as any).call({
+      addWatchFile: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    });
+
+    const warn = vi.fn();
+    const result = await (plugin.transform as any).handler.call(
+      { warn, error: vi.fn() },
+      `import type { ApplicationConfig } from '@angular/core';\nexport const appConfig: ApplicationConfig = {};`,
+      configFile,
+    );
+
+    expect(result.code).toBe('export const appConfig = {};');
+    expect(warn).not.toHaveBeenCalled();
+  });
 });

--- a/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
@@ -812,15 +812,12 @@ export function compilationAPIPlugin(
           return;
         }
 
-        // Skip non-Angular files — in compilation API mode, Angular
-        // compiles TypeScript before this hook, so only Angular files
-        // need processing.
+        // Angular emits every file in the program, not only files with
+        // Angular decorators, and `@analogjs/platform` excludes `.ts` from
+        // Vite's own transform. So serve Angular's output for any emitted
+        // file; only the "not emitted" warning below is decorator-specific.
         const isAngular =
           /(Component|Directive|Pipe|Injectable|NgModule)\(/.test(code);
-        if (!isAngular) {
-          debugCompilationApi('transform skip (non-Angular file)', { id });
-          return;
-        }
 
         if (id.includes('?') && id.includes('analog-content-')) {
           return;

--- a/packages/vite-plugin-angular/src/lib/encapsulation-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/encapsulation-plugin.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { encapsulationPlugin } from './encapsulation-plugin.js';
+
+const transform = (code: string, id: string) =>
+  (encapsulationPlugin().transform as any)(code, id) as
+    | { code: string }
+    | undefined;
+
+describe('encapsulationPlugin', () => {
+  it('rewrites :host for emulated component stylesheet requests', () => {
+    const result = transform(
+      ':host { display: block; }',
+      '/abc123.css?direct&ngcomp=ng-c1&e=0',
+    );
+
+    expect(result?.code).toContain('[_nghost-ng-c1]');
+    expect(result?.code).not.toContain(':host');
+  });
+
+  it('leaves requests without a component id untouched', () => {
+    expect(transform(':host { display: block; }', '/abc123.css')).toBe(
+      undefined,
+    );
+    expect(
+      transform(':host { display: block; }', '/abc123.css?ngcomp=ng-c1&e=2'),
+    ).toBe(undefined);
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/encapsulation-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/encapsulation-plugin.ts
@@ -29,15 +29,18 @@ export function getComponentStyleSheetMeta(id: string): {
  * (enforce: 'pre') fully resolves @apply directives — including those
  * inside :host {} — before Angular's ShadowCss rewrites selectors.
  * (#2293)
+ *
+ * The `ngcomp=` query only appears on requests Angular's runtime makes for
+ * externalized component styles, so it is the only gate needed. This plugin
+ * is shared by the ngtsc and Angular Compilation API paths and must not
+ * depend on either path's private state.
  */
-export function encapsulationPlugin(
-  shouldExternalizeStyles: () => boolean,
-): Plugin {
+export function encapsulationPlugin(): Plugin {
   return {
     name: '@analogjs/vite-plugin-angular:encapsulation',
     enforce: 'post',
     transform(code: string, id: string) {
-      if (shouldExternalizeStyles() && isComponentStyleSheet(id)) {
+      if (isComponentStyleSheet(id)) {
         const { encapsulation, componentId } = getComponentStyleSheetMeta(id);
         if (encapsulation === 'emulated' && componentId) {
           debugStylesV('applying emulated view encapsulation (post)', {


### PR DESCRIPTION
## PR Checklist

`useAngularCompilationAPI: true` was unusable with `analog()` in dev on `alpha`. Found while validating the `analog.setup()` interop model from [RFC: Nitro-style Vite plugin interop hooks analogjs/analog#2254](https://github.com/analogjs/analog/issues/2254) against `apps/tailwind-debug-app`, whose committed config uses the Compilation API path. Related: [@apply inside :host fails with tailwindCss prefix analogjs/analog#2293](https://github.com/analogjs/analog/issues/2293), which the debug app exists to reproduce.

Closes #

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

Not needed; single commit.

## What is the new behavior?

Two defects, the second only visible once the first was fixed:

1. **Raw TypeScript reached the browser.** `@analogjs/platform`'s deps plugin excludes `**/*.ts` from Vite's own transform so the Angular plugin owns compilation, but the Compilation API transform returned nothing for files without an Angular decorator. Files such as `app.config.ts` and the generated route tree were served untranspiled and the page died on `import type`. Angular already emits every file in the program, so the transform now returns that output for any emitted file. The "not in the TypeScript program" warning stays decorator-specific.

2. **`:host` styles vanished.** `encapsulationPlugin` is registered once by the `angular()` factory and was gated on the ngtsc plugin's `shouldExternalizeStyles()`. That closure reads a `watchMode` variable assigned only in the ngtsc `config` hook, which never runs in Compilation API mode, so the predicate was always false and `:host` was never rewritten to `[_nghost-...]`. Fetching the component stylesheet with `Accept: text/css` on that path returned raw `:host { ... }`. The `ngcomp=` query only exists on requests Angular's runtime makes for externalized component styles, so it is now the only gate and the plugin no longer depends on either compilation path's private state.

## Test plan

- [x] `nx format:check` on changed files
- [x] `nx build vite-plugin-angular`
- [x] `vitest run` for `vite-plugin-angular`: 865 passed, 6 skipped, 3 new tests (`compilation-api-plugin.spec.ts`, new `encapsulation-plugin.spec.ts`)
- [x] Manual verification: `apps/tailwind-debug-app-e2e` `host-apply.spec.ts` against the dev server on the app's committed config (Compilation API on, live reload on, PostCSS and route-tree import intact). Before: parse error overlay, then after fix 1 the `:host` background assertion failed. After: 2 passed. Also 2 passed with live reload off and Tailwind provided through an `analog.setup()` plugin instead of the `tailwindCss` option.

`tsc --noEmit` for the package reports the same 23 pre-existing errors as `alpha`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`encapsulationPlugin()` drops its predicate parameter; it is internal to the package.

## Other information

The factory-level `liveReloadPlugin` in `angular()` is registered with the ngtsc plugin's `classNames` and `fileEmitter` maps, which stay empty in Compilation API mode. It is inert there rather than broken, so this PR leaves it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAcJKwrVLs2yyyy4Scnmv9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAcJKwrVLs2yyyy4Scnmv9)_