### PR TITLE
fix(vite-plugin-nitro): trace TypeScript server imports without bundling

### DIFF
--- a/packages/vite-plugin-nitro/src/lib/typescript-externals.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/typescript-externals.spec.ts
@@ -45,7 +45,7 @@ describe('TypeScript server externalization', () => {
       options: { node: true, externals: config.externals },
       hooks: { hook },
     };
-    await (config.modules![0] as Function)(instance);
+    await (config.modules![0] as (nitro: typeof instance) => void)(instance);
     const existing = { name: 'consumer-plugin' };
     const rollup = { plugins: [existing] };
     await hook.mock.calls[0][1](instance, rollup);
@@ -78,7 +78,7 @@ describe('TypeScript server externalization', () => {
         options: { ...options, externals: config.externals },
         hooks: { hook },
       };
-      await (config.modules![0] as Function)(instance);
+      await (config.modules![0] as (nitro: typeof instance) => void)(instance);
       const rollup = { plugins: [] };
       await hook.mock.calls[0][1](instance, rollup);
       expect(rollup.plugins).toEqual([]);

--- a/packages/vite-plugin-nitro/src/lib/typescript-externals.spec.ts
+++ b/packages/vite-plugin-nitro/src/lib/typescript-externals.spec.ts
@@ -1,0 +1,88 @@
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { nitro } from './vite-plugin-nitro';
+import { buildServer } from './build-server';
+
+vi.mock('./build-server');
+vi.mock('node:os', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:os')>()),
+  platform: () => 'win32',
+}));
+
+async function configure(ssr = false) {
+  const userHook = vi.fn();
+  const external = vi.fn(() => false);
+  const plugin = nitro(
+    {
+      ssr: false,
+    },
+    { hooks: { 'rollup:before': userHook }, rollupConfig: { external } },
+  )[1] as any;
+  const config = await plugin.config(
+    { root: process.cwd(), build: { ssr } },
+    { command: 'build' },
+  );
+  await config.builder.buildApp({
+    build: vi.fn(),
+    environments: { client: {} },
+  });
+  return {
+    config: vi.mocked(buildServer).mock.calls.at(-1)![1],
+    userHook,
+    external,
+  };
+}
+
+describe('TypeScript server externalization', () => {
+  it('traces the application compiler only when imported, without replacing user hooks or external rules', async () => {
+    const { config, userHook, external } = await configure();
+    expect(config.externals?.traceInclude).toEqual([]);
+    expect(config.hooks?.['rollup:before']).toBe(userHook);
+    expect(config.rollupConfig?.external).toBe(external);
+    const hook = vi.fn();
+    const instance = {
+      options: { node: true, externals: config.externals },
+      hooks: { hook },
+    };
+    await (config.modules![0] as Function)(instance);
+    const existing = { name: 'consumer-plugin' };
+    const rollup = { plugins: [existing] };
+    await hook.mock.calls[0][1](instance, rollup);
+    const resolver = (rollup.plugins[0] as any).resolveId;
+    expect(resolver('rxjs')).toBeNull();
+    expect(config.externals?.traceInclude).toEqual([]);
+    expect(resolver('typescript')).toEqual({
+      id: 'typescript',
+      external: true,
+    });
+    resolver('typescript');
+    expect(config.externals?.traceInclude).toEqual([
+      createRequire(resolve('package.json')).resolve('typescript'),
+    ]);
+    expect(rollup.plugins[1]).toEqual([existing]);
+  });
+
+  it('preserves tracing initialization for Windows SSR builds', async () => {
+    const { config } = await configure(true);
+    expect(config.externals?.inline).toContain('std-env');
+    expect(config.externals?.traceInclude).toEqual([]);
+  });
+
+  it.each([{ node: false }, { node: true, noExternals: true }])(
+    'retains bundling for %j',
+    async (options) => {
+      const { config } = await configure();
+      const hook = vi.fn();
+      const instance = {
+        options: { ...options, externals: config.externals },
+        hooks: { hook },
+      };
+      await (config.modules![0] as Function)(instance);
+      const rollup = { plugins: [] };
+      await hook.mock.calls[0][1](instance, rollup);
+      expect(rollup.plugins).toEqual([]);
+      expect(config.externals?.traceInclude).toEqual([]);
+    },
+  );
+});

--- a/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
+++ b/packages/vite-plugin-nitro/src/lib/vite-plugin-nitro.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { platform } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 
 import { buildServer } from './build-server.js';
 import { buildSSRApp } from './build-ssr.js';
@@ -189,6 +190,32 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
                 ],
               }
             : {}),
+          modules: [
+            (nitro) => {
+              nitro.hooks.hook('rollup:before', (_nitro, rollupConfig) => {
+                if (!nitro.options.node || nitro.options.noExternals) return;
+                rollupConfig.plugins = [
+                  {
+                    name: 'analog-typescript-external',
+                    resolveId(source) {
+                      if (source !== 'typescript') return null;
+                      const entry = createRequire(
+                        resolve(workspaceRoot, rootDir, 'package.json'),
+                      ).resolve(source);
+                      // Nitro retains this array for tracing. Add the compiler
+                      // only when imported, including in relocated deployments.
+                      const traceInclude =
+                        nitro.options.externals.traceInclude!;
+                      if (!traceInclude.includes(entry))
+                        traceInclude.push(entry);
+                      return { id: source, external: true };
+                    },
+                  },
+                  rollupConfig.plugins,
+                ];
+              });
+            },
+          ],
           rollupConfig: {
             onwarn(warning) {
               if (
@@ -439,6 +466,8 @@ export function nitro(options?: Options, nitroOptions?: NitroConfig): Plugin[] {
           nitroConfig,
           nitroOptions as Record<string, any>,
         );
+        nitroConfig.externals ??= {};
+        nitroConfig.externals.traceInclude ??= [];
 
         return {
           environments: {


### PR DESCRIPTION
Keep Node server routes importing `typescript` executable in development and deployed output. Externalize the compiler only when it is imported, and let Nitro trace it into the deployment's dependencies.

## PR Checklist

Closes analogjs/analog#2457.

## Affected scope

- Primary scope: vite-plugin-nitro
- Secondary scopes: none

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

No commit boundaries need preservation.

## What is the new behavior?

A Node API route using `await import('typescript')` retains that bare import. Previously Nitro bundled TypeScript's CommonJS runtime into an ESM chunk that failed on `__filename`; the reported dev initialization failure also reproduces in Nitro 2.

A small Nitro module registers a resolver before Nitro's default resolver and adds the application's resolved compiler entry to Nitro's existing trace list only when imported. This preserves deployment packaging, unlike a top-level Rollup external rule alone. Applications that do not import TypeScript receive no compiler payload. Non-Node and `noExternals` configurations retain their existing behavior.

User Rollup external rules and hooks are preserved. Trace initialization occurs after the final config merge, including the Windows SSR externals branch.

## Test plan

- [x] Frozen install and `pnpm nx build vite-plugin-nitro`.
- [x] `pnpm nx test vite-plugin-nitro` — 70 passed, 11 existing skips.
- [x] Reproduced the original runtime error with plain Nitro 2.13.4 / TypeScript 6.0.3.
- [x] Qualified the rebuilt plugin artifact through a real Vite 8 / Nitro 2 fixture: a dev GET and production GET both return TypeScript 6.0.3.
- [x] Relocated the built server outside the app's dependency tree; GET still succeeds. Output includes the traced TypeScript dependency and no bundled `typescript.mjs` chunk.
- [x] Removed the TypeScript import and rebuilt: no copied compiler directory, chunk, or output dependency.
- [x] Unit regressions check lazy tracing, deduplication, preserved user hooks/external rules, Windows SSR configuration, and non-Node/noExternals behavior.
- [x] Prettier and `git diff --check`.

Runtime qualification was on Linux; the Windows-specific configuration branch is covered by a mocked-platform regression. This does not claim a fresh Windows runtime execution of the API fixture.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Targets beta's Nitro 2 adapter. The open Nitro 3 migration remains separate. Other CommonJS packages and TypeScript deep imports are outside this narrow fix.

## [optional] What gif best describes this PR or how it makes you feel?

Not applicable.
