### PR TITLE
fix(vite-plugin-angular): preserve mappings for hoisted statements

### DIFF
--- a/packages/vite-plugin-angular/src/lib/compiler/compile.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/compile.ts
@@ -1460,9 +1460,8 @@ export function compile(
           nonHoistableNames.add(name);
         }
       } else {
-        const text = stmt.getText(origSourceFile);
-        ms.remove(stmtStart, stmt.getEnd());
-        ms.appendLeft(firstClassPos, text + '\n');
+        ms.appendLeft(stmt.getEnd(), '\n');
+        ms.move(stmtStart, stmt.getEnd(), firstClassPos);
       }
     }
   }

--- a/packages/vite-plugin-angular/src/lib/compiler/hoist-sourcemap.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/hoist-sourcemap.spec.ts
@@ -1,0 +1,57 @@
+import { SourceMap } from 'node:module';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { compile } from './compile';
+
+describe('hoisted statement source maps', () => {
+  it.each(['\n', '\r\n'])(
+    'preserves original positions with %j line endings',
+    (newline) => {
+      const source = [
+        "import { Component } from '@angular/core';",
+        "@Component({ selector: 'app-test', template: '' })",
+        'export class TestComponent {}',
+        '// A helper used by application code.',
+        'const helper = () => 42',
+        'function greeting() { return helper(); }',
+        'const last = greeting()',
+      ].join(newline);
+      const { code, map } = compile(source, 'test.ts');
+      const sourceMap = new SourceMap(JSON.parse(map.toString()));
+      const position = (text: string, token: string) => {
+        const prefix = text.slice(0, text.indexOf(token));
+        const lines = prefix.split('\n');
+        return { line: lines.length, column: lines.at(-1)!.length + 1 };
+      };
+
+      for (const token of [
+        'helper =',
+        'greeting()',
+        'last =',
+        'return helper',
+      ]) {
+        const generated = position(code, token);
+        const original = position(source, token);
+        expect(
+          sourceMap.findOrigin(generated.line, generated.column),
+        ).toMatchObject({
+          lineNumber: original.line,
+          columnNumber: original.column,
+        });
+      }
+      expect(code.indexOf('const helper')).toBeLessThan(
+        code.indexOf('function greeting'),
+      );
+      expect(code.indexOf('function greeting')).toBeLessThan(
+        code.indexOf('const last'),
+      );
+      expect(code.indexOf('const last')).toBeLessThan(
+        code.indexOf('class TestComponent'),
+      );
+      expect(
+        ts.transpileModule(code, { reportDiagnostics: true }).diagnostics,
+      ).toEqual([]);
+      expect(JSON.parse(map.toString()).sourcesContent).toEqual([source]);
+    },
+  );
+});


### PR DESCRIPTION
Preserve debugger positions for helper declarations hoisted by `fastCompile`. Moving the original source chunks retains their mappings while preserving the existing initialization order.

## PR Checklist

Closes analogjs/analog#2517.

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

No commit boundaries need preservation.

## What is the new behavior?

When a component file declares a helper after its class, the compiler hoists the helper before the generated static definitions. Previously, remove/reinsert discarded the helper's source positions; a breakpoint could map to the component decorator instead. MagicString now moves the original chunk and adds a separating newline, including for semicolonless declarations at EOF.

The hoisting eligibility rules and public API are unchanged. This fixes a separate operation from the transform-chain work in [analogjs/analog#2506](https://github.com/analogjs/analog/pull/2506); it does not modify that PR's transforms or map composition.

## Test plan

- [x] Frozen dependency installation with the beta pin, pnpm 11.6.0, on Node 24.15.0.
- [x] Regression failed before the fix: generated helper position incorrectly mapped to line 2 instead of line 5.
- [x] `pnpm nx test vite-plugin-angular` — 722 passed, 6 existing skips.
- [x] `pnpm nx build vite-plugin-angular` — passed.
- [x] Prettier on both changed files; `git diff --check`.

The new regression checks exact original line/column positions for moved variables and function bodies, LF/CRLF, multiple declarations, order, valid emitted syntax, and no final newline. Existing tests cover declarations that must not be hoisted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Targets beta for the current 2.x compiler. The same small change can be ported to alpha after integration. Local validation uses a supported Node version; upstream beta currently pins 24.11.0 despite requiring at least 24.15.0 on the 24.x line. GitHub CI remains the authority for remote validation.

## [optional] What gif best describes this PR or how it makes you feel?

Not applicable.
