### PR TITLE
docs(platform): publish the v2 migration guide on beta

### DIFF
--- a/apps/docs-analog/src/app/sidebar.ts
+++ b/apps/docs-analog/src/app/sidebar.ts
@@ -205,6 +205,11 @@ export function getSidebar(): SidebarNode[] {
         },
         {
           kind: 'doc',
+          id: 'guides/migrating-v1-to-v2',
+          label: $localize`:@@sidebar.migrating-v1-to-v2:Migrating from Analog v1 to v2`,
+        },
+        {
+          kind: 'doc',
           id: 'guides/libraries',
           label: $localize`:@@sidebar.libraries:Building an Angular library`,
         },

--- a/apps/docs-analog/src/content/features/updating/overview.md
+++ b/apps/docs-analog/src/content/features/updating/overview.md
@@ -1,5 +1,7 @@
 # Updating to the latest version
 
+For an existing Analog v1 app, follow the [Analog v1 to v2 migration guide](/docs/guides/migrating-v1-to-v2).
+
 You can use the `ng update` command for an Angular CLI workspace, or the `nx migrate` command for updating within an Nx workspace.
 
 <Tabs groupId="app-upgrader">

--- a/apps/docs-analog/src/content/guides/migrating-v1-to-v2.md
+++ b/apps/docs-analog/src/content/guides/migrating-v1-to-v2.md
@@ -2,6 +2,12 @@
 
 This guide updates an existing Analog v1 application to the Analog v2 release line. To migrate a plain Angular application, use the [Angular application migration guide](/docs/guides/migrating).
 
+## Check prerequisites
+
+Analog v2 requires Angular 17 or newer and Vite 6 or newer. Upgrade Angular 16 applications before updating Analog, and use the Node.js and TypeScript versions supported by your chosen Angular version. Keep the Angular packages in your workspace on matching versions.
+
+For `@analogjs/astro-angular`, Angular 20 or newer is required. The integration enables zoneless change detection for both server rendering and browser hydration. Components should notify Angular of updates through signals, template event listeners, the async pipe, or `ChangeDetectorRef.markForCheck()`. Check asynchronous updates that previously relied on Zone.js, and remove `zone.js` imports from the Astro integration's bootstrap setup.
+
 ## Update the workspace packages
 
 Use the standard Analog update flow for your workspace type, but target the v2 major:
@@ -29,11 +35,40 @@ nx migrate @analogjs/platform@2
 If your app imports from internal paths such as `@analogjs/content/lib`, switch those imports to the public `@analogjs/content` entrypoint.
 
 ```ts
-import { ContentRenderer, type TableOfContentItem } from '@analogjs/content';
+import { ContentRenderer } from '@analogjs/content';
+
+type TableOfContentItem = ReturnType<
+  ContentRenderer['getContentHeadings']
+>[number];
 ```
+
+The v2 package does not export `TableOfContentItem` by name. If you need that type, derive it from the public renderer method as shown above instead of importing an internal file.
+
+## Configure content highlighting
+
+If your application uses content rendering with syntax highlighting, configure the content package in the `analog` Vite plugin as well as the application's providers. In v2, the package is externalized unless content support is configured.
+
+For an existing Prism setup, replace `analog()` with:
+
+```ts
+import analog from '@analogjs/platform';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [
+    analog({
+      content: {
+        highlighter: 'prism',
+      },
+    }),
+  ],
+});
+```
+
+Keep your other Vite options and application providers. The application should register `provideContent(withMarkdownRenderer(), withPrismHighlighter())`, importing `provideContent` and `withMarkdownRenderer` from `@analogjs/content` and `withPrismHighlighter` from `@analogjs/content/prism-highlighter`. See [content routes](/docs/features/routing/content) for the corresponding stylesheet and Shiki configuration.
 
 ## Verify the migration
 
 Review the generated dependency and source changes, install dependencies with your workspace's package manager, and run any generated migrations. For Nx workspaces, run `nx migrate --run-migrations` if the update created a `migrations.json` file.
 
-Build and test your application, including server rendering and content pages. Keep content rendering, markdown helpers, and table-of-contents usage on the public package entrypoints.
+Build and test your application, including server rendering, content highlighting, and table-of-contents navigation. For Astro integrations, also test hydration and asynchronous component updates. Keep content rendering and markdown helpers on the public package entrypoints.

