### PR TITLE
ci: drop baseUrl from tsconfig.base.json so Windows SSR builds stop looping

### DIFF
--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.spec.ts
@@ -1,7 +1,11 @@
 // Mocked at module level so the plugin sees our stubs for the OXC/esbuild
 // strip pass on the bypass path. Kept in a separate file from compile.spec.ts
 // because that suite uses real `vite.transformWithOxc` for end-to-end checks.
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { readConfiguration } from '@angular/compiler-cli';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 let mockRolldownVersion: string | undefined;
 const mockTransformWithOxc = vi.fn();
@@ -22,7 +26,7 @@ vi.mock('vite', async () => {
   };
 });
 
-import { fastCompilePlugin } from './fast-compile-plugin';
+import { fastCompilePlugin, getPathsBasePath } from './fast-compile-plugin';
 
 function buildPlugin() {
   return fastCompilePlugin({
@@ -350,5 +354,62 @@ describe('fastCompilePlugin transform filter', () => {
     expect(matchesExclude('/src/app/foo.ts')).toBe(false);
     expect(matchesExclude('/src/app/foo.ts?t=12345')).toBe(false);
     expect(matchesExclude('/src/app/foo.ts?component')).toBe(false);
+  });
+});
+
+describe('getPathsBasePath', () => {
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'analog-paths-base-'));
+  });
+
+  afterEach(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  function writeConfigs(
+    root: Record<string, unknown>,
+    app: Record<string, unknown>,
+  ) {
+    mkdirSync(join(workspaceRoot, 'apps', 'demo'), { recursive: true });
+    writeFileSync(
+      join(workspaceRoot, 'tsconfig.base.json'),
+      JSON.stringify(root),
+    );
+    const appConfig = join(workspaceRoot, 'apps', 'demo', 'tsconfig.json');
+    writeFileSync(
+      appConfig,
+      JSON.stringify({ extends: '../../tsconfig.base.json', ...app }),
+    );
+    return appConfig;
+  }
+
+  it('anchors inherited paths on the config that declares them when baseUrl is unset', () => {
+    const appConfig = writeConfigs(
+      { compilerOptions: { paths: { lib: ['./libs/lib/src/index.ts'] } } },
+      { files: [] },
+    );
+
+    const { options } = readConfiguration(appConfig);
+
+    expect(getPathsBasePath(options, dirname(appConfig))).toBe(workspaceRoot);
+  });
+
+  it('prefers an explicit baseUrl over the declaring config directory', () => {
+    const appConfig = writeConfigs(
+      { compilerOptions: { paths: { lib: ['./libs/lib/src/index.ts'] } } },
+      { compilerOptions: { baseUrl: './src' }, files: [] },
+    );
+
+    const { options } = readConfiguration(appConfig);
+
+    expect(getPathsBasePath(options, dirname(appConfig))).toBe(
+      join(workspaceRoot, 'apps', 'demo', 'src'),
+    );
+  });
+
+  it('falls back to the project root when no config anchors paths', () => {
+    expect(getPathsBasePath(undefined, '/project')).toBe('/project');
   });
 });

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -71,6 +71,19 @@ export interface FastCompilePluginOptions {
   fastCompileMode?: 'full' | 'partial';
 }
 
+/**
+ * Directory that `compilerOptions.paths` targets resolve against. Mirrors
+ * TypeScript: `baseUrl` when set, otherwise the directory of the config
+ * that declares `paths` (`pathsBasePath`, since `baseUrl` is optional
+ * from TS 4.1).
+ */
+export function getPathsBasePath(
+  options: { baseUrl?: string; pathsBasePath?: string } | undefined,
+  fallback: string,
+): string {
+  return options?.baseUrl ?? options?.pathsBasePath ?? fallback;
+}
+
 export function fastCompilePlugin(
   pluginOptions: FastCompilePluginOptions,
 ): Plugin {
@@ -214,15 +227,7 @@ export function fastCompilePlugin(
     // silently drops it because arrays don't have a directive def.
     const candidates = new Set<string>(config.rootNames);
     const tsPaths = config.options?.paths;
-    // `paths` resolve against the config that declares them, which
-    // TypeScript exposes as `pathsBasePath`; `baseUrl` is optional since
-    // TS 4.1, so it can't be the only anchor.
-    const pathsBasePath = (
-      config.options as { pathsBasePath?: string } | undefined
-    )?.pathsBasePath;
-    const baseUrl = (pathsBasePath ??
-      config.options?.baseUrl ??
-      projectRoot) as string;
+    const baseUrl = getPathsBasePath(config.options, projectRoot);
     // Cold-start dedup caches shared by the three scan phases below
     // (candidates scan, walkImports, scanBarrelExports). Scoped to this
     // init call only — HMR/watcher re-scans must hit disk fresh.

--- a/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/fast-compile-plugin.ts
@@ -214,7 +214,15 @@ export function fastCompilePlugin(
     // silently drops it because arrays don't have a directive def.
     const candidates = new Set<string>(config.rootNames);
     const tsPaths = config.options?.paths;
-    const baseUrl = (config.options?.baseUrl ?? projectRoot) as string;
+    // `paths` resolve against the config that declares them, which
+    // TypeScript exposes as `pathsBasePath`; `baseUrl` is optional since
+    // TS 4.1, so it can't be the only anchor.
+    const pathsBasePath = (
+      config.options as { pathsBasePath?: string } | undefined
+    )?.pathsBasePath;
+    const baseUrl = (pathsBasePath ??
+      config.options?.baseUrl ??
+      projectRoot) as string;
     // Cold-start dedup caches shared by the three scan phases below
     // (candidates scan, walkImports, scanBarrelExports). Scoped to this
     // init call only — HMR/watcher re-scans must hit disk fresh.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,82 +14,84 @@
     "lib": ["es2021", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "baseUrl": ".",
     "ignoreDeprecations": "6.0",
     "paths": {
-      "@analogjs/astro-angular": ["packages/astro-angular/src/index.ts"],
+      "@analogjs/astro-angular": ["./packages/astro-angular/src/index.ts"],
       "@analogjs/content": [
         "./node_modules/@analogjs/content",
-        "packages/content/src/index.ts"
+        "./packages/content/src/index.ts"
       ],
-      "@analogjs/content-plugin": ["packages/content-plugin/src/index.ts"],
+      "@analogjs/content-plugin": ["./packages/content-plugin/src/index.ts"],
       "@analogjs/content/prism-highlighter": [
-        "packages/content/prism-highlighter/src/index.ts"
+        "./packages/content/prism-highlighter/src/index.ts"
       ],
       "@analogjs/content/resources": [
         "./node_modules/@analogjs/content/resources",
-        "packages/content/resources/src/index.ts"
+        "./packages/content/resources/src/index.ts"
       ],
       "@analogjs/content/shiki-highlighter": [
-        "packages/content/shiki-highlighter/src/index.ts"
+        "./packages/content/shiki-highlighter/src/index.ts"
       ],
-      "@analogjs/nx": ["packages/nx-plugin/src/index.ts"],
+      "@analogjs/nx": ["./packages/nx-plugin/src/index.ts"],
       "@analogjs/platform": [
         "./node_modules/@analogjs/platform",
-        "packages/platform/src/index.ts"
+        "./packages/platform/src/index.ts"
       ],
       "@analogjs/router": [
         "./node_modules/@analogjs/router",
-        "packages/router/src/index.ts"
+        "./packages/router/src/index.ts"
       ],
       "@analogjs/router/server": [
         "./node_modules/@analogjs/router/server",
-        "packages/router/server/src/index.ts"
+        "./packages/router/server/src/index.ts"
       ],
       "@analogjs/router/i18n": [
         "./node_modules/@analogjs/router/i18n",
-        "packages/router/i18n/src/index.ts"
+        "./packages/router/i18n/src/index.ts"
       ],
       "@analogjs/router/tokens": [
         "./node_modules/@analogjs/router/tokens",
-        "packages/router/tokens/src/index.ts"
+        "./packages/router/tokens/src/index.ts"
       ],
-      "@analogjs/top-bar": ["libs/top-bar/src/index.ts"],
-      "@analogjs/trpc": ["packages/trpc/src/index.ts"],
+      "@analogjs/top-bar": ["./libs/top-bar/src/index.ts"],
+      "@analogjs/trpc": ["./packages/trpc/src/index.ts"],
       "@analogjs/vite-plugin-angular": [
         "./node_modules/@analogjs/vite-plugin-angular",
-        "packages/vite-plugin-angular/src/index.ts"
+        "./packages/vite-plugin-angular/src/index.ts"
       ],
       "@analogjs/vite-plugin-nitro": [
         "./node_modules/@analogjs/vite-plugin-nitro",
-        "packages/vite-plugin-nitro/src/index.ts"
+        "./packages/vite-plugin-nitro/src/index.ts"
       ],
       "@analogjs/vitest-angular": [
         "./node_modules/@analogjs/vitest-angular",
-        "packages/vitest-angular/src/index.ts"
+        "./packages/vitest-angular/src/index.ts"
       ],
       "@analogjs/vitest-angular/setup-serializers": [
         "./node_modules/@analogjs/vitest-angular/setup-serializers",
-        "packages/vitest-angular/setup-serializers.ts"
+        "./packages/vitest-angular/setup-serializers.ts"
       ],
       "@analogjs/vitest-angular/setup-snapshots": [
         "./node_modules/@analogjs/vitest-angular/setup-snapshots",
-        "packages/vitest-angular/setup-snapshots.ts"
+        "./packages/vitest-angular/setup-snapshots.ts"
       ],
       "@analogjs/vitest-angular/setup-testbed": [
         "./node_modules/@analogjs/vitest-angular/setup-testbed",
-        "packages/vitest-angular/setup-testbed.ts"
+        "./packages/vitest-angular/setup-testbed.ts"
       ],
       "@analogjs/vitest-angular/setup-zone": [
         "./node_modules/@analogjs/vitest-angular/setup-zone",
-        "packages/vitest-angular/setup-zone.ts"
+        "./packages/vitest-angular/setup-zone.ts"
       ],
-      "libs/card": ["libs/card/src/index.ts"],
-      "my-package": ["./dist/libs/my-package", "libs/my-package/src/index.ts"],
-      "shared/feature": ["libs/shared/feature/src/index.ts"],
+      "libs/card": ["./libs/card/src/index.ts"],
+      "my-package": [
+        "./dist/libs/my-package",
+        "./libs/my-package/src/index.ts"
+      ],
+      "shared/feature": ["./libs/shared/feature/src/index.ts"],
       "vitest-angular": [
         "./node_modules/@analogjs/vitest-angular",
-        "packages/vitest-angular/src/index.ts"
+        "./packages/vitest-angular/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
## PR Checklist

Since #2503 swapped `nxViteTsPaths()` for `viteTsConfigPaths()`, every Windows build fails: the nightly `ci-windows-full` run (runs 65 and 66) and the `build-windows` smoke job on every PR since. Each app's client build finishes in seconds, then the SSR build sits in `transforming...` for 4-5 minutes and dies with `memory allocation of N bytes failed` (rolldown) or `Committing semi space failed - JavaScript heap out of memory` (V8). Linux is green throughout.

Root cause: with `baseUrl` set, vite-tsconfig-paths joins every unmatched bare import onto the workspace root and asks Vite to resolve it. In the SSR environment rolldown feeds that candidate straight back into the plugin's own `resolveId` hook (instrumented locally: 60 re-entries during the blog-app SSR build, none during the client build). The plugin's only guard is `id[0] === "/"`, so on Linux the loop stops immediately, while on Windows a `D:\...` candidate passes the guard, gets joined onto the root again, and re-resolves without end until memory runs out.

Closes #

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: workspace config (`tsconfig.base.json`), ci

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

## What is the new behavior?

- `tsconfig.base.json` no longer sets `baseUrl`. Nothing in the repo imports through it, and TypeScript has resolved `paths` without it since 4.1. Every `paths` target now carries a `./` prefix, which TypeScript requires once `baseUrl` is gone (TS5090 otherwise). Alias keys are unchanged.
- The fast-compile plugin anchored its `paths` barrel scan on `baseUrl`, falling back to the app's own tsconfig directory. Without `baseUrl` it would have looked for library barrels under the app folder and silently skipped them. It now reads TypeScript's `pathsBasePath` (the directory of the config that declares the mappings) before either fallback.

Alternatives considered: patching vite-tsconfig-paths 6.1.1 to guard with `isAbsolute` (works, but adds a pnpm patch to maintain) and Vite's native `resolve.tsconfigPaths` (rolldown/rolldown#8732 reported it failing on this same Windows SSR build). The templates in `create-analog` and the nx-plugin app generator still ship `baseUrl` alongside `viteTsConfigPaths()`, so generated apps on Windows have the same exposure; that is worth a separate change.

## Test plan

- [x] `nx format:check` (prettier on the changed files)
- [ ] `pnpm build`
- [ ] `pnpm test`
- [x] Manual verification
  - `ci-windows-full` dispatched on this branch: https://github.com/analogjs/analog/actions/runs/33899843519 (green in 10 minutes; the failing runs took 30)
  - `nx build blog-app --skip-nx-cache` and `nx build analog-app --skip-nx-cache` (the app with `fastCompile: true`) on Linux
  - `nx test trpc-app` and the `fast-compile-plugin` unit tests

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The `[tsconfig-paths] An error occurred while parsing ".../dist/tsconfig.json"` lines in the nightly logs are unrelated: the create-analog build copies its top-level files into `dist/` with `cpy`, so the plugin's workspace scan finds a stray tsconfig there. Harmless, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYEWUwFabM4v56frXKnJHh

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYEWUwFabM4v56frXKnJHh)_