### PR TITLE
fix(vite-plugin-nitro): exclude load-only server-function hosts

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.spec.ts
@@ -45,7 +45,9 @@ describe('getServerFnHandlers', () => {
     // the whole Angular app into the dispatch bundle.
     writeFileSync(
       join(workspaceRoot, 'src/main.server.ts'),
-      `export default async function render() { return ''; }`,
+      `import { serverFn } from '@analogjs/router/server';
+       export const rootFn = serverFn(async () => []);
+       export default async function render() { return ''; }`,
     );
     writeFileSync(
       join(workspaceRoot, 'src/main-cf.server.ts'),

--- a/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.spec.ts
@@ -125,7 +125,7 @@ describe('getServerFnHandlers', () => {
     `export const load = async () => ({});`,
     `// import { serverFn } from '@analogjs/router/server';
      export const load = async () => ({ text: 'serverFn' });`,
-    `import { serverFn } from 'another-library'; export const load = serverFn();`,
+    `import { serverFn } from 'another-library'; export const load = async () => ({});`,
     `import type { serverFn } from '@analogjs/router/server'; export const load = async () => ({});`,
     `import { type serverFn } from '@analogjs/router/server'; export const load = async () => ({});`,
   ])('excludes load-only modules: %s', (code) => {
@@ -185,6 +185,42 @@ describe('getServerFnHandlers', () => {
       ).toBe(true);
     },
   );
+
+  it('wires dispatch for the conventional serverFn re-export that the client transforms', async () => {
+    rmSync(join(workspaceRoot, 'src/app/server-fns'), { recursive: true });
+    writeFileSync(
+      join(workspaceRoot, 'src/app/server-fn.ts'),
+      `export { serverFn } from '@analogjs/router/server';`,
+    );
+    const page = join(workspaceRoot, 'src/app/pages/shipping/index.server.ts');
+    writeFileSync(
+      page,
+      `import { serverFn } from '../../server-fn';
+       export const load = async () => ({});
+       export const getData = serverFn(async () => []);`,
+    );
+
+    const plugin = nitro({ ssr: false, useAPIMiddleware: false })[1] as any;
+    const config = await plugin.config(
+      { root: workspaceRoot, build: {} },
+      { command: 'build', mode: 'production' },
+    );
+    await config.builder.buildApp({
+      build: vi.fn(),
+      environments: { client: {} },
+    });
+    const nitroConfig = vi.mocked(buildServer).mock.calls.at(-1)![1];
+
+    expect(
+      nitroConfig.handlers?.some(
+        (handler) =>
+          typeof handler !== 'string' && handler.route === '/_analog/fn/:id',
+      ),
+    ).toBe(true);
+    expect(
+      JSON.stringify(nitroConfig.virtual).includes('shipping/index.server.ts'),
+    ).toBe(true);
+  });
 
   it('returns deterministic, de-duplicated, sorted output', () => {
     const first = getServerFnHandlers({ workspaceRoot, sourceRoot, rootDir });

--- a/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.spec.ts
@@ -4,6 +4,12 @@ import { join } from 'node:path';
 import { normalizePath } from 'vite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { vi } from 'vitest';
+import { nitro } from '../vite-plugin-nitro';
+import { buildServer } from '../build-server';
+
+vi.mock('../build-server');
+
 import { getServerFnHandlers } from './get-server-fn-handlers';
 
 describe('getServerFnHandlers', () => {
@@ -21,12 +27,14 @@ describe('getServerFnHandlers', () => {
     // Dedicated server-fn module.
     writeFileSync(
       join(workspaceRoot, 'src/app/server-fns/products.server.ts'),
-      `export const getProducts = serverFn({ id: 'getProducts' }, async () => []);`,
+      `import { serverFn } from '@analogjs/router/server'; export const getProducts = serverFn({ id: 'getProducts' }, async () => []);`,
     );
     // A page server file may also host a server function.
     writeFileSync(
       join(workspaceRoot, 'src/app/pages/shipping/index.server.ts'),
-      `export default async function load() { return {}; }`,
+      `import { serverFn as defineServerFn } from '@analogjs/router/server';
+       export const load = async () => ({});
+       export const shipping = defineServerFn(async () => []);`,
     );
     // Angular SSR config — matched by the glob but must be excluded.
     writeFileSync(
@@ -99,7 +107,7 @@ describe('getServerFnHandlers', () => {
   it('keeps a page named main.server.ts, which is not an SSR entry', () => {
     writeFileSync(
       join(workspaceRoot, 'src/app/pages/main.server.ts'),
-      `export const load = async () => ({});`,
+      `import { serverFn } from '@analogjs/router/server'; export const main = serverFn(async () => ({}));`,
     );
 
     const files = getServerFnHandlers({
@@ -112,6 +120,71 @@ describe('getServerFnHandlers', () => {
       true,
     );
   });
+
+  it.each([
+    `export const load = async () => ({});`,
+    `// import { serverFn } from '@analogjs/router/server';
+     export const load = async () => ({ text: 'serverFn' });`,
+    `import { serverFn } from 'another-library'; export const load = serverFn();`,
+    `import type { serverFn } from '@analogjs/router/server'; export const load = async () => ({});`,
+    `import { type serverFn } from '@analogjs/router/server'; export const load = async () => ({});`,
+  ])('excludes load-only modules: %s', (code) => {
+    rmSync(join(workspaceRoot, 'src/app/server-fns'), { recursive: true });
+    writeFileSync(
+      join(workspaceRoot, 'src/app/pages/shipping/index.server.ts'),
+      code,
+    );
+    expect(getServerFnHandlers({ workspaceRoot, sourceRoot, rootDir })).toEqual(
+      [],
+    );
+  });
+
+  it.each([false, true])(
+    'wires dispatch only for runtime serverFn imports: %s',
+    async (withServerFn) => {
+      rmSync(join(workspaceRoot, 'src/app/server-fns'), { recursive: true });
+      const page = join(
+        workspaceRoot,
+        'src/app/pages/shipping/index.server.ts',
+      );
+      writeFileSync(
+        page,
+        `export const load = async () => ({});` +
+          (withServerFn
+            ? `import { serverFn as defineFn } from '@analogjs/router/server'; export const getData = defineFn(async () => []);`
+            : ''),
+      );
+      const plugin = nitro({ ssr: false, useAPIMiddleware: false })[1] as any;
+      const config = await plugin.config(
+        { root: workspaceRoot, build: {} },
+        { command: 'build', mode: 'production' },
+      );
+      await config.builder.buildApp({
+        build: vi.fn(),
+        environments: { client: {} },
+      });
+      const nitroConfig = vi.mocked(buildServer).mock.calls.at(-1)![1];
+      expect(
+        nitroConfig.handlers?.some(
+          (handler) =>
+            typeof handler !== 'string' && handler.route === '/_analog/fn/:id',
+        ),
+      ).toBe(withServerFn);
+      expect(
+        JSON.stringify(nitroConfig.virtual).includes('@analogjs/router/server'),
+      ).toBe(withServerFn);
+      expect(
+        nitroConfig.moduleSideEffects?.includes('@angular/compiler') ?? false,
+      ).toBe(withServerFn);
+      expect(
+        nitroConfig.handlers?.some(
+          (handler) =>
+            typeof handler !== 'string' &&
+            handler.handler.includes('shipping/index.server.ts'),
+        ),
+      ).toBe(true);
+    },
+  );
 
   it('returns deterministic, de-duplicated, sorted output', () => {
     const first = getServerFnHandlers({ workspaceRoot, sourceRoot, rootDir });
@@ -127,7 +200,7 @@ describe('getServerFnHandlers', () => {
     mkdirSync(join(workspaceRoot, 'libs/shared/src'), { recursive: true });
     writeFileSync(
       join(workspaceRoot, 'libs/shared/src/reports.server.ts'),
-      `export const getReport = serverFn({ id: 'getReport' }, async () => ({}));`,
+      `import { serverFn } from '@analogjs/router/server'; export const getReport = serverFn({ id: 'getReport' }, async () => ({}));`,
     );
 
     const files = getServerFnHandlers({

--- a/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.spec.ts
@@ -125,6 +125,7 @@ describe('getServerFnHandlers', () => {
     `export const load = async () => ({});`,
     `// import { serverFn } from '@analogjs/router/server';
      export const load = async () => ({ text: 'serverFn' });`,
+    `import { serverFn } from '@analogjs/router/server'; export const load = async () => ({});`,
     `import { serverFn } from 'another-library'; export const load = async () => ({});`,
     `import type { serverFn } from '@analogjs/router/server'; export const load = async () => ({});`,
     `import { type serverFn } from '@analogjs/router/server'; export const load = async () => ({});`,

--- a/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { parseSync } from 'oxc-parser';
 import { resolve } from 'node:path';
 import { globSync } from 'tinyglobby';
 
@@ -37,7 +39,7 @@ const EXCLUDED_SERVER_FILES: RegExp[] = [/\/app\.config\.server\.ts$/];
  *
  * Scope is `<projectRoot>/<sourceRoot>/**\/*.server.ts` because the RFC allows a
  * server function to live in any `.server.ts` module, including existing page
- * server files. Files that define no server function simply register nothing.
+ * server files. Only modules importing the serverFn runtime API participate.
  * Angular SSR config (`app.config.server.ts`) is excluded — it is not a route or
  * function module and must not be pulled into the dispatch bundle.
  *
@@ -72,5 +74,27 @@ export function getServerFnHandlers({
     )
     .filter((file) => (seen.has(file) ? false : (seen.add(file), true)))
     .sort()
+    .filter(importsServerFn)
     .map((file) => ({ file }));
+}
+
+function importsServerFn(file: string): boolean {
+  const code = readFileSync(file, 'utf8');
+  if (!code.includes('serverFn')) return false;
+
+  const { program } = parseSync(file, code);
+  return program.body.some(
+    (node) =>
+      node.type === 'ImportDeclaration' &&
+      node.importKind !== 'type' &&
+      node.source.value === '@analogjs/router/server' &&
+      node.specifiers.some(
+        (specifier) =>
+          specifier.type === 'ImportSpecifier' &&
+          specifier.importKind !== 'type' &&
+          (specifier.imported.type === 'Identifier'
+            ? specifier.imported.name
+            : specifier.imported.value) === 'serverFn',
+      ),
+  );
 }

--- a/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.ts
@@ -117,6 +117,7 @@ function definesServerFn(file: string): boolean {
       node.declaration?.type === 'VariableDeclaration' &&
       node.declaration.declarations.some(
         (declarator) =>
+          declarator.id?.type === 'Identifier' &&
           declarator.init?.type === 'CallExpression' &&
           declarator.init.callee?.type === 'Identifier' &&
           localNames.has(declarator.init.callee.name),

--- a/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.ts
+++ b/packages/vite-plugin-nitro/src/lib/utils/get-server-fn-handlers.ts
@@ -39,7 +39,8 @@ const EXCLUDED_SERVER_FILES: RegExp[] = [/\/app\.config\.server\.ts$/];
  *
  * Scope is `<projectRoot>/<sourceRoot>/**\/*.server.ts` because the RFC allows a
  * server function to live in any `.server.ts` module, including existing page
- * server files. Only modules importing the serverFn runtime API participate.
+ * server files. Only modules defining a server function that the client
+ * transform can rewrite participate.
  * Angular SSR config (`app.config.server.ts`) is excluded — it is not a route or
  * function module and must not be pulled into the dispatch bundle.
  *
@@ -74,27 +75,51 @@ export function getServerFnHandlers({
     )
     .filter((file) => (seen.has(file) ? false : (seen.add(file), true)))
     .sort()
-    .filter(importsServerFn)
+    .filter(definesServerFn)
     .map((file) => ({ file }));
 }
 
-function importsServerFn(file: string): boolean {
+/**
+ * Match the client scrub's supported server-function declaration shape. The
+ * scrub deliberately falls back to the conventional `serverFn` name when the
+ * function is re-exported through a local barrel, so discovery must make the
+ * same choice or the browser receives a proxy without a dispatch route.
+ */
+function definesServerFn(file: string): boolean {
   const code = readFileSync(file, 'utf8');
   if (!code.includes('serverFn')) return false;
 
   const { program } = parseSync(file, code);
+  const localNames = new Set<string>();
+  for (const node of program.body) {
+    if (
+      node.type !== 'ImportDeclaration' ||
+      node.source.value !== '@analogjs/router/server'
+    ) {
+      continue;
+    }
+    for (const specifier of node.specifiers) {
+      if (
+        specifier.type === 'ImportSpecifier' &&
+        (specifier.imported.type === 'Identifier'
+          ? specifier.imported.name
+          : specifier.imported.value) === 'serverFn'
+      ) {
+        localNames.add(specifier.local.name);
+      }
+    }
+  }
+  if (localNames.size === 0) localNames.add('serverFn');
+
   return program.body.some(
     (node) =>
-      node.type === 'ImportDeclaration' &&
-      node.importKind !== 'type' &&
-      node.source.value === '@analogjs/router/server' &&
-      node.specifiers.some(
-        (specifier) =>
-          specifier.type === 'ImportSpecifier' &&
-          specifier.importKind !== 'type' &&
-          (specifier.imported.type === 'Identifier'
-            ? specifier.imported.name
-            : specifier.imported.value) === 'serverFn',
+      node.type === 'ExportNamedDeclaration' &&
+      node.declaration?.type === 'VariableDeclaration' &&
+      node.declaration.declarations.some(
+        (declarator) =>
+          declarator.init?.type === 'CallExpression' &&
+          declarator.init.callee?.type === 'Identifier' &&
+          localNames.has(declarator.init.callee.name),
       ),
   );
 }


### PR DESCRIPTION
Load-only applications no longer receive the server-function dispatch route and registration imports. Discovery now matches the exported `serverFn(...)` declaration shape the client scrub can proxy, including the conventional name imported through a local barrel.

## PR Checklist

Closes analogjs/analog#2496.

## Affected scope

- Primary scope: vite-plugin-nitro
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

No commit boundaries need preservation.

## What is the new behavior?

A page exporting only `load` still gets its page endpoint, but no longer enables `/_analog/fn/:id` or the generated module importing the server-function runtime. An exported supported server-function declaration enables them whether it imports `serverFn` directly, aliases the runtime import, or uses the conventional `serverFn` name re-exported through a local barrel. This preserves the client proxy/dispatch contract.

The Oxc AST excludes comments, strings, type-only usage with no declaration, and imports that are unused by a supported exported declaration. It deliberately follows the client transform's established fallback for a conventional `serverFn` identifier rather than evaluating application modules during configuration or attempting tree-shaking. That syntactic fallback preserves existing barrel and conventional-name compatibility across discovery, client scrubbing, and SSR id injection; it does not attempt to prove the identifier's ultimate binding origin.

## Test plan

- [x] Frozen installation using beta's pnpm 11.6.0 on Node 24.15.0.
- [x] Barrel regression failed on the prior PR head because no dispatch handler was registered, then passes with the repair.
- [x] `pnpm nx test vite-plugin-nitro` — 75 passed, 11 existing skips.
- [x] `pnpm nx build vite-plugin-nitro` — passed.
- [x] `pnpm nx lint vite-plugin-nitro` — passed with 29 pre-existing warnings and no errors.
- [x] Prettier on changed files and `git diff --check`.

Integration tests run the actual plugin configuration and Environment API build hook, capturing the configuration passed to Nitro's build boundary. They verify dispatch handlers and virtual registration imports are absent for load-only pages and present for direct, aliased, and barrel server functions, while the page endpoint remains in both cases. These are configuration tests, not a production bundle-size measurement.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Targets beta's existing Nitro integration. The native alpha HTTP work in [analogjs/analog#2529](https://github.com/analogjs/analog/pull/2529) explicitly leaves this legacy discovery issue separate.

## [optional] What gif best describes this PR or how it makes you feel?

Not applicable.