--- a/apps/docs-analog/src/content/guides/migrating-v1-to-v2.md
+++ b/apps/docs-analog/src/content/guides/migrating-v1-to-v2.md
@@ -1,0 +1,39 @@
+# Migrating from Analog v1 to v2
+
+This guide updates an existing Analog v1 application to the Analog v2 release line. To migrate a plain Angular application, use the [Angular application migration guide](/docs/guides/migrating).
+
+## Update the workspace packages
+
+Use the standard Analog update flow for your workspace type, but target the v2 major:
+
+<Tabs groupId="app-upgrader">
+  <TabItem label="ng update" value="ng-update">
+
+```shell
+ng update @analogjs/platform@2
+```
+
+  </TabItem>
+
+  <TabItem label="Nx migrate" value="nx-migrate">
+
+```shell
+nx migrate @analogjs/platform@2
+```
+
+  </TabItem>
+</Tabs>
+
+## Replace internal content imports
+
+If your app imports from internal paths such as `@analogjs/content/lib`, switch those imports to the public `@analogjs/content` entrypoint.
+
+```ts
+import { ContentRenderer, type TableOfContentItem } from '@analogjs/content';
+```
+
+## Verify the migration
+
+Review the generated dependency and source changes, install dependencies with your workspace's package manager, and run any generated migrations. For Nx workspaces, run `nx migrate --run-migrations` if the update created a `migrations.json` file.
+
+Build and test your application, including server rendering and content pages. Keep content rendering, markdown helpers, and table-of-contents usage on the public package entrypoints.

--- a/apps/docs-analog/src/i18n/de.json
+++ b/apps/docs-analog/src/i18n/de.json
@@ -61,6 +61,7 @@
   "sidebar.updating": "Aktualisieren",
   "sidebar.guides": "Anleitungen",
   "sidebar.migrating": "Eine Angular-App zu Analog migrieren",
+  "sidebar.migrating-v1-to-v2": "Von Analog v1 zu v2 migrieren",
   "sidebar.libraries": "Eine Angular-Library bauen",
   "sidebar.angular-compilation": "Angular-Kompilierung",
   "sidebar.compatibility": "Versionskompatibilität",

--- a/apps/docs-analog/src/i18n/es.json
+++ b/apps/docs-analog/src/i18n/es.json
@@ -61,6 +61,7 @@
   "sidebar.updating": "Actualización",
   "sidebar.guides": "Guías",
   "sidebar.migrating": "Migrar una app de Angular a Analog",
+  "sidebar.migrating-v1-to-v2": "Migrar de Analog v1 a v2",
   "sidebar.libraries": "Crear una librería de Angular",
   "sidebar.angular-compilation": "Compilación de Angular",
   "sidebar.compatibility": "Compatibilidad de versiones",

--- a/apps/docs-analog/src/i18n/pt-br.json
+++ b/apps/docs-analog/src/i18n/pt-br.json
@@ -61,6 +61,7 @@
   "sidebar.updating": "Atualizando",
   "sidebar.guides": "Guias",
   "sidebar.migrating": "Migrar um app Angular para Analog",
+  "sidebar.migrating-v1-to-v2": "Migrar do Analog v1 para v2",
   "sidebar.libraries": "Criar uma biblioteca Angular",
   "sidebar.angular-compilation": "Compilação Angular",
   "sidebar.compatibility": "Compatibilidade de versões",

--- a/apps/docs-analog/src/i18n/zh-hans.json
+++ b/apps/docs-analog/src/i18n/zh-hans.json
@@ -61,6 +61,7 @@
   "sidebar.updating": "更新",
   "sidebar.guides": "指南",
   "sidebar.migrating": "将 Angular 应用迁移到 Analog",
+  "sidebar.migrating-v1-to-v2": "从 Analog v1 迁移到 v2",
   "sidebar.libraries": "构建 Angular 库",
   "sidebar.angular-compilation": "Angular 编译",
   "sidebar.compatibility": "版本兼容性",


### PR DESCRIPTION
Publish the Analog v1-to-v2 migration guide on beta, with supported-version prerequisites, public content imports, highlighting configuration and Astro zoneless checks. Make it discoverable from Updating and the sidebar; the earlier guide landed only on alpha.

## PR Checklist

Closes analogjs/analog#1939.

## Affected scope

- Primary scope: platform
- Secondary scopes: docs

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

No commit boundaries need preservation.

## What is the new behavior?

An Analog 1 user can find major-pinned `ng update` / `nx migrate` commands and the public content-entrypoint migration in the current beta documentation. The guide distinguishes upgrading Analog from migrating a plain Angular app, and includes installation, generated-migration and build/test verification steps.

Adapted from the guide introduced on alpha in [analogjs/analog#2240](https://github.com/analogjs/analog/pull/2240). Removed legacy Docusaurus imports and the link to a v3 guide that does not exist on beta. Added sidebar labels in all four existing translation catalogs.

## Test plan

- [x] Frozen dependency installation.
- [x] `pnpm nx build docs-analog` — passed, zero broken links reported.
- [x] Inspected the prerendered guide for the v2 update commands and migration steps, and verified legacy MDX imports are absent.
- [x] Compiled the documented content import, derived table-of-contents type and Prism providers against the built beta package using TypeScript.
- [x] Prettier and `git diff --check`.

Existing localized prerender redirect warnings remain in the build log. The prerequisites were checked against the v2.0.0 release notes and beta package sources. This guide does not claim a fresh end-to-end migration of every historical v1 application.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Targets beta. No v3 runtime or support changes are included.

## [optional] What gif best describes this PR or how it makes you feel?

Not applicable.

