### PR TITLE
fix(vite-plugin-angular): emit source-linked workspace packages

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1139,6 +1139,26 @@ export class AppComponent {}
       modules: [],
     });
     expect((await transform('directive.ts'))?.code).toContain('updated = 42');
+    const watchers = new Map<string, (file: string) => void>();
+    mainPlugin.configureServer({
+      watcher: {
+        on: (event: string, handler: (file: string) => void) =>
+          watchers.set(event, handler),
+      },
+    });
+    const barrel = normalizePath(path.join(libDir, 'index.ts'));
+    realFs.rmSync(barrel);
+    vi.useFakeTimers();
+    try {
+      watchers.get('unlink')!(barrel);
+      await vi.advanceTimersByTimeAsync(100);
+      await mainPlugin.buildStart.call(ctx);
+      expect(
+        await mainPlugin.transform.handler.call(ctx, '', barrel),
+      ).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
     expect(ctx.warn).not.toHaveBeenCalled();
   }, 60_000);
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1074,6 +1074,74 @@ export class AppComponent {}
     }
   }
 
+  it('emits source-linked workspace packages without an explicit include', async () => {
+    const libDir = path.join(fixtureDir, 'lib');
+    realFs.mkdirSync(libDir, { recursive: true });
+    realFs.mkdirSync(path.join(fixtureDir, 'node_modules'), {
+      recursive: true,
+    });
+    realFs.writeFileSync(
+      path.join(libDir, 'package.json'),
+      JSON.stringify({
+        name: 'linked-lib',
+        type: 'module',
+        exports: './index.ts',
+      }),
+    );
+    realFs.writeFileSync(
+      path.join(libDir, 'index.ts'),
+      "export { DemoDirective } from './directive';",
+    );
+    realFs.writeFileSync(
+      path.join(libDir, 'directive.ts'),
+      "import { Directive } from '@angular/core'; @Directive({ selector: '[demo]', standalone: true }) export class DemoDirective {}",
+    );
+    realFs.symlinkSync(
+      libDir,
+      path.join(fixtureDir, 'node_modules/linked-lib'),
+      'junction',
+    );
+    realFs.appendFileSync(
+      componentPath,
+      "\nexport { DemoDirective } from 'linked-lib';",
+    );
+    const mainPlugin = createAppBuildPlugin();
+    await mainPlugin.config(
+      { root: fixtureDir, build: {} },
+      { command: 'build' },
+    );
+    mainPlugin.configResolved({
+      root: fixtureDir,
+      mode: 'production',
+      build: {},
+      server: { watch: {} },
+      safeModulePaths: new Set(),
+    });
+    const ctx = { warn: vi.fn(), error: vi.fn(), addWatchFile: vi.fn() };
+    await mainPlugin.buildStart.call(ctx);
+    const transform = async (name: string) => {
+      const id = normalizePath(path.join(libDir, name));
+      return mainPlugin.transform.handler.call(
+        ctx,
+        realFs.readFileSync(id, 'utf8'),
+        id,
+      );
+    };
+    expect((await transform('index.ts'))?.code).toContain('DemoDirective');
+    expect((await transform('directive.ts'))?.code).toContain('ɵdir');
+    expect((await transform('index.ts'))?.code).toContain('DemoDirective');
+    realFs.appendFileSync(
+      path.join(libDir, 'directive.ts'),
+      '\nexport const updated = 42;',
+    );
+    await mainPlugin.handleHotUpdate({
+      file: normalizePath(path.join(libDir, 'directive.ts')),
+      modules: [],
+    });
+    expect((await transform('directive.ts'))?.code).toContain('updated = 42');
+    expect(ctx.warn).not.toHaveBeenCalled();
+  }, 60_000);
+
   it('waits for the initial compilation before emitting a transform result', async () => {
     const mainPlugin = createAppBuildPlugin();
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -3,6 +3,19 @@ import * as realFs from 'node:fs';
 import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { normalizePath, preprocessCSS } from 'vite';
+import { NgtscProgram } from '@angular/compiler-cli';
+
+vi.mock('@angular/compiler-cli', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@angular/compiler-cli')>();
+  return {
+    ...actual,
+    NgtscProgram: vi.fn(function (
+      ...args: ConstructorParameters<typeof actual.NgtscProgram>
+    ) {
+      return new actual.NgtscProgram(...args);
+    }),
+  };
+});
 
 vi.mock('vite', async () => {
   const actual = await vi.importActual<typeof import('vite')>('vite');
@@ -25,6 +38,7 @@ import {
   mapTemplateUpdatesToFiles,
   toAngularCompilationFileReplacements,
   isTestWatchMode,
+  type PluginOptions,
 } from './angular-vite-plugin';
 import type { EmitFileResult } from './models';
 
@@ -1056,7 +1070,7 @@ export class AppComponent {}
 
   // The plugin reads these at creation time to pick the AOT/JIT path, so an
   // app build has to be simulated by clearing Vitest's own markers.
-  function createAppBuildPlugin() {
+  function createAppBuildPlugin(options: PluginOptions = {}) {
     const { VITEST, NODE_ENV } = process.env;
     delete process.env['VITEST'];
     delete process.env['NODE_ENV'];
@@ -1065,6 +1079,7 @@ export class AppComponent {}
       return angular({
         tsconfig: path.join(fixtureDir, 'tsconfig.json'),
         workspaceRoot: fixtureDir,
+        ...options,
       }).find((p) => p.name === '@analogjs/vite-plugin-angular') as any;
     } finally {
       process.env['VITEST'] = VITEST as string;
@@ -1074,93 +1089,155 @@ export class AppComponent {}
     }
   }
 
-  it('emits source-linked workspace packages without an explicit include', async () => {
-    const libDir = path.join(fixtureDir, 'lib');
-    realFs.mkdirSync(libDir, { recursive: true });
-    realFs.mkdirSync(path.join(fixtureDir, 'node_modules'), {
-      recursive: true,
-    });
-    realFs.writeFileSync(
-      path.join(libDir, 'package.json'),
-      JSON.stringify({
-        name: 'linked-lib',
-        type: 'module',
-        exports: './index.ts',
-      }),
-    );
-    realFs.writeFileSync(
-      path.join(libDir, 'index.ts'),
-      "export { DemoDirective } from './directive';",
-    );
-    realFs.writeFileSync(
-      path.join(libDir, 'directive.ts'),
-      "import { Directive } from '@angular/core'; @Directive({ selector: '[demo]', standalone: true }) export class DemoDirective {}",
-    );
-    realFs.symlinkSync(
-      libDir,
-      path.join(fixtureDir, 'node_modules/linked-lib'),
-      'junction',
-    );
-    realFs.appendFileSync(
-      componentPath,
-      "\nexport { DemoDirective } from 'linked-lib';",
-    );
-    const mainPlugin = createAppBuildPlugin();
-    await mainPlugin.config(
-      { root: fixtureDir, build: {} },
-      { command: 'build' },
-    );
-    mainPlugin.configResolved({
-      root: fixtureDir,
-      mode: 'production',
-      build: {},
-      server: { watch: {} },
-      safeModulePaths: new Set(),
-    });
-    const ctx = { warn: vi.fn(), error: vi.fn(), addWatchFile: vi.fn() };
-    await mainPlugin.buildStart.call(ctx);
-    const transform = async (name: string) => {
-      const id = normalizePath(path.join(libDir, name));
-      return mainPlugin.transform.handler.call(
-        ctx,
-        realFs.readFileSync(id, 'utf8'),
-        id,
+  it.each([
+    { command: 'build', jit: false },
+    { command: 'serve', jit: false },
+    { command: 'build', jit: true },
+    { command: 'serve', jit: true },
+  ])(
+    'emits source-linked workspace packages in $command mode (jit=$jit)',
+    async ({ command, jit }) => {
+      const libDir = path.join(fixtureDir, 'lib');
+      realFs.mkdirSync(libDir, { recursive: true });
+      realFs.mkdirSync(path.join(fixtureDir, 'node_modules'), {
+        recursive: true,
+      });
+      realFs.writeFileSync(
+        path.join(libDir, 'package.json'),
+        JSON.stringify({
+          name: 'linked-lib',
+          type: 'module',
+          exports: {
+            '.': './index.ts',
+            './types': './types.d.ts',
+            './*': './*.ts',
+          },
+        }),
       );
-    };
-    expect((await transform('index.ts'))?.code).toContain('DemoDirective');
-    expect((await transform('directive.ts'))?.code).toContain('ɵdir');
-    expect((await transform('index.ts'))?.code).toContain('DemoDirective');
-    realFs.appendFileSync(
-      path.join(libDir, 'directive.ts'),
-      '\nexport const updated = 42;',
-    );
-    await mainPlugin.handleHotUpdate({
-      file: normalizePath(path.join(libDir, 'directive.ts')),
-      modules: [],
-    });
-    expect((await transform('directive.ts'))?.code).toContain('updated = 42');
-    const watchers = new Map<string, (file: string) => void>();
-    mainPlugin.configureServer({
-      watcher: {
-        on: (event: string, handler: (file: string) => void) =>
-          watchers.set(event, handler),
-      },
-    });
-    const barrel = normalizePath(path.join(libDir, 'index.ts'));
-    realFs.rmSync(barrel);
-    vi.useFakeTimers();
-    try {
-      watchers.get('unlink')!(barrel);
-      await vi.advanceTimersByTimeAsync(100);
+      realFs.writeFileSync(
+        path.join(libDir, 'index.ts'),
+        "export { DemoDirective } from './directive';",
+      );
+      realFs.writeFileSync(
+        path.join(libDir, 'directive.ts'),
+        "import { Directive } from '@angular/core'; @Directive({ selector: '[demo]', standalone: true }) export class DemoDirective {}",
+      );
+      const declarationPath = path.join(libDir, 'types.d.ts');
+      realFs.writeFileSync(
+        declarationPath,
+        'export interface LinkedType { value: string; }',
+      );
+      const installedDir = path.join(fixtureDir, 'node_modules/installed-lib');
+      realFs.mkdirSync(installedDir, { recursive: true });
+      realFs.writeFileSync(
+        path.join(installedDir, 'package.json'),
+        JSON.stringify({ name: 'installed-lib', exports: './index.ts' }),
+      );
+      const installedPath = path.join(installedDir, 'index.ts');
+      realFs.writeFileSync(installedPath, 'export const installed = 42;');
+      realFs.symlinkSync(
+        libDir,
+        path.join(fixtureDir, 'node_modules/linked-lib'),
+        'junction',
+      );
+      realFs.appendFileSync(
+        componentPath,
+        "\nexport { DemoDirective } from 'linked-lib';\nexport type { LinkedType } from 'linked-lib/types';\nexport { installed } from 'installed-lib';",
+      );
+      const entries = Array.from({ length: 8 }, (_, index) => `entry${index}`);
+      for (const entry of entries) {
+        realFs.writeFileSync(
+          path.join(libDir, `${entry}.ts`),
+          `export const ${entry} = 42;`,
+        );
+        realFs.appendFileSync(
+          componentPath,
+          `\nexport { ${entry} } from 'linked-lib/${entry}';`,
+        );
+      }
+      vi.mocked(NgtscProgram).mockClear();
+      const mainPlugin = createAppBuildPlugin({
+        disableTypeChecking: false,
+        jit,
+      });
+      await mainPlugin.config({ root: fixtureDir, build: {} }, { command });
+      mainPlugin.configResolved({
+        root: fixtureDir,
+        mode: 'production',
+        build: {},
+        server: { watch: {} },
+        safeModulePaths: new Set(),
+      });
+      const ctx = { warn: vi.fn(), error: vi.fn(), addWatchFile: vi.fn() };
       await mainPlugin.buildStart.call(ctx);
-      expect(
-        await mainPlugin.transform.handler.call(ctx, '', barrel),
-      ).toBeUndefined();
-    } finally {
-      vi.useRealTimers();
-    }
-    expect(ctx.warn).not.toHaveBeenCalled();
-  }, 60_000);
+      if (!jit) {
+        const program = vi
+          .mocked(NgtscProgram)
+          .mock.results[0].value.getTsProgram();
+        for (const externalPath of [declarationPath, installedPath]) {
+          const sourceFile = program.getSourceFile(normalizePath(externalPath));
+          expect(sourceFile).toBeDefined();
+          expect(program.isSourceFileFromExternalLibrary(sourceFile)).toBe(
+            true,
+          );
+        }
+      }
+      const transform = async (name: string) => {
+        const id = normalizePath(path.join(libDir, name));
+        return mainPlugin.transform.handler.call(
+          ctx,
+          realFs.readFileSync(id, 'utf8'),
+          id,
+        );
+      };
+      expect((await transform('index.ts'))?.code).toContain('DemoDirective');
+      expect((await transform('directive.ts'))?.code).toContain(
+        jit ? '__decorate' : 'ɵdir',
+      );
+      expect((await transform('index.ts'))?.code).toContain('DemoDirective');
+      const results = await Promise.all(
+        entries.map((entry) => transform(`${entry}.ts`)),
+      );
+      results.forEach((result, index) =>
+        expect(result?.code).toContain(`${entries[index]} = 42`),
+      );
+      expect(NgtscProgram).toHaveBeenCalledTimes(jit ? 0 : 1);
+      realFs.appendFileSync(
+        path.join(libDir, 'directive.ts'),
+        '\nexport const updated = 42;',
+      );
+      await mainPlugin.handleHotUpdate({
+        file: normalizePath(path.join(libDir, 'directive.ts')),
+        modules: [],
+      });
+      expect((await transform('directive.ts'))?.code).toContain('updated = 42');
+      expect(NgtscProgram).toHaveBeenCalledTimes(jit ? 0 : 2);
+      mainPlugin.buildEnd.call(ctx);
+      expect(ctx.error).not.toHaveBeenCalled();
+      const watchers = new Map<string, (file: string) => void>();
+      mainPlugin.configureServer({
+        watcher: {
+          on: (event: string, handler: (file: string) => void) =>
+            watchers.set(event, handler),
+        },
+      });
+      const barrel = normalizePath(path.join(libDir, 'index.ts'));
+      realFs.rmSync(barrel);
+      vi.useFakeTimers();
+      try {
+        watchers.get('unlink')!(barrel);
+        await vi.advanceTimersByTimeAsync(100);
+        await mainPlugin.buildStart.call(ctx);
+        expect(
+          await mainPlugin.transform.handler.call(ctx, '', barrel),
+        ).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+      expect(ctx.warn).not.toHaveBeenCalled();
+    },
+    60_000,
+  );
 
   it('waits for the initial compilation before emitting a transform result', async () => {
     const mainPlugin = createAppBuildPlugin();

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -33,6 +33,7 @@ import {
 } from './component-resolvers.js';
 import {
   augmentHostWithCaching,
+  augmentHostWithModuleResolution,
   augmentHostWithResources,
   augmentProgramWithVersioning,
   mergeTransformers,
@@ -77,6 +78,7 @@ import { fastCompilePlugin } from './fast-compile-plugin.js';
 import { ANGULAR_DECORATOR_CALL_RE } from './compiler/index.js';
 import {
   TS_EXT_REGEX,
+  EXCLUDED_TS_EXT_REGEX,
   createTsConfigGetter,
   getTsConfigPath,
   createDepOptimizerConfig,
@@ -1387,55 +1389,7 @@ export function angular(options?: PluginOptions): Plugin[] {
           return file;
         },
       });
-      const resolutionCache = ts.createModuleResolutionCache(
-        host.getCurrentDirectory(),
-        host.getCanonicalFileName.bind(host),
-        tsCompilerOptions,
-      );
-      host.getModuleResolutionCache = () => resolutionCache;
-      host.resolveModuleNameLiterals = (
-        literals,
-        containingFile,
-        redirectedReference,
-        compilerOptions,
-        containingSourceFile,
-      ) =>
-        literals.map((literal) => {
-          const resolution: ts.ResolvedModuleWithFailedLookupLocations =
-            ts.resolveModuleName(
-              literal.text,
-              containingFile,
-              compilerOptions,
-              host,
-              resolutionCache,
-              redirectedReference,
-              ts.getModeForUsageLocation(
-                containingSourceFile,
-                literal,
-                compilerOptions,
-              ),
-            );
-          const resolvedModule = resolution.resolvedModule;
-          if (
-            resolvedModule?.isExternalLibraryImport &&
-            TS_EXT_REGEX.test(resolvedModule.resolvedFileName) &&
-            !EXCLUDED_TS_EXT_REGEX.test(resolvedModule.resolvedFileName) &&
-            !normalizePath(resolvedModule.resolvedFileName).includes(
-              '/node_modules/',
-            )
-          ) {
-            // A workspace symlink resolves to source outside node_modules.
-            // Classify it before program creation so TypeScript emits it.
-            return {
-              ...resolution,
-              resolvedModule: {
-                ...resolvedModule,
-                isExternalLibraryImport: false,
-              },
-            };
-          }
-          return resolution;
-        });
+      augmentHostWithModuleResolution(host, tsCompilerOptions);
       cachedHost = host;
       cachedHostKey = hostKey;
 
@@ -1718,9 +1672,6 @@ export function angular(options?: PluginOptions): Plugin[] {
 }
 
 const COMPONENT_RESOURCE_EXT_REGEX = /\.(html|htm|css|scss|sass|less)$/;
-// Spec files stay included — a newly added spec must join the program's
-// root names in Vitest watch mode.
-const EXCLUDED_TS_EXT_REGEX = /\.d\.[cm]?ts$/;
 
 export function createFsWatcherCacheInvalidator(
   invalidateFsCaches: () => void,

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -211,6 +211,7 @@ export function angular(options?: PluginOptions): Plugin[] {
   let cachedHost: ts.CompilerHost | undefined;
   let cachedHostKey: string | undefined;
   let includeCache: string[] = [];
+  const linkedSourceRoots = new Set<string>();
   function invalidateFsCaches() {
     includeCache = [];
   }
@@ -380,6 +381,7 @@ export function angular(options?: PluginOptions): Plugin[] {
         server.watcher.on('unlink', invalidateCompilationOnFsChange);
         server.watcher.on('change', (file) => {
           if (file.includes('tsconfig')) {
+            linkedSourceRoots.clear();
             invalidateTsconfigCaches();
           }
         });
@@ -733,7 +735,22 @@ export function angular(options?: PluginOptions): Plugin[] {
             pendingCompilation = null;
           }
 
-          const typescriptResult = fileEmitter(id);
+          let typescriptResult = fileEmitter(id);
+          const sourceFile = builder?.getSourceFile(id);
+          if (
+            typescriptResult?.content === '' &&
+            sourceFile &&
+            builder!.getProgram().isSourceFileFromExternalLibrary(sourceFile) &&
+            !linkedSourceRoots.has(normalizePath(sourceFile.fileName))
+          ) {
+            // TypeScript skips emit for source-linked package entries until
+            // they are roots. Only promote files requested by Vite.
+            linkedSourceRoots.add(normalizePath(sourceFile.fileName));
+            pendingCompilation = performCompilation(resolvedConfig, [id]);
+            await pendingCompilation;
+            pendingCompilation = null;
+            typescriptResult = fileEmitter(id);
+          }
 
           // File not in the Angular program — skip and let other plugins
           // or Vite's built-in transform handle it. Warn if it looks like
@@ -1278,7 +1295,14 @@ export function angular(options?: PluginOptions): Plugin[] {
       ),
     );
     // Merge + dedupe root names
-    rootNames = [...new Set([...rootNames, ...includeCache, ...replacements])];
+    rootNames = [
+      ...new Set([
+        ...rootNames,
+        ...includeCache,
+        ...replacements,
+        ...linkedSourceRoots,
+      ]),
+    ];
     const hostKey = JSON.stringify(tsCompilerOptions);
     let host: ts.CompilerHost;
 

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -377,8 +377,20 @@ export function angular(options?: PluginOptions): Plugin[] {
               `${normalizePath(resolve(pluginOptions.workspaceRoot))}${glob}`,
           ),
         );
-        server.watcher.on('add', invalidateCompilationOnFsChange);
-        server.watcher.on('unlink', invalidateCompilationOnFsChange);
+        server.watcher.on('add', (file) => {
+          if (basename(file).includes('tsconfig')) linkedSourceRoots.clear();
+          invalidateCompilationOnFsChange(file);
+        });
+        server.watcher.on('unlink', (file) => {
+          const id = normalizePath(file);
+          if (linkedSourceRoots.delete(id)) {
+            outputFiles.delete(id);
+            fileTransformMap.delete(id);
+            sourceFileCache.delete(id);
+          }
+          if (basename(file).includes('tsconfig')) linkedSourceRoots.clear();
+          invalidateCompilationOnFsChange(file);
+        });
         server.watcher.on('change', (file) => {
           if (file.includes('tsconfig')) {
             linkedSourceRoots.clear();

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -211,7 +211,6 @@ export function angular(options?: PluginOptions): Plugin[] {
   let cachedHost: ts.CompilerHost | undefined;
   let cachedHostKey: string | undefined;
   let includeCache: string[] = [];
-  const linkedSourceRoots = new Set<string>();
   function invalidateFsCaches() {
     includeCache = [];
   }
@@ -377,23 +376,16 @@ export function angular(options?: PluginOptions): Plugin[] {
               `${normalizePath(resolve(pluginOptions.workspaceRoot))}${glob}`,
           ),
         );
-        server.watcher.on('add', (file) => {
-          if (basename(file).includes('tsconfig')) linkedSourceRoots.clear();
-          invalidateCompilationOnFsChange(file);
-        });
+        server.watcher.on('add', invalidateCompilationOnFsChange);
         server.watcher.on('unlink', (file) => {
           const id = normalizePath(file);
-          if (linkedSourceRoots.delete(id)) {
-            outputFiles.delete(id);
-            fileTransformMap.delete(id);
-            sourceFileCache.delete(id);
-          }
-          if (basename(file).includes('tsconfig')) linkedSourceRoots.clear();
+          outputFiles.delete(id);
+          fileTransformMap.delete(id);
+          sourceFileCache.delete(id);
           invalidateCompilationOnFsChange(file);
         });
         server.watcher.on('change', (file) => {
           if (file.includes('tsconfig')) {
-            linkedSourceRoots.clear();
             invalidateTsconfigCaches();
           }
         });
@@ -747,22 +739,7 @@ export function angular(options?: PluginOptions): Plugin[] {
             pendingCompilation = null;
           }
 
-          let typescriptResult = fileEmitter(id);
-          const sourceFile = builder?.getSourceFile(id);
-          if (
-            typescriptResult?.content === '' &&
-            sourceFile &&
-            builder!.getProgram().isSourceFileFromExternalLibrary(sourceFile) &&
-            !linkedSourceRoots.has(normalizePath(sourceFile.fileName))
-          ) {
-            // TypeScript skips emit for source-linked package entries until
-            // they are roots. Only promote files requested by Vite.
-            linkedSourceRoots.add(normalizePath(sourceFile.fileName));
-            pendingCompilation = performCompilation(resolvedConfig, [id]);
-            await pendingCompilation;
-            pendingCompilation = null;
-            typescriptResult = fileEmitter(id);
-          }
+          const typescriptResult = fileEmitter(id);
 
           // File not in the Angular program — skip and let other plugins
           // or Vite's built-in transform handle it. Warn if it looks like
@@ -1307,14 +1284,7 @@ export function angular(options?: PluginOptions): Plugin[] {
       ),
     );
     // Merge + dedupe root names
-    rootNames = [
-      ...new Set([
-        ...rootNames,
-        ...includeCache,
-        ...replacements,
-        ...linkedSourceRoots,
-      ]),
-    ];
+    rootNames = [...new Set([...rootNames, ...includeCache, ...replacements])];
     const hostKey = JSON.stringify(tsCompilerOptions);
     let host: ts.CompilerHost;
 
@@ -1337,6 +1307,55 @@ export function angular(options?: PluginOptions): Plugin[] {
           return file;
         },
       });
+      const resolutionCache = ts.createModuleResolutionCache(
+        host.getCurrentDirectory(),
+        host.getCanonicalFileName.bind(host),
+        tsCompilerOptions,
+      );
+      host.getModuleResolutionCache = () => resolutionCache;
+      host.resolveModuleNameLiterals = (
+        literals,
+        containingFile,
+        redirectedReference,
+        compilerOptions,
+        containingSourceFile,
+      ) =>
+        literals.map((literal) => {
+          const resolution: ts.ResolvedModuleWithFailedLookupLocations =
+            ts.resolveModuleName(
+              literal.text,
+              containingFile,
+              compilerOptions,
+              host,
+              resolutionCache,
+              redirectedReference,
+              ts.getModeForUsageLocation(
+                containingSourceFile,
+                literal,
+                compilerOptions,
+              ),
+            );
+          const resolvedModule = resolution.resolvedModule;
+          if (
+            resolvedModule?.isExternalLibraryImport &&
+            TS_EXT_REGEX.test(resolvedModule.resolvedFileName) &&
+            !EXCLUDED_TS_EXT_REGEX.test(resolvedModule.resolvedFileName) &&
+            !normalizePath(resolvedModule.resolvedFileName).includes(
+              '/node_modules/',
+            )
+          ) {
+            // A workspace symlink resolves to source outside node_modules.
+            // Classify it before program creation so TypeScript emits it.
+            return {
+              ...resolution,
+              resolvedModule: {
+                ...resolvedModule,
+                isExternalLibraryImport: false,
+              },
+            };
+          }
+          return resolution;
+        });
       cachedHost = host;
       cachedHostKey = hostKey;
 

--- a/packages/vite-plugin-angular/src/lib/host.ts
+++ b/packages/vite-plugin-angular/src/lib/host.ts
@@ -6,6 +6,62 @@ import * as ts from 'typescript';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import type { SourceFileCache } from './utils/source-file-cache.js';
+import { EXCLUDED_TS_EXT_REGEX, TS_EXT_REGEX } from './utils/plugin-config.js';
+
+export function augmentHostWithModuleResolution(
+  host: ts.CompilerHost,
+  options: ts.CompilerOptions,
+): void {
+  const resolutionCache = ts.createModuleResolutionCache(
+    host.getCurrentDirectory(),
+    host.getCanonicalFileName.bind(host),
+    options,
+  );
+  host.getModuleResolutionCache = () => resolutionCache;
+  host.resolveModuleNameLiterals = (
+    literals,
+    containingFile,
+    redirectedReference,
+    compilerOptions,
+    containingSourceFile,
+  ) =>
+    literals.map((literal) => {
+      const resolution: ts.ResolvedModuleWithFailedLookupLocations =
+        ts.resolveModuleName(
+          literal.text,
+          containingFile,
+          compilerOptions,
+          host,
+          resolutionCache,
+          redirectedReference,
+          ts.getModeForUsageLocation(
+            containingSourceFile,
+            literal,
+            compilerOptions,
+          ),
+        );
+      const resolvedModule = resolution.resolvedModule;
+      if (
+        resolvedModule?.isExternalLibraryImport &&
+        TS_EXT_REGEX.test(resolvedModule.resolvedFileName) &&
+        !EXCLUDED_TS_EXT_REGEX.test(resolvedModule.resolvedFileName) &&
+        !normalizePath(resolvedModule.resolvedFileName).includes(
+          '/node_modules/',
+        )
+      ) {
+        // A workspace symlink resolves to source outside node_modules.
+        // Classify it before program creation so TypeScript emits it.
+        return {
+          ...resolution,
+          resolvedModule: {
+            ...resolvedModule,
+            isExternalLibraryImport: false,
+          },
+        };
+      }
+      return resolution;
+    });
+}
 
 export function augmentHostWithResources(
   host: ts.CompilerHost,

--- a/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
+++ b/packages/vite-plugin-angular/src/lib/utils/plugin-config.ts
@@ -26,6 +26,10 @@ import {
  */
 export const TS_EXT_REGEX = /\.[cm]?ts(?![a-z])/;
 
+// Spec files stay included — a newly added spec must join the program's
+// root names in Vitest watch mode.
+export const EXCLUDED_TS_EXT_REGEX = /\.d\.[cm]?ts$/;
+
 /**
  * Resolves whether Angular should be compiled for production. An explicit
  * `development` mode wins over an ambient production `NODE_ENV` (e.g. set by


### PR DESCRIPTION
Fix empty output for source-linked pnpm workspace packages in the normal Angular compiler. When TypeScript skips an external-classified source requested by Vite, promote that source to a compilation root and retry the normal Angular emit.

## PR Checklist

Closes analogjs/analog#2507.

## Affected scope

- Primary scope: vite-plugin-angular
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

No commit boundaries need preservation.

## What is the new behavior?

A pnpm workspace library exporting a TypeScript barrel now builds with `angular()` without requiring a manual `include` glob. TypeScript previously classified the real linked source as external and skipped its emit, so Vite received an empty module and reported missing exports.

The retry only applies to an empty result whose source TypeScript identifies as external. Roots are deduplicated and retained for incremental recompilation; tsconfig change/add/unlink events clear the discovered roots, and unlinking a promoted source removes its root and cached output. Emission continues through Angular's existing serialized compilation path and its transformers. Existing node_modules filters, fastCompile, explicit includes, and missing-file fallbacks are unchanged.

## Test plan

- [x] Frozen dependency installation, pnpm 11.6.0 on Node 24.15.0.
- [x] New real-compiler regression fails before the fix with an empty linked barrel.
- [x] `pnpm nx test vite-plugin-angular` — 721 passed, 6 existing skips.
- [x] `pnpm nx build vite-plugin-angular` — passed.
- [x] Packed the built plugin and installed it in the [reporter's reproduction](https://github.com/eblocha/analogjs-vite-plugin-angular-repro). `pnpm run build` now passes: 245 modules on Angular 21.2.22, TypeScript 5.9.3, and Vite 8.2.2, with no `include` workaround. The original dependency reproduced the missing `DemoDirective` export.
- [x] Prettier on changed files and `git diff --check`.

The regression uses an actual symlinked package with a TypeScript export, checks both its barrel and compiled Angular directive, repeats the barrel transform, verifies an edit to the directive survives incremental recompilation, then unlinks the barrel and checks that the next compilation cannot return stale output. The unlink regression also fails against the implementation before the cleanup fix.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Targets beta. [analogjs/analog#2520](https://github.com/analogjs/analog/pull/2520) refactors alpha's compiler roots but does not address TypeScript's external-source emit classification. This fix should be adapted to that refactor when ported to alpha; no changes are made to its branch here.

## [optional] What gif best describes this PR or how it makes you feel?

Not applicable.
