### PR TITLE
fix(vite-plugin-angular): use null for default providedIn setting for Injectable

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/compile.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/compile.spec.ts
@@ -28,4 +28,10 @@ describe('NgLite Compiler', () => {
     expect(pipe).toContain('ɵpipe');
     expect(service).toContain('ɵprov');
   });
+
+  it('uses null for the default providedIn for Injectable', () => {
+    const service = compile(`@Injectable() class S {}`, 's.ts');
+    expect(service).not.toContain('providedIn: "root"');
+    expect(service).not.toContain("providedIn: 'root'");
+  });
 });

--- a/packages/vite-plugin-angular/src/lib/compiler/compile.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/compile.ts
@@ -1063,7 +1063,7 @@ export function compile(
             type: classRef,
             typeArgumentCount: 0,
             providedIn: {
-              expression: new o.LiteralExpr(meta.providedIn || 'root'),
+              expression: new o.LiteralExpr(meta.providedIn ?? null),
               forwardRef: 0,
             },
           };


### PR DESCRIPTION
## PR Checklist

Closes #2512

## Affected scope

<!-- List the primary scope from CONTRIBUTING.md and any closely related secondary scopes. -->

- Primary scope: vite-plugin-angular

## Recommended merge strategy for maintainer [optional]

<!-- Squash merge is highly preferred. -->
<!-- Recommend a non-squash merge only if you can justify why the PR should bypass focused changes per package. -->

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

<!-- If you recommend a non-squash merge, briefly explain why the commit boundaries matter and why this PR should bypass focused changes per package. -->

## What is the new behavior?

The fastCompile option in vite-plugin-angular now correctly uses `null` for the default value of `providedIn` when compiling `@Injectable`s. This matches the Angular compiler. Previously, it used `"root"` for this setting, which caused services to always be available, leading to problems for optional services.

## Test plan

<!-- List the commands you ran and any manual verification you performed. -->

- [x] `nx format:check`
- [x] `pnpm build`
- [x] `pnpm test`
- [x] Manual verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
