### PR TITLE
fix(vite-plugin-angular): preserve source maps across TypeScript transforms

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, it, expect } from 'vitest';
 import type { Plugin, UserConfig } from 'vite';
-import { buildOptimizerPlugin } from './angular-build-optimizer-plugin';
+import {
+  buildOptimizerPlugin,
+  extractInlineSourceMap,
+} from './angular-build-optimizer-plugin';
 
 function createPlugin(): Plugin {
   return buildOptimizerPlugin({
@@ -226,5 +229,94 @@ describe('buildOptimizerPlugin vendor sourcemaps', () => {
 
     expect(result?.map).toBeNull();
     expect(result?.code).toBe(sourceWithMapUrl);
+  });
+});
+
+describe('extractInlineSourceMap', () => {
+  it('extracts base64 encoded sourcemap and removes sourceMappingURL comment', () => {
+    const mapObj = {
+      version: 3,
+      file: 'test.js',
+      sourceRoot: '',
+      sources: ['test.ts', 'utils.ts'],
+      sourcesContent: [
+        `import { formatGreeting } from './utils';
+
+export class Greeter {
+  private prefix = 'Hello';
+
+  constructor(public suffix: string = '!') {}
+
+  greet(name: string): string {
+    const greeting = formatGreeting(this.prefix, name, this.suffix);
+    console.log(greeting);
+    return greeting;
+  }
+}
+`,
+        `export function formatGreeting(prefix: string, name: string, suffix: string): string {
+  return \`\${prefix}, \${name}\${suffix}\`;
+}
+`,
+      ],
+      names: [
+        'Greeter',
+        'prefix',
+        'suffix',
+        'greet',
+        'name',
+        'greeting',
+        'formatGreeting',
+        'console',
+        'log',
+      ],
+      mappings:
+        'AAAA,OAAO,EAAE,cAAc,EAAE,MAAM,SAAS,CAAC;AAEzC,OAAM,MAAO,OAAO;IAClB,OAAA,MAAe,GAAA,KAAO,CAAC;IAEvB,YAAA,OAAA,MAAc,GAAA,GAAG,CAAA,CAAE;IAEnB,KAAK,CAAC,IAAY;QAChB,MAAM,QAAQ,GAAG,cAAc,CAAC,IAAI,CAAC,MAAM,EAAE,IAAI,EAAE,IAAI,CAAC,MAAM,CAAC,CAAC;QAChE,OAAO,CAAC,GAAG,CAAC,QAAQ,CAAC,CAAC;QACtB,OAAO,QAAQ,CAAC;IAClB,CAAC;CACF',
+      ignoreList: [],
+    };
+    const base64Map = Buffer.from(JSON.stringify(mapObj)).toString('base64');
+    const sourceCode = `import { formatGreeting } from './utils';
+export class Greeter {
+  constructor(suffix = '!') {
+    this.suffix = suffix;
+    this.prefix = 'Hello';
+  }
+  greet(name) {
+    const greeting = formatGreeting(this.prefix, name, this.suffix);
+    console.log(greeting);
+    return greeting;
+  }
+}`;
+    const code = `${sourceCode}\n//# sourceMappingURL=data:application/json;base64,${base64Map}`;
+
+    const result = extractInlineSourceMap(code, '/x/test.js');
+
+    expect(result.code).toBe(sourceCode);
+    expect(JSON.parse(result.map)).toEqual(mapObj);
+  });
+
+  it('supports charset parameter in data URI', () => {
+    const mapObj = {
+      version: 3,
+      file: 'test.js',
+      sources: ['test.ts'],
+      sourcesContent: ['export const message = "hello world";\n'],
+      names: ['message'],
+      mappings: 'AAAA,OAAO,MAAMA,OAAO,GAAG,aAAa,CAAC',
+    };
+    const base64Map = Buffer.from(JSON.stringify(mapObj)).toString('base64');
+    const sourceCode = 'export const message = "hello world";';
+    const code = `${sourceCode}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Map}`;
+
+    const result = extractInlineSourceMap(code, '/x/test.js');
+
+    expect(result.code).toBe(sourceCode);
+    expect(JSON.parse(result.map)).toEqual(mapObj);
+  });
+
+  it('throws an error if no inline sourcemap is present', () => {
+    expect(() =>
+      extractInlineSourceMap('console.log("test");', '/x/test.js'),
+    ).toThrow('Angular optimizer did not generate a source map for /x/test.js');
   });
 });

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
@@ -73,6 +73,16 @@ describe('buildOptimizerPlugin config()', () => {
     );
   });
 
+  it('does not re-enable Vite TypeScript transforms', () => {
+    const plugin = createPlugin();
+    const config = (
+      plugin as Plugin & { config: (c: UserConfig) => UserConfig }
+    ).config({ mode: 'production' });
+
+    expect(config).not.toHaveProperty('oxc');
+    expect(config).not.toHaveProperty('esbuild');
+  });
+
   it('should set ngServerMode to true for production SSR builds', () => {
     const plugin = createPlugin();
     const config = (

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
@@ -314,9 +314,11 @@ export class Greeter {
     expect(JSON.parse(result.map)).toEqual(mapObj);
   });
 
-  it('throws an error if no inline sourcemap is present', () => {
-    expect(() =>
-      extractInlineSourceMap('console.log("test");', '/x/test.js'),
-    ).toThrow('Angular optimizer did not generate a source map for /x/test.js');
+  it('returns null map if no inline sourcemap is present', () => {
+    const result = extractInlineSourceMap('console.log("test");', '/x/test.js');
+    expect(result).toEqual({
+      code: 'console.log("test");',
+      map: null,
+    });
   });
 });

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.spec.ts
@@ -322,3 +322,50 @@ export class Greeter {
     });
   });
 });
+
+describe('buildOptimizerPlugin lifecycle & environment handling', () => {
+  it('closes transformer on closeBundle in non-watch mode', async () => {
+    const plugin = createPlugin();
+    plugin.configResolved?.({
+      command: 'build',
+      build: { sourcemap: false },
+    } as any);
+    const ctx = { environment: { name: 'client' } };
+
+    await (plugin.transform as any).handler.call(
+      ctx,
+      'console.log("hello");',
+      '/x/test.js',
+    );
+
+    await expect((plugin as any).closeBundle.call(ctx)).resolves.not.toThrow();
+  });
+
+  it('maintains isolated transformers across client and ssr environments', async () => {
+    const plugin = createPlugin();
+    plugin.configResolved?.({
+      command: 'build',
+      build: { sourcemap: false },
+    } as any);
+    const clientCtx = { environment: { name: 'client' } };
+    const ssrCtx = { environment: { name: 'ssr' } };
+
+    await (plugin.transform as any).handler.call(
+      clientCtx,
+      'console.log("client");',
+      '/x/test.js',
+    );
+    await (plugin.transform as any).handler.call(
+      ssrCtx,
+      'console.log("ssr");',
+      '/x/test.js',
+    );
+
+    await expect(
+      (plugin as any).closeBundle.call(clientCtx),
+    ).resolves.not.toThrow();
+    await expect(
+      (plugin as any).closeBundle.call(ssrCtx),
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -106,9 +106,10 @@ export function extractInlineSourceMap(code: string, id: string) {
     /\n?\/\/# sourceMappingURL=data:application\/json(?:;charset=[^;,]+)?;base64,([A-Za-z0-9+/=]+)\s*$/,
   );
   if (!sourceMapMatch || sourceMapMatch.index === undefined) {
-    throw new Error(
-      `Angular optimizer did not generate a source map for ${id}`,
-    );
+    return {
+      code,
+      map: null,
+    };
   }
   return {
     code: code.slice(0, sourceMapMatch.index),

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -8,9 +8,30 @@ export function buildOptimizerPlugin({
   supportedBrowsers: string[];
   jit: boolean;
 }): Plugin {
-  let javascriptTransformer: InstanceType<typeof JavaScriptTransformer>;
+  const transformers = new Map<
+    string,
+    InstanceType<typeof JavaScriptTransformer>
+  >();
   let isProd = false;
+  let isWatch = false;
   let preserveVendorMaps = false;
+
+  function getTransformer(envName = 'default') {
+    let transformer = transformers.get(envName);
+    if (!transformer) {
+      transformer = new JavaScriptTransformer(
+        {
+          sourcemap: preserveVendorMaps,
+          thirdPartySourcemaps: preserveVendorMaps,
+          advancedOptimizations: isProd,
+          jit: true,
+        },
+        1,
+      );
+      transformers.set(envName, transformer);
+    }
+    return transformer;
+  }
 
   return {
     name: '@analogjs/vite-plugin-angular-optimizer',
@@ -44,15 +65,7 @@ export function buildOptimizerPlugin({
     },
     configResolved(config) {
       preserveVendorMaps = !!config.build.sourcemap;
-      javascriptTransformer = new JavaScriptTransformer(
-        {
-          sourcemap: preserveVendorMaps,
-          thirdPartySourcemaps: preserveVendorMaps,
-          advancedOptimizations: isProd,
-          jit: true,
-        },
-        1,
-      );
+      isWatch = config.command === 'serve' || !!config.build?.watch;
     },
     transform: {
       filter: {
@@ -85,7 +98,9 @@ export function buildOptimizerPlugin({
 
         const sideEffects =
           jit && cleanId.includes('@angular/compiler') ? true : false;
-        const result: Uint8Array = await javascriptTransformer.transformData(
+        const envName = this.environment?.name ?? 'default';
+        const transformer = getTransformer(envName);
+        const result: Uint8Array = await transformer.transformData(
           cleanId,
           code,
           false,
@@ -97,6 +112,17 @@ export function buildOptimizerPlugin({
           ? extractInlineSourceMap(transformed, cleanId)
           : { code: transformed, map: { mappings: '' } };
       },
+    },
+    async closeBundle() {
+      if (isWatch) {
+        return;
+      }
+      const envName = this.environment?.name ?? 'default';
+      const transformer = transformers.get(envName);
+      if (transformer) {
+        transformers.delete(envName);
+        await transformer.close();
+      }
     },
   };
 }

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -1,5 +1,4 @@
 import type { Plugin, UserConfig } from 'vite';
-import * as vite from 'vite';
 import { JavaScriptTransformer } from './utils/devkit.js';
 import { isProdMode } from './utils/plugin-config.js';
 
@@ -51,16 +50,6 @@ export function buildOptimizerPlugin({
               ngServerMode: `${!!userConfig.build?.ssr}`,
             }
           : {},
-        [vite.rolldownVersion ? 'oxc' : 'esbuild']: {
-          define: isProd
-            ? {
-                ngDevMode: 'false',
-                ngJitMode: 'false',
-                ngI18nClosureMode: 'false',
-                ngServerMode: `${!!userConfig.build?.ssr}`,
-              }
-            : undefined,
-        },
       } as UserConfig;
     },
     configResolved(config) {

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -98,6 +98,10 @@ export function buildOptimizerPlugin({
           : { code: transformed, map: { mappings: '' } };
       },
     },
+    async closeBundle() {
+      await javascriptTransformer?.close?.();
+      javascriptTransformer = undefined;
+    },
   };
 }
 

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -31,16 +31,6 @@ export function buildOptimizerPlugin({
       isProd = isProdMode(userConfig.mode);
       // Advanced optimizations paired with dev-mode defines would strip
       // dev-only code the debug API needs, so both key off `isProd`.
-      javascriptTransformer ??= new JavaScriptTransformer(
-        {
-          sourcemap: false,
-          thirdPartySourcemaps: false,
-          advancedOptimizations: isProd,
-          jit: true,
-        },
-        1,
-      );
-
       return {
         define: isProd
           ? {
@@ -54,6 +44,15 @@ export function buildOptimizerPlugin({
     },
     configResolved(config) {
       preserveVendorMaps = !!config.build.sourcemap;
+      javascriptTransformer = new JavaScriptTransformer(
+        {
+          sourcemap: preserveVendorMaps,
+          thirdPartySourcemaps: preserveVendorMaps,
+          advancedOptimizations: isProd,
+          jit: true,
+        },
+        1,
+      );
     },
     transform: {
       filter: {
@@ -93,10 +92,26 @@ export function buildOptimizerPlugin({
           sideEffects,
         );
 
-        return {
-          code: Buffer.from(result).toString(),
-        };
+        const transformed = Buffer.from(result).toString();
+        return preserveVendorMaps
+          ? extractInlineSourceMap(transformed, cleanId)
+          : { code: transformed, map: { mappings: '' } };
       },
     },
+  };
+}
+
+export function extractInlineSourceMap(code: string, id: string) {
+  const sourceMapMatch = code.match(
+    /\n?\/\/# sourceMappingURL=data:application\/json(?:;charset=[^;,]+)?;base64,([A-Za-z0-9+/=]+)\s*$/,
+  );
+  if (!sourceMapMatch || sourceMapMatch.index === undefined) {
+    throw new Error(
+      `Angular optimizer did not generate a source map for ${id}`,
+    );
+  }
+  return {
+    code: code.slice(0, sourceMapMatch.index),
+    map: Buffer.from(sourceMapMatch[1]!, 'base64').toString(),
   };
 }

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -98,10 +98,6 @@ export function buildOptimizerPlugin({
           : { code: transformed, map: { mappings: '' } };
       },
     },
-    async closeBundle() {
-      await javascriptTransformer?.close?.();
-      javascriptTransformer = undefined;
-    },
   };
 }
 

--- a/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-jit-plugin.ts
@@ -3,6 +3,7 @@ import {
   JIT_INLINE_STYLE_PREFIX,
   getJitInlineStyles,
 } from './utils/jit-inline-styles.js';
+import { releaseCssPreprocessorWorkers } from './utils/css-preprocessor-workers.js';
 
 export function jitPlugin({
   inlineStylesExtension,
@@ -54,6 +55,11 @@ export function jitPlugin({
       }
 
       return;
+    },
+    closeBundle() {
+      if (!this.meta?.watchMode) {
+        releaseCssPreprocessorWorkers();
+      }
     },
   };
 }

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1203,6 +1203,57 @@ export class AppComponent {}
     expect(sources).toContain(normalizePath(templatePath));
   }, 60_000);
 
+  it('releases production compilation output at buildEnd', async () => {
+    const mainPlugin = createAppBuildPlugin();
+
+    await mainPlugin.config(
+      { root: fixtureDir, build: {} },
+      { command: 'build' },
+    );
+    const resolvedConfig = {
+      root: fixtureDir,
+      mode: 'production',
+      build: {},
+      server: { watch: {} },
+      safeModulePaths: new Set(),
+    };
+    mainPlugin.configResolved(resolvedConfig);
+    const environmentConfig = {
+      ...resolvedConfig,
+      plugins: [
+        {
+          name: 'vite:css',
+          transform: {
+            handler: vi.fn(async (code: string) => ({ code })),
+          },
+        },
+      ],
+    };
+    const ctx = {
+      environment: { config: environmentConfig },
+      warn: vi.fn(),
+      error: vi.fn(),
+      addWatchFile: vi.fn(),
+    };
+    const code = realFs.readFileSync(componentPath, 'utf-8');
+
+    await mainPlugin.buildStart.call(ctx);
+    const compiled = await mainPlugin.transform.handler.call(
+      ctx,
+      code,
+      componentPath,
+    );
+    await mainPlugin.buildEnd.call(ctx);
+    const released = await mainPlugin.transform.handler.call(
+      ctx,
+      code,
+      componentPath,
+    );
+
+    expect(compiled?.code).toContain('ɵcmp');
+    expect(released).toBeUndefined();
+  }, 60_000);
+
   it('handles environment without vite:css or missing this.environment gracefully', async () => {
     const mainPlugin = createAppBuildPlugin();
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -3,15 +3,7 @@ import * as realFs from 'node:fs';
 import { SourceMap } from 'node:module';
 import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
-import { normalizePath, preprocessCSS } from 'vite';
-
-vi.mock('vite', async () => {
-  const actual = await vi.importActual<typeof import('vite')>('vite');
-  return {
-    ...actual,
-    preprocessCSS: vi.fn(async (code: string) => ({ code, deps: new Set() })),
-  };
-});
+import { normalizePath } from 'vite';
 
 import type ts from 'typescript';
 import * as tsModule from 'typescript';
@@ -1020,6 +1012,9 @@ describe('buildStart initial compilation', () => {
   const templatePath = normalizePath(
     path.join(fixtureDir, 'src', 'app.component.html'),
   );
+  const stylePath = normalizePath(
+    path.join(fixtureDir, 'src', 'app.component.scss'),
+  );
 
   beforeEach(() => {
     realFs.rmSync(fixtureDir, { recursive: true, force: true });
@@ -1047,12 +1042,18 @@ describe('buildStart initial compilation', () => {
   selector: 'app-root',
   standalone: true,
   templateUrl: './app.component.html',
+  styleUrl: './app.component.scss',
 })
 export class AppComponent {}
 `,
       'utf-8',
     );
     realFs.writeFileSync(templatePath, '<h1>hello</h1>', 'utf-8');
+    realFs.writeFileSync(
+      stylePath,
+      '$color: red; h1 { color: $color; }',
+      'utf-8',
+    );
   });
 
   afterEach(() => {
@@ -1086,15 +1087,31 @@ export class AppComponent {}
       { root: fixtureDir, build: {} },
       { command: 'build' },
     );
-    mainPlugin.configResolved({
+    const resolvedConfig = {
       root: fixtureDir,
       mode: 'production',
       build: {},
       server: { watch: {} },
       safeModulePaths: new Set(),
-    });
+    };
+    mainPlugin.configResolved(resolvedConfig);
+    const cssTransform = vi.fn(async (code: string) => ({ code }));
+    const environmentConfig = {
+      ...resolvedConfig,
+      plugins: [
+        {
+          name: 'vite:css',
+          transform: { handler: cssTransform },
+        },
+      ],
+    };
 
-    const ctx = { warn: vi.fn(), error: vi.fn(), addWatchFile: vi.fn() };
+    const ctx = {
+      environment: { config: environmentConfig },
+      warn: vi.fn(),
+      error: vi.fn(),
+      addWatchFile: vi.fn(),
+    };
     const code = realFs.readFileSync(componentPath, 'utf-8');
 
     // Deliberately don't await `buildStart` — this is the racing plugin's view.
@@ -1107,25 +1124,58 @@ export class AppComponent {}
     await buildStart;
 
     expect(result?.code).toContain('ɵcmp');
+    expect(cssTransform).toHaveBeenCalledWith(
+      expect.any(String),
+      `${stylePath}?direct`,
+    );
+    expect(cssTransform.mock.contexts[0]).toBe(ctx);
     expect(ctx.warn).not.toHaveBeenCalled();
   }, 60_000);
 
   it('emits sourcemaps for production builds when build.sourcemap is enabled', async () => {
     const mainPlugin = createAppBuildPlugin();
+    realFs.writeFileSync(
+      componentPath,
+      `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  templateUrl: './app.component.html',
+})
+export class AppComponent {}
+`,
+      'utf-8',
+    );
 
     await mainPlugin.config(
       { root: fixtureDir, build: { sourcemap: true } },
       { command: 'build' },
     );
-    mainPlugin.configResolved({
+    const resolvedConfig = {
       root: fixtureDir,
       mode: 'production',
       build: { sourcemap: true },
       server: { watch: {} },
       safeModulePaths: new Set(),
-    });
+    };
+    mainPlugin.configResolved(resolvedConfig);
+    const environmentConfig = {
+      ...resolvedConfig,
+      plugins: [
+        {
+          name: 'vite:css',
+          transform: { handler: vi.fn(async (code: string) => ({ code })) },
+        },
+      ],
+    };
 
-    const ctx = { warn: vi.fn(), error: vi.fn(), addWatchFile: vi.fn() };
+    const ctx = {
+      environment: { config: environmentConfig },
+      warn: vi.fn(),
+      error: vi.fn(),
+      addWatchFile: vi.fn(),
+    };
     const code = realFs.readFileSync(componentPath, 'utf-8');
 
     await mainPlugin.buildStart.call(ctx);

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1202,4 +1202,39 @@ export class AppComponent {}
     expect(entry.originalColumn).toBe(13);
     expect(sources).toContain(normalizePath(templatePath));
   }, 60_000);
+
+  it('handles environment without vite:css or missing this.environment gracefully', async () => {
+    const mainPlugin = createAppBuildPlugin();
+
+    await mainPlugin.config(
+      { root: fixtureDir, build: {} },
+      { command: 'build' },
+    );
+    const resolvedConfig = {
+      root: fixtureDir,
+      mode: 'production',
+      build: {},
+      server: { watch: {} },
+      safeModulePaths: new Set(),
+      plugins: [],
+    };
+    mainPlugin.configResolved(resolvedConfig);
+
+    // Context without this.environment (e.g. older Vite or minimal test harness)
+    const ctx = {
+      warn: vi.fn(),
+      error: vi.fn(),
+      addWatchFile: vi.fn(),
+    };
+    const code = realFs.readFileSync(componentPath, 'utf-8');
+
+    await mainPlugin.buildStart.call(ctx);
+    const result = await mainPlugin.transform.handler.call(
+      ctx,
+      code,
+      componentPath,
+    );
+
+    expect(result?.code).toContain('ɵcmp');
+  }, 60_000);
 });

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import * as realFs from 'node:fs';
+import { SourceMap } from 'node:module';
 import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { normalizePath, preprocessCSS } from 'vite';
@@ -1016,6 +1017,9 @@ describe('buildStart initial compilation', () => {
   const componentPath = normalizePath(
     path.join(fixtureDir, 'src', 'app.component.ts'),
   );
+  const templatePath = normalizePath(
+    path.join(fixtureDir, 'src', 'app.component.html'),
+  );
 
   beforeEach(() => {
     realFs.rmSync(fixtureDir, { recursive: true, force: true });
@@ -1042,12 +1046,13 @@ describe('buildStart initial compilation', () => {
 @Component({
   selector: 'app-root',
   standalone: true,
-  template: '<h1>hello</h1>',
+  templateUrl: './app.component.html',
 })
 export class AppComponent {}
 `,
       'utf-8',
     );
+    realFs.writeFileSync(templatePath, '<h1>hello</h1>', 'utf-8');
   });
 
   afterEach(() => {
@@ -1103,5 +1108,48 @@ export class AppComponent {}
 
     expect(result?.code).toContain('ɵcmp');
     expect(ctx.warn).not.toHaveBeenCalled();
+  }, 60_000);
+
+  it('emits sourcemaps for production builds when build.sourcemap is enabled', async () => {
+    const mainPlugin = createAppBuildPlugin();
+
+    await mainPlugin.config(
+      { root: fixtureDir, build: { sourcemap: true } },
+      { command: 'build' },
+    );
+    mainPlugin.configResolved({
+      root: fixtureDir,
+      mode: 'production',
+      build: { sourcemap: true },
+      server: { watch: {} },
+      safeModulePaths: new Set(),
+    });
+
+    const ctx = { warn: vi.fn(), error: vi.fn(), addWatchFile: vi.fn() };
+    const code = realFs.readFileSync(componentPath, 'utf-8');
+
+    await mainPlugin.buildStart.call(ctx);
+    const result = await mainPlugin.transform.handler.call(
+      ctx,
+      code,
+      componentPath,
+    );
+
+    expect(result?.code).toContain('ɵcmp');
+    const generatedOffset = result.code.indexOf('AppComponent');
+    const generatedBeforeTarget = result.code.slice(0, generatedOffset);
+    const generatedLine = generatedBeforeTarget.split('\n').length - 1;
+    const generatedColumn =
+      generatedOffset - generatedBeforeTarget.lastIndexOf('\n') - 1;
+    const entry = new SourceMap(JSON.parse(result.map)).findEntry(
+      generatedLine,
+      generatedColumn,
+    );
+    const sources = JSON.parse(result.map).sources as string[];
+
+    expect(entry.originalSource).toBe(normalizePath(componentPath));
+    expect(entry.originalLine).toBe(7);
+    expect(entry.originalColumn).toBe(13);
+    expect(sources).toContain(normalizePath(templatePath));
   }, 60_000);
 });

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1093,21 +1093,12 @@ export class AppComponent {}
       build: {},
       server: { watch: {} },
       safeModulePaths: new Set(),
+      css: {},
     };
     mainPlugin.configResolved(resolvedConfig);
-    const cssTransform = vi.fn(async (code: string) => ({ code }));
-    const environmentConfig = {
-      ...resolvedConfig,
-      plugins: [
-        {
-          name: 'vite:css',
-          transform: { handler: cssTransform },
-        },
-      ],
-    };
 
     const ctx = {
-      environment: { config: environmentConfig },
+      environment: { config: resolvedConfig },
       warn: vi.fn(),
       error: vi.fn(),
       addWatchFile: vi.fn(),
@@ -1124,11 +1115,6 @@ export class AppComponent {}
     await buildStart;
 
     expect(result?.code).toContain('ɵcmp');
-    expect(cssTransform).toHaveBeenCalledWith(
-      expect.any(String),
-      `${stylePath}?direct`,
-    );
-    expect(cssTransform.mock.contexts[0]).toBe(ctx);
     expect(ctx.warn).not.toHaveBeenCalled();
   }, 60_000);
 
@@ -1158,20 +1144,12 @@ export class AppComponent {}
       build: { sourcemap: true },
       server: { watch: {} },
       safeModulePaths: new Set(),
+      css: {},
     };
     mainPlugin.configResolved(resolvedConfig);
-    const environmentConfig = {
-      ...resolvedConfig,
-      plugins: [
-        {
-          name: 'vite:css',
-          transform: { handler: vi.fn(async (code: string) => ({ code })) },
-        },
-      ],
-    };
 
     const ctx = {
-      environment: { config: environmentConfig },
+      environment: { config: resolvedConfig },
       warn: vi.fn(),
       error: vi.fn(),
       addWatchFile: vi.fn(),
@@ -1216,21 +1194,11 @@ export class AppComponent {}
       build: {},
       server: { watch: {} },
       safeModulePaths: new Set(),
+      css: {},
     };
     mainPlugin.configResolved(resolvedConfig);
-    const environmentConfig = {
-      ...resolvedConfig,
-      plugins: [
-        {
-          name: 'vite:css',
-          transform: {
-            handler: vi.fn(async (code: string) => ({ code })),
-          },
-        },
-      ],
-    };
     const ctx = {
-      environment: { config: environmentConfig },
+      environment: { config: resolvedConfig },
       warn: vi.fn(),
       error: vi.fn(),
       addWatchFile: vi.fn(),
@@ -1254,7 +1222,7 @@ export class AppComponent {}
     expect(released).toBeUndefined();
   }, 60_000);
 
-  it('handles environment without vite:css or missing this.environment gracefully', async () => {
+  it('handles missing this.environment gracefully', async () => {
     const mainPlugin = createAppBuildPlugin();
 
     await mainPlugin.config(
@@ -1267,6 +1235,7 @@ export class AppComponent {}
       build: {},
       server: { watch: {} },
       safeModulePaths: new Set(),
+      css: {},
       plugins: [],
     };
     mainPlugin.configResolved(resolvedConfig);

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -254,10 +254,9 @@ export function angular(options?: PluginOptions): Plugin[] {
   let liveReloadProgramHasExternalStyles = false;
   const declarationFiles: DeclarationFile[] = [];
   const fileTransformMap = new Map<string, string>();
-  let styleTransform: (
-    code: string,
-    filename: string,
-  ) => Promise<vite.PreprocessCSSResult>;
+  let styleTransform:
+    | ((code: string, filename: string) => Promise<vite.PreprocessCSSResult>)
+    | undefined;
   let pendingCompilation: Promise<void> | null;
   let compilationLock = Promise.resolve();
   // Persistent Angular Compilation API instance. Kept alive across rebuilds so
@@ -267,6 +266,16 @@ export function angular(options?: PluginOptions): Plugin[] {
   let angularCompilation:
     | Awaited<ReturnType<typeof createAngularCompilationType>>
     | undefined;
+
+  function getStyleTransform() {
+    return (
+      styleTransform ??
+      (async (code: string) => ({
+        code,
+        deps: new Set<string>(),
+      }))
+    );
+  }
 
   function angularPlugin(): Plugin {
     let isProd = false;
@@ -381,7 +390,8 @@ export function angular(options?: PluginOptions): Plugin[] {
       async buildStart() {
         if (!jit) {
           const pluginContext = this;
-          const cssTransformHook = this.environment.config.plugins.find(
+          const environmentConfig = this.environment?.config ?? resolvedConfig;
+          const cssTransformHook = environmentConfig.plugins?.find(
             (plugin) => plugin.name === 'vite:css',
           )?.transform;
           const cssTransform = (
@@ -406,24 +416,22 @@ export function angular(options?: PluginOptions): Plugin[] {
                   >)
             | undefined;
 
-          if (!cssTransform) {
-            throw new Error('Unable to locate the Vite CSS transform hook');
-          }
+          if (cssTransform) {
+            styleTransform = async (code: string, filename: string) => {
+              const result = await cssTransform.call(
+                pluginContext,
+                code,
+                filename,
+              );
 
-          styleTransform = async (code: string, filename: string) => {
-            const result = await cssTransform.call(
-              pluginContext,
-              code,
-              filename,
-            );
-
-            return {
-              code:
-                typeof result === 'string' ? result : (result?.code ?? code),
-              map: typeof result === 'object' ? result?.map : undefined,
-              deps: new Set<string>(),
+              return {
+                code:
+                  typeof result === 'string' ? result : (result?.code ?? code),
+                map: typeof result === 'object' ? result?.map : undefined,
+                deps: new Set<string>(),
+              };
             };
-          };
+          }
         }
 
         // Defer the first compilation in test mode
@@ -1055,7 +1063,10 @@ export function angular(options?: PluginOptions): Plugin[] {
           let stylesheetResult;
 
           try {
-            stylesheetResult = await styleTransform(data, `${filename}?direct`);
+            stylesheetResult = await getStyleTransform()(
+              data,
+              `${filename}?direct`,
+            );
           } catch (e) {
             console.error(`${e}`);
           }
@@ -1390,7 +1401,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       externalComponentStyles = tsCompilerOptions['externalRuntimeStyles']
         ? new Map()
         : undefined;
-      augmentHostWithResources(host, styleTransform, {
+      augmentHostWithResources(host, getStyleTransform(), {
         inlineStylesExtension: pluginOptions.inlineStylesExtension,
         isProd,
         inlineComponentStyles,

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -370,7 +370,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         const invalidateCompilationOnFsChange = createFsWatcherCacheInvalidator(
           invalidateFsCaches,
           invalidateTsconfigCaches,
-          () => performCompilation(resolvedConfig),
+          () => performCompilation(server.environments.client.config),
           pluginOptions.include.map(
             (glob) =>
               `${normalizePath(resolve(pluginOptions.workspaceRoot))}${glob}`,
@@ -387,7 +387,9 @@ export function angular(options?: PluginOptions): Plugin[] {
       async buildStart() {
         // Defer the first compilation in test mode
         if (!isVitestVscode) {
-          pendingCompilation = performCompilation(resolvedConfig);
+          pendingCompilation = performCompilation(
+            this.environment?.config ?? resolvedConfig,
+          );
           await pendingCompilation;
           pendingCompilation = null;
 
@@ -421,7 +423,10 @@ export function angular(options?: PluginOptions): Plugin[] {
         if (TS_EXT_REGEX.test(ctx.file)) {
           let [fileId] = ctx.file.split('?');
 
-          pendingCompilation = performCompilation(resolvedConfig, [fileId]);
+          pendingCompilation = performCompilation(
+            ctx.server.environments.client.config,
+            [fileId],
+          );
 
           let result;
 
@@ -523,10 +528,10 @@ export function angular(options?: PluginOptions): Plugin[] {
             });
           });
 
-          pendingCompilation = performCompilation(resolvedConfig, [
-            ...mods.map((mod) => mod.id as string),
-            ...updates,
-          ]);
+          pendingCompilation = performCompilation(
+            ctx.server.environments.client.config,
+            [...mods.map((mod) => mod.id as string), ...updates],
+          );
 
           if (updates.length > 0) {
             await pendingCompilation;
@@ -693,7 +698,9 @@ export function angular(options?: PluginOptions): Plugin[] {
           if (isTest) {
             if (isVitestVscode && !initialCompilation) {
               // Do full initial compilation
-              pendingCompilation = performCompilation(resolvedConfig);
+              pendingCompilation = performCompilation(
+                this.environment?.config ?? resolvedConfig,
+              );
               initialCompilation = true;
             }
 
@@ -702,7 +709,10 @@ export function angular(options?: PluginOptions): Plugin[] {
               const invalidated = tsMod.lastInvalidationTimestamp;
 
               if (testWatchMode && invalidated) {
-                pendingCompilation = performCompilation(resolvedConfig, [id]);
+                pendingCompilation = performCompilation(
+                  this.environment?.config ?? resolvedConfig,
+                  [id],
+                );
               }
             }
           }

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -817,7 +817,9 @@ export function angular(options?: PluginOptions): Plugin[] {
 
           return {
             code: data,
-            map: typescriptResult.map ?? null,
+            map: typescriptResult.map
+              ? normalizeSourceMapSources(typescriptResult.map, id)
+              : null,
           };
         },
       },
@@ -834,6 +836,26 @@ export function angular(options?: PluginOptions): Plugin[] {
         angularCompilation = undefined;
       },
     };
+  }
+
+  function normalizeSourceMapSources(map: string, id: string): string {
+    const sourceMap = JSON.parse(map) as {
+      sources?: string[];
+      sourceRoot?: string;
+    };
+    const sourceDirectory = dirname(id);
+    const sourceRoot = sourceMap.sourceRoot ?? '';
+
+    sourceMap.sources = sourceMap.sources?.map((source) => {
+      if (isAbsolute(source) || /^[a-z][a-z\d+.-]*:/i.test(source)) {
+        return normalizePath(source);
+      }
+
+      return normalizePath(resolve(sourceDirectory, sourceRoot, source));
+    });
+    delete sourceMap.sourceRoot;
+
+    return JSON.stringify(sourceMap);
   }
 
   const compilationPlugin = pluginOptions.fastCompile
@@ -1177,6 +1199,9 @@ export function angular(options?: PluginOptions): Plugin[] {
     }
 
     const isProd = config.mode === 'production';
+    // Analog historically forced sourceMap off in production. Honour Vite's
+    // `build.sourcemap` so production builds can emit maps for Sentry / etc.
+    const emitSourceMaps = !isProd || !!config.build.sourcemap;
     const modifiedFiles = new Set<string>(ids ?? []);
     sourceFileCache.invalidate(modifiedFiles);
 
@@ -1197,6 +1222,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       isProd ? 'prod' : 'dev',
       isTest ? 'test' : 'app',
       config.build?.lib ? 'lib' : 'nolib',
+      emitSourceMaps ? 'maps' : 'nomaps',
     ].join('|');
     let cached = tsconfigOptionsCache.get(tsconfigKey);
 
@@ -1204,9 +1230,9 @@ export function angular(options?: PluginOptions): Plugin[] {
       const read = compilerCli.readConfiguration(resolvedTsConfigPath, {
         suppressOutputPathCheck: true,
         outDir: undefined,
-        sourceMap: !isProd,
+        sourceMap: emitSourceMaps,
         inlineSourceMap: false,
-        inlineSources: !isProd,
+        inlineSources: emitSourceMaps,
         // Don't force-override `declaration`/`declarationMap` here — the
         // user's tsconfig value is respected below so that app builds running
         // through Vite's library mode (e.g. WXT entrypoints) can opt out of

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -277,6 +277,29 @@ export function angular(options?: PluginOptions): Plugin[] {
     );
   }
 
+  async function releaseCompilation() {
+    await angularCompilation?.close?.();
+    angularCompilation = undefined;
+    builder = undefined;
+    nextProgram = undefined;
+    cachedHost = undefined;
+    cachedHostKey = undefined;
+    inlineComponentStyles = undefined;
+    externalComponentStyles = undefined;
+    outputFile = undefined;
+    outputFiles.clear();
+    emittedIds.clear();
+    fileTransformMap.clear();
+    sourceFileCache.clear();
+    sourceFileCache.modifiedFiles.clear();
+    sourceFileCache.babelFileCache?.clear();
+    sourceFileCache.typeScriptFileCache?.clear();
+    sourceFileCache.referencedFiles = undefined;
+    tsconfigOptionsCache.clear();
+    includeCache = [];
+    styleTransform = undefined;
+  }
+
   function angularPlugin(): Plugin {
     let isProd = false;
 
@@ -445,7 +468,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           initialCompilation = true;
         }
       },
-      buildEnd() {
+      async buildEnd() {
         // Report diagnostics for production builds. Watch/serve already report
         // per-module from `transform`; build mode defers to here so a single
         // errored file no longer aborts the build before the rest are checked
@@ -458,14 +481,18 @@ export function angular(options?: PluginOptions): Plugin[] {
           return;
         }
 
-        const { errors, warnings } = collectEmittedDiagnostics(outputFiles);
+        try {
+          const { errors, warnings } = collectEmittedDiagnostics(outputFiles);
 
-        if (warnings.length > 0) {
-          this.warn(warnings.join('\n'));
-        }
+          if (warnings.length > 0) {
+            this.warn(warnings.join('\n'));
+          }
 
-        if (errors.length > 0) {
-          this.error(errors.join('\n\n'));
+          if (errors.length > 0) {
+            this.error(errors.join('\n\n'));
+          }
+        } finally {
+          await releaseCompilation();
         }
       },
       async handleHotUpdate(ctx) {
@@ -889,10 +916,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             writeFileSync(declarationPath, data, 'utf-8');
           },
         );
-        // Tear down the persistent compilation instance at end of build so it
-        // does not leak memory across unrelated Vite invocations.
-        angularCompilation?.close?.();
-        angularCompilation = undefined;
+        declarationFiles.length = 0;
       },
     };
   }

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -21,7 +21,6 @@ import {
   ModuleNode,
   normalizePath,
   Plugin,
-  preprocessCSS,
   ResolvedConfig,
   ViteDevServer,
 } from 'vite';
@@ -344,11 +343,6 @@ export function angular(options?: PluginOptions): Plugin[] {
           inlineComponentStyles = new Map();
         }
 
-        if (!jit) {
-          styleTransform = (code: string, filename: string) =>
-            preprocessCSS(code, filename, config);
-        }
-
         if (isTest) {
           // set test watch mode
           // - vite override from vitest-angular
@@ -385,6 +379,53 @@ export function angular(options?: PluginOptions): Plugin[] {
         });
       },
       async buildStart() {
+        if (!jit) {
+          const pluginContext = this;
+          const cssTransformHook = this.environment.config.plugins.find(
+            (plugin) => plugin.name === 'vite:css',
+          )?.transform;
+          const cssTransform = (
+            typeof cssTransformHook === 'function'
+              ? cssTransformHook
+              : cssTransformHook?.handler
+          ) as
+            | ((
+                this: typeof pluginContext,
+                code: string,
+                filename: string,
+              ) =>
+                | string
+                | { code: string; map?: vite.PreprocessCSSResult['map'] }
+                | null
+                | undefined
+                | Promise<
+                    | string
+                    | { code: string; map?: vite.PreprocessCSSResult['map'] }
+                    | null
+                    | undefined
+                  >)
+            | undefined;
+
+          if (!cssTransform) {
+            throw new Error('Unable to locate the Vite CSS transform hook');
+          }
+
+          styleTransform = async (code: string, filename: string) => {
+            const result = await cssTransform.call(
+              pluginContext,
+              code,
+              filename,
+            );
+
+            return {
+              code:
+                typeof result === 'string' ? result : (result?.code ?? code),
+              map: typeof result === 'object' ? result?.map : undefined,
+              deps: new Set<string>(),
+            };
+          };
+        }
+
         // Defer the first compilation in test mode
         if (!isVitestVscode) {
           pendingCompilation = performCompilation(
@@ -1014,11 +1055,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           let stylesheetResult;
 
           try {
-            stylesheetResult = await preprocessCSS(
-              data,
-              `${filename}?direct`,
-              resolvedConfig,
-            );
+            stylesheetResult = await styleTransform(data, `${filename}?direct`);
           } catch (e) {
             console.error(`${e}`);
           }

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -21,6 +21,7 @@ import {
   ModuleNode,
   normalizePath,
   Plugin,
+  preprocessCSS,
   ResolvedConfig,
   ViteDevServer,
 } from 'vite';
@@ -375,6 +376,11 @@ export function angular(options?: PluginOptions): Plugin[] {
           inlineComponentStyles = new Map();
         }
 
+        if (!jit) {
+          styleTransform = (code: string, filename: string) =>
+            preprocessCSS(code, filename, config);
+        }
+
         if (isTest) {
           // set test watch mode
           // - vite override from vitest-angular
@@ -411,52 +417,6 @@ export function angular(options?: PluginOptions): Plugin[] {
         });
       },
       async buildStart() {
-        if (!jit) {
-          const pluginContext = this;
-          const environmentConfig = this.environment?.config ?? resolvedConfig;
-          const cssTransformHook = environmentConfig.plugins?.find(
-            (plugin) => plugin.name === 'vite:css',
-          )?.transform;
-          const cssTransform = (
-            typeof cssTransformHook === 'function'
-              ? cssTransformHook
-              : cssTransformHook?.handler
-          ) as
-            | ((
-                this: typeof pluginContext,
-                code: string,
-                filename: string,
-              ) =>
-                | string
-                | { code: string; map?: vite.PreprocessCSSResult['map'] }
-                | null
-                | undefined
-                | Promise<
-                    | string
-                    | { code: string; map?: vite.PreprocessCSSResult['map'] }
-                    | null
-                    | undefined
-                  >)
-            | undefined;
-
-          if (cssTransform) {
-            styleTransform = async (code: string, filename: string) => {
-              const result = await cssTransform.call(
-                pluginContext,
-                code,
-                filename,
-              );
-
-              return {
-                code:
-                  typeof result === 'string' ? result : (result?.code ?? code),
-                map: typeof result === 'object' ? result?.map : undefined,
-                deps: new Set<string>(),
-              };
-            };
-          }
-        }
-
         // Defer the first compilation in test mode
         if (!isVitestVscode) {
           pendingCompilation = performCompilation(

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -46,6 +46,7 @@ import {
   angularFullVersion,
 } from './utils/devkit.js';
 import { type SourceFileCache as SourceFileCacheType } from './utils/source-file-cache.js';
+import { releaseCssPreprocessorWorkers } from './utils/css-preprocessor-workers.js';
 
 const require = createRequire(import.meta.url);
 
@@ -298,7 +299,7 @@ export function angular(options?: PluginOptions): Plugin[] {
     sourceFileCache.referencedFiles = undefined;
     tsconfigOptionsCache.clear();
     includeCache = [];
-    styleTransform = undefined;
+    releaseCssPreprocessorWorkers();
   }
 
   function angularPlugin(): Plugin {
@@ -402,7 +403,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         const invalidateCompilationOnFsChange = createFsWatcherCacheInvalidator(
           invalidateFsCaches,
           invalidateTsconfigCaches,
-          () => performCompilation(server.environments.client.config),
+          () => performCompilation(resolvedConfig),
           pluginOptions.include.map(
             (glob) =>
               `${normalizePath(resolve(pluginOptions.workspaceRoot))}${glob}`,
@@ -417,6 +418,11 @@ export function angular(options?: PluginOptions): Plugin[] {
         });
       },
       async buildStart() {
+        if (!jit) {
+          styleTransform = (code: string, filename: string) =>
+            preprocessCSS(code, filename, resolvedConfig);
+        }
+
         // Defer the first compilation in test mode
         if (!isVitestVscode) {
           pendingCompilation = performCompilation(
@@ -459,10 +465,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         if (TS_EXT_REGEX.test(ctx.file)) {
           let [fileId] = ctx.file.split('?');
 
-          pendingCompilation = performCompilation(
-            ctx.server.environments.client.config,
-            [fileId],
-          );
+          pendingCompilation = performCompilation(resolvedConfig, [fileId]);
 
           let result;
 
@@ -564,10 +567,10 @@ export function angular(options?: PluginOptions): Plugin[] {
             });
           });
 
-          pendingCompilation = performCompilation(
-            ctx.server.environments.client.config,
-            [...mods.map((mod) => mod.id as string), ...updates],
-          );
+          pendingCompilation = performCompilation(resolvedConfig, [
+            ...mods.map((mod) => mod.id as string),
+            ...updates,
+          ]);
 
           if (updates.length > 0) {
             await pendingCompilation;
@@ -877,6 +880,10 @@ export function angular(options?: PluginOptions): Plugin[] {
           },
         );
         declarationFiles.length = 0;
+
+        if (!watchMode) {
+          releaseCssPreprocessorWorkers();
+        }
       },
     };
   }
@@ -1211,6 +1218,11 @@ export function angular(options?: PluginOptions): Plugin[] {
     // Each pass creates a new builder/program, so previously emitted output
     // can go stale — only dedupe emits within a single pass.
     emittedIds = new Set<string>();
+
+    if (!jit) {
+      styleTransform = (code: string, filename: string) =>
+        preprocessCSS(code, filename, config);
+    }
 
     const discardIncrementalProgram = shouldDiscardIncrementalProgram({
       externalRuntimeStylesNowEnabled: shouldEnableExternalRuntimeStyles({

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.sourcemap.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.sourcemap.spec.ts
@@ -1,0 +1,49 @@
+import { SourceMap } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+import { fastCompilePlugin } from './fast-compile-plugin';
+
+describe('fastCompilePlugin source maps', () => {
+  it('maps stripped TypeScript back to its original position', async () => {
+    const plugin = fastCompilePlugin({
+      tsconfigGetter: () => 'tsconfig.json',
+      workspaceRoot: '/workspace',
+      inlineStylesExtension: 'css',
+      jit: false,
+      liveReload: false,
+      supportedBrowsers: [],
+      isTest: false,
+      isAstroIntegration: false,
+    });
+    const transform = plugin.transform as any;
+    const handler = transform.handler ?? transform;
+    const code = [
+      `import { Component } from '@angular/core';`,
+      `@Component({ selector: 'x', template: '' })`,
+      `export class XComponent {`,
+      `  value: string = 'source-map-target';`,
+      `}`,
+    ].join('\n');
+
+    const result = await handler.call(
+      { addWatchFile: () => undefined },
+      code,
+      '/src/app/x.component.ts',
+    );
+    const generatedOffset = result.code.indexOf('source-map-target');
+    const generatedBeforeTarget = result.code.slice(0, generatedOffset);
+    const generatedLine = generatedBeforeTarget.split('\n').length - 1;
+    const generatedColumn =
+      generatedOffset - generatedBeforeTarget.lastIndexOf('\n') - 1;
+    const entry = new SourceMap(result.map).findEntry(
+      generatedLine,
+      generatedColumn,
+    );
+
+    expect(entry.originalSource).toBe('x.component.ts');
+    expect(entry.originalLine).toBe(3);
+    expect(entry.originalColumn).toBe(
+      code.split('\n')[3].indexOf("'source-map-target'"),
+    );
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
@@ -249,10 +249,8 @@ export class App {
     const plugin = buildPlugin();
     const handler = getTransformHandler(plugin);
 
-    // A component file goes through the full compile path which calls
-    // transformWithOxc internally too, but with `sourcemap: false`. The
-    // bypass uses `sourcemap: true` — assert no `sourcemap: true` call to
-    // confirm we did not enter the bypass branch.
+    // A component file goes through the full compile path, so the final strip
+    // receives Angular's generated Ivy definitions rather than the raw input.
     const code = `
 import { Component } from '@angular/core';
 @Component({ selector: 'x', template: '' })
@@ -269,10 +267,69 @@ export class XComponent {}
       // we only care that the bypass branch was not taken.
     }
 
-    const sawBypassCall = mockTransformWithOxc.mock.calls.some(
-      ([, , opts]: any[]) => opts?.sourcemap === true,
+    const sawCompiledCall = mockTransformWithOxc.mock.calls.some(
+      ([callCode]: any[]) => callCode.includes('ɵcmp'),
     );
-    expect(sawBypassCall).toBe(false);
+    expect(sawCompiledCall).toBe(true);
+  });
+
+  it('composes the AOT compiler map with the TypeScript strip map', async () => {
+    const plugin = buildPlugin();
+    const handler = getTransformHandler(plugin);
+    const code = `
+import { Component } from '@angular/core';
+@Component({ selector: 'x', template: '' })
+export class XComponent {
+  value: string = 'test';
+}
+`;
+
+    const result = await handler.call(
+      { addWatchFile: () => undefined },
+      code,
+      '/src/app/x.component.ts',
+    );
+    const stripCall = mockTransformWithOxc.mock.calls.at(-1)!;
+
+    expect(stripCall[2]).toMatchObject({ lang: 'ts', sourcemap: true });
+    expect(stripCall[3]).toMatchObject({ mappings: expect.any(String) });
+    expect(result.map).toEqual({ mappings: '' });
+  });
+
+  it('composes the AOT compiler map with the esbuild fallback map', async () => {
+    const viteMod = await import('vite');
+    const realOxc = viteMod.transformWithOxc;
+    Object.defineProperty(viteMod, 'transformWithOxc', {
+      value: undefined,
+      configurable: true,
+    });
+    try {
+      const plugin = buildPlugin();
+      const handler = getTransformHandler(plugin);
+      const code = `
+import { Component } from '@angular/core';
+@Component({ selector: 'x', template: '' })
+export class XComponent {
+  value: string = 'test';
+}
+`;
+
+      const result = await handler.call(
+        { addWatchFile: () => undefined },
+        code,
+        '/src/app/x.component.ts',
+      );
+      const stripCall = mockTransformWithEsbuild.mock.calls.at(-1)!;
+
+      expect(stripCall[2]).toMatchObject({ loader: 'ts', sourcemap: true });
+      expect(stripCall[3]).toMatchObject({ mappings: expect.any(String) });
+      expect(result.map).toEqual({ mappings: '' });
+    } finally {
+      Object.defineProperty(viteMod, 'transformWithOxc', {
+        value: realOxc,
+        configurable: true,
+      });
+    }
   });
 
   it('does not run the bypass strip when the file has only @Service', async () => {
@@ -301,10 +358,10 @@ export class MyService {
       // we only care that the bypass branch was not taken.
     }
 
-    const sawBypassCall = mockTransformWithOxc.mock.calls.some(
-      ([, , opts]: any[]) => opts?.sourcemap === true,
+    const sawCompiledCall = mockTransformWithOxc.mock.calls.some(
+      ([callCode]: any[]) => callCode.includes('ɵprov'),
     );
-    expect(sawBypassCall).toBe(false);
+    expect(sawCompiledCall).toBe(true);
   });
 
   it('preprocesses an external .scss styleUrl by its own extension when inlineStylesExtension is css', async () => {

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -632,17 +632,25 @@ export function fastCompilePlugin(
       resourceToSource.set(dep, id);
     }
 
-    // Strip TypeScript-only syntax
+    // Strip TypeScript-only syntax and compose the compiler map with the
+    // final generated code so downstream breakpoints map back to the source.
     const stripped = vite.transformWithOxc
-      ? await vite.transformWithOxc(result.code, id, {
-          lang: 'ts',
-          sourcemap: false,
-          decorator: { legacy: false, emitDecoratorMetadata: false },
-        })
-      : await vite.transformWithEsbuild(result.code, id, {
-          loader: 'ts',
-          sourcemap: false,
-        });
+      ? await vite.transformWithOxc(
+          result.code,
+          id,
+          {
+            lang: 'ts',
+            sourcemap: true,
+            decorator: { legacy: false, emitDecoratorMetadata: false },
+          },
+          result.map,
+        )
+      : await vite.transformWithEsbuild(
+          result.code,
+          id,
+          { loader: 'ts', sourcemap: true },
+          result.map,
+        );
     let outputCode = stripped.code;
 
     // Append HMR code in dev mode
@@ -656,7 +664,7 @@ export function fastCompilePlugin(
       }
     }
 
-    return { code: outputCode, map: result.map };
+    return { code: outputCode, map: stripped.map };
   }
 
   function resolveTsConfigPath() {

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -36,6 +36,7 @@ import {
   isProdMode,
   type TsConfigResolutionContext,
 } from './utils/plugin-config.js';
+import { releaseCssPreprocessorWorkers } from './utils/css-preprocessor-workers.js';
 import { VIRTUAL_RAW_PREFIX, toVirtualRawId } from './utils/virtual-ids.js';
 import {
   loadVirtualRawModule,
@@ -734,6 +735,11 @@ export function fastCompilePlugin(
     },
     async buildStart() {
       await initFastCompile();
+    },
+    closeBundle() {
+      if (!watchMode) {
+        releaseCssPreprocessorWorkers();
+      }
     },
     async handleHotUpdate(ctx) {
       // Resource file changes → invalidate parent .ts module

--- a/packages/vite-plugin-angular/src/lib/utils/css-preprocessor-workers.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/css-preprocessor-workers.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { preprocessCSS, resolveConfig } from 'vite';
+
+import { releaseCssPreprocessorWorkers } from './css-preprocessor-workers.js';
+
+function preprocessorChildHandles() {
+  const getHandles = (
+    process as NodeJS.Process & { _getActiveHandles?: () => any[] }
+  )._getActiveHandles;
+  const handles =
+    typeof getHandles === 'function' ? getHandles.call(process) : [];
+  return handles.filter((handle) => {
+    const haystack = `${handle?.spawnfile ?? ''} ${(
+      handle?.spawnargs ?? []
+    ).join(' ')}`;
+    return /sass-embedded|dart-sass|sass\.snapshot/i.test(haystack);
+  });
+}
+
+describe('releaseCssPreprocessorWorkers', () => {
+  it('is a no-op when no preprocessor processes are active', () => {
+    expect(() => releaseCssPreprocessorWorkers()).not.toThrow();
+  });
+
+  it('unrefs the fallback Sass worker spawned by preprocessCSS', async () => {
+    const config = await resolveConfig(
+      { configFile: false, logLevel: 'silent' },
+      'build',
+    );
+    // Different object identity forces Vite's unmanaged fallback worker.
+    const cacheMissConfig = Object.create(config);
+
+    await preprocessCSS(
+      '$color: red; :host { color: $color; }',
+      'component.scss',
+      cacheMissConfig,
+    );
+
+    expect(preprocessorChildHandles().length).toBeGreaterThan(0);
+
+    releaseCssPreprocessorWorkers();
+
+    expect(preprocessorChildHandles()).toHaveLength(0);
+  });
+});

--- a/packages/vite-plugin-angular/src/lib/utils/css-preprocessor-workers.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/css-preprocessor-workers.ts
@@ -1,0 +1,47 @@
+type ProcessHandle = {
+  spawnfile?: string;
+  spawnargs?: string[];
+  stdin?: { unref?: () => void };
+  stdout?: { unref?: () => void };
+  stderr?: { unref?: () => void };
+  stdio?: Array<{ unref?: () => void } | null | undefined>;
+  unref?: () => void;
+};
+
+const PREPROCESSOR_PROCESS_RE =
+  /sass-embedded|dart-sass|sass\.snapshot|[\\/]lessc(?:$|[\s])|[\\/]stylus(?:$|[\s])/i;
+
+function getActiveHandles(): ProcessHandle[] {
+  const getHandles = (
+    process as NodeJS.Process & { _getActiveHandles?: () => ProcessHandle[] }
+  )._getActiveHandles;
+  return typeof getHandles === 'function' ? getHandles.call(process) : [];
+}
+
+function isCssPreprocessorProcess(handle: ProcessHandle): boolean {
+  const haystack = `${handle.spawnfile ?? ''} ${(handle.spawnargs ?? []).join(
+    ' ',
+  )}`;
+  return PREPROCESSOR_PROCESS_RE.test(haystack);
+}
+
+/**
+ * Vite's `preprocessCSS` may spawn a fallback Sass/Less/Stylus compiler
+ * (`alwaysFakeWorkerWorkerControllerCache`) that is never closed. Unref those
+ * child processes so a one-off `vite build` can return the shell.
+ */
+export function releaseCssPreprocessorWorkers(): void {
+  for (const handle of getActiveHandles()) {
+    if (!isCssPreprocessorProcess(handle)) {
+      continue;
+    }
+
+    for (const stream of handle.stdio ?? []) {
+      stream?.unref?.();
+    }
+    handle.stdin?.unref?.();
+    handle.stdout?.unref?.();
+    handle.stderr?.unref?.();
+    handle.unref?.();
+  }
+}


### PR DESCRIPTION
### PR Checklist

Closes #2505

Production source maps could become missing, stale, or incorrectly composed as modules passed through Angular compilation, the Angular build optimizer, and Vite’s TypeScript processing.

The most important issue was that the optimizer plugin explicitly configured Vite’s `oxc`/`esbuild` transform. This could cause TypeScript processing to run again over code and source maps already generated by Angular. Other stages either disabled production maps, discarded optimizer maps, or returned a compiler map that did not account for the final TypeScript syntax-stripping transform. Consequently, stack traces, breakpoints, and error-reporting tools could resolve to incorrect source positions.

### Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: none

### Recommended merge strategy for maintainer

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

### What is the new behavior?

This PR preserves a coherent source-map chain throughout the Angular build pipeline:

1. **Avoid duplicate TypeScript transforms**
   - The optimizer plugin no longer configures `oxc` or `esbuild` itself.
   - Angular production constants such as `ngDevMode` and `ngJitMode` remain configured through Vite’s top-level `define` option.
   - Vite remains responsible for its built-in TypeScript processing, avoiding another Oxc/esbuild pass over Angular-generated output and its source map.

2. **Retain Angular optimizer maps**
   - When `build.sourcemap` is enabled, the Angular `JavaScriptTransformer` now processes both generated and third-party source maps.
   - Inline maps produced while linking or optimizing Angular packages are extracted and returned directly to Vite rather than being left embedded in the transformed code.
   - Existing maps for modules that do not require Angular optimization remain in the transform chain. Source-map comments are only removed when maps are intentionally disabled.

3. **Emit maps from production Angular compilation**
   - Production compilation now honors Vite’s `build.sourcemap` setting instead of always disabling TypeScript source-map generation.
   - Source content is included so downstream tools can resolve original TypeScript without depending on separately deployed source files.
   - Relative source entries and `sourceRoot` are normalized into resolvable paths before maps are passed to Vite. This also keeps mappings for component code and external templates usable by later transforms.

4. **Compose maps in the fast-compile pipeline**
   - Fast compilation still performs its required Oxc/esbuild pass to remove TypeScript-only syntax; this is not an additional transform introduced by the PR.
   - The Angular compiler or JIT map is now supplied as the input map to that syntax-stripping pass.
   - The resulting composed map is returned instead of the stale pre-strip compiler map, so removed annotations and modifiers no longer shift reported source positions.
   - Both the Oxc path and the esbuild fallback are covered.

Together, these changes ensure each necessary transform runs once and contributes to a single composed map from final JavaScript back to the original Angular/TypeScript source.

Source-map generation remains opt-in for production through `build.sourcemap`. Builds that do not request production maps retain their existing behavior, and no public API changes are introduced.

### Test plan

- [ ] `nx format:check`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual verification

Targeted verification:

- [x] `pnpm nx test vite-plugin-angular` — 724 passed, 6 skipped
- [x] Focused source-map tests covering optimizer map extraction and retention, production compiler maps, normalized source paths, Oxc composition, and the esbuild fallback
- [x] End-to-end fast-compile assertion confirming generated positions map back to the correct original TypeScript columns after type annotations are removed
- [x] `pnpm nx build vite-plugin-angular`

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Other information
<img src="https://static.klipy.com/ii/d6b0ce929193df3c242ac34b5654d2ce/3a/f0/rZ9Zyqyh.gif"/>