### PR TITLE
fix(platform): restore TypeScript transforms for v3 dev SSR

### DIFF
--- a/packages/platform/src/lib/deps-plugin.spec.ts
+++ b/packages/platform/src/lib/deps-plugin.spec.ts
@@ -1,20 +1,130 @@
-import { describe, it, expect } from 'vitest';
+import angular from '@analogjs/vite-plugin-angular';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { createServer, resolveConfig } from 'vite';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 
 import { depsPlugin } from './deps-plugin.js';
 
 describe('depsPlugin oxc config', () => {
-  it('returns oxc key', () => {
+  it('leaves TypeScript transformation to Vite and the selected compiler', () => {
     const plugins = depsPlugin();
     const result = (plugins[0].config as any)();
 
-    expect(result).toHaveProperty('oxc');
+    expect(result).not.toHaveProperty('oxc');
     expect(result).not.toHaveProperty('esbuild');
   });
+});
 
-  it('excludes ts/js files so vite-plugin-angular owns Angular file compilation', () => {
-    const plugins = depsPlugin();
-    const result = (plugins[0].config as any)();
+describe('server TypeScript compilation', () => {
+  beforeEach(() => {
+    // Exercise development compilation, not Analog's Vitest-only TS fallback.
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('VITEST', undefined);
+  });
+  afterEach(() => vi.unstubAllEnvs());
 
-    expect(result.oxc).toEqual({ exclude: ['**/*.ts', '**/*.js'] });
+  it.each([
+    {
+      mode: 'compilation API',
+      options: { experimental: { useAngularCompilationAPI: true } },
+    },
+    { mode: 'fast compile', options: { fastCompile: true } },
+  ])(
+    'loads a typed server helper with $mode and preserves Angular AOT',
+    async ({ options }) => {
+      const temporaryRoot = resolve(import.meta.dirname, '../../../../tmp');
+      await mkdir(temporaryRoot, { recursive: true });
+      const root = await mkdtemp(join(temporaryRoot, 'server-typescript-'));
+      try {
+        await mkdir(join(root, 'src/server'), { recursive: true });
+        await writeFile(
+          join(root, 'src/app.ts'),
+          `import { Component } from '@angular/core';
+         @Component({ selector: 'test-app', template: 'Hello', standalone: true })
+         export class App {}`,
+        );
+        await writeFile(
+          join(root, 'tsconfig.json'),
+          JSON.stringify({
+            compilerOptions: {
+              target: 'ES2022',
+              module: 'ESNext',
+              moduleResolution: 'bundler',
+              experimentalDecorators: true,
+              skipLibCheck: true,
+            },
+            angularCompilerOptions: { disableTypeScriptVersionCheck: true },
+            files: ['src/app.ts'],
+          }),
+        );
+        await writeFile(
+          join(root, 'src/server/helper.ts'),
+          `export const CANONICAL_HOST = 'example.com' as const;
+         export function canonicalUrl(requestUrl: URL): URL {
+           const result = new URL(requestUrl);
+           result.hostname = CANONICAL_HOST;
+           return result;
+         }`,
+        );
+        const server = await createServer({
+          configFile: false,
+          root,
+          plugins: [
+            depsPlugin()[0],
+            angular({
+              tsconfig: join(root, 'tsconfig.json'),
+              liveReload: false,
+              ...options,
+            }),
+          ],
+          server: { middlewareMode: true, watch: null },
+          optimizeDeps: { noDiscovery: true, include: [] },
+        });
+        try {
+          const helper = await server.ssrLoadModule('/src/server/helper.ts');
+          expect(
+            helper.canonicalUrl(new URL('https://www.example.com/path?q=1'))
+              .href,
+          ).toBe('https://example.com/path?q=1');
+          const app = await server.transformRequest('/src/app.ts');
+          expect(app?.code).toContain('ɵɵdefineComponent');
+          expect(app?.code).not.toContain('@Component');
+        } finally {
+          await server.close();
+        }
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it('retains normal Angular compiler ownership of TypeScript transforms', async () => {
+    const config = await resolveConfig(
+      {
+        configFile: false,
+        root: resolve(import.meta.dirname, '../..'),
+        plugins: [
+          depsPlugin()[0],
+          angular({
+            tsconfig: resolve(import.meta.dirname, '../../tsconfig.lib.json'),
+          }),
+        ],
+      },
+      'serve',
+    );
+    expect(config.oxc).toBe(false);
+  });
+
+  it('preserves application-authored transform exclusions', async () => {
+    const config = await resolveConfig(
+      {
+        configFile: false,
+        plugins: [depsPlugin()[0]],
+        oxc: { exclude: ['**/generated/**'] },
+      },
+      'serve',
+    );
+    expect(config.oxc).toMatchObject({ exclude: ['**/generated/**'] });
   });
 });

--- a/packages/platform/src/lib/deps-plugin.spec.ts
+++ b/packages/platform/src/lib/deps-plugin.spec.ts
@@ -1,7 +1,7 @@
 import angular from '@analogjs/vite-plugin-angular';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import { createServer, resolveConfig } from 'vite';
+import { build, createServer, resolveConfig } from 'vite';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 
 import { depsPlugin } from './deps-plugin.js';
@@ -99,22 +99,91 @@ describe('server TypeScript compilation', () => {
     },
   );
 
-  it('retains normal Angular compiler ownership of TypeScript transforms', async () => {
-    const config = await resolveConfig(
-      {
+  it.each([
+    { mode: 'normal', options: {} },
+    {
+      mode: 'compilation API',
+      options: { experimental: { useAngularCompilationAPI: true } },
+    },
+    { mode: 'fast compile', options: { fastCompile: true } },
+  ])('preserves production AOT with $mode', async ({ options }) => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const temporaryRoot = resolve(import.meta.dirname, '../../../../tmp');
+    await mkdir(temporaryRoot, { recursive: true });
+    const root = await mkdtemp(join(temporaryRoot, 'production-aot-'));
+    try {
+      await writeFile(
+        join(root, 'app.ts'),
+        `import { Component } from '@angular/core';
+        @Component({ selector: 'test-app', template: 'Hello', standalone: true })
+        export class App {}`,
+      );
+      await writeFile(
+        join(root, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            experimentalDecorators: true,
+            skipLibCheck: true,
+            sourceMap: true,
+          },
+          angularCompilerOptions: { disableTypeScriptVersionCheck: true },
+          files: ['app.ts'],
+        }),
+      );
+      const result = await build({
         configFile: false,
-        root: resolve(import.meta.dirname, '../..'),
+        root,
         plugins: [
           depsPlugin()[0],
           angular({
-            tsconfig: resolve(import.meta.dirname, '../../tsconfig.lib.json'),
+            tsconfig: join(root, 'tsconfig.json'),
+            liveReload: false,
+            ...options,
           }),
         ],
-      },
-      'serve',
-    );
-    expect(config.oxc).toBe(false);
+        build: {
+          write: false,
+          minify: false,
+          ssr: join(root, 'app.ts'),
+          rollupOptions: { external: ['@angular/core'] },
+        },
+      });
+      const output = (Array.isArray(result) ? result : [result]).flatMap(
+        (bundle) => ('output' in bundle ? bundle.output : []),
+      );
+      const code = output
+        .filter((item) => item.type === 'chunk')
+        .map((item) => item.code)
+        .join('\n');
+      expect(code).toContain('ɵɵdefineComponent');
+      expect(code).not.toContain('__decorate');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
+
+  it.each(['serve', 'build'] as const)(
+    'retains normal Angular compiler ownership during %s',
+    async (command) => {
+      const config = await resolveConfig(
+        {
+          configFile: false,
+          root: resolve(import.meta.dirname, '../..'),
+          plugins: [
+            depsPlugin()[0],
+            angular({
+              tsconfig: resolve(import.meta.dirname, '../../tsconfig.lib.json'),
+            }),
+          ],
+        },
+        command,
+      );
+      expect(config.oxc).toBe(false);
+    },
+  );
 
   it('preserves application-authored transform exclusions', async () => {
     const config = await resolveConfig(

--- a/packages/platform/src/lib/deps-plugin.ts
+++ b/packages/platform/src/lib/deps-plugin.ts
@@ -3,8 +3,6 @@ import type { Plugin } from 'vite';
 import { crawlFrameworkPkgs } from 'vitefu';
 
 import { Options } from './options.js';
-import { debugPlatform } from './utils/debug.js';
-import { getJsTransformConfigKey } from './utils/rolldown.js';
 
 export function depsPlugin(options?: Options): Plugin[] {
   const workspaceRoot =
@@ -14,18 +12,10 @@ export function depsPlugin(options?: Options): Plugin[] {
     {
       name: 'analogjs-deps-plugin',
       config() {
-        // Skip Vite's built-in ts/js transform so `@analogjs/vite-plugin-angular`
-        // (when the user includes it) owns Angular file compilation. Users who
-        // run an alternative compiler or compile through Angular's own
-        // compilation API can override this in their own Vite config.
-        const transformConfig = { exclude: ['**/*.ts', '**/*.js'] };
-        debugPlatform('deps transform config', {
-          jsTransformKey: getJsTransformConfigKey(),
-          transformExcluded: true,
-        });
-
+        // Each Angular compiler mode configures Vite's TypeScript transform.
+        // The compilation API and fast compiler need its fallback for files
+        // outside Angular's program, including Nitro-only server helpers.
         return {
-          [getJsTransformConfigKey()]: transformConfig,
           ssr: {
             noExternal: [
               '@analogjs/**',

--- a/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-build-optimizer-plugin.ts
@@ -52,16 +52,19 @@ export function buildOptimizerPlugin({
               ngServerMode: `${!!userConfig.build?.ssr}`,
             }
           : {},
-        [jsTransformConfigKey]: {
-          define: isProd
-            ? {
-                ngDevMode: 'false',
-                ngJitMode: 'false',
-                ngI18nClosureMode: 'false',
-                ngServerMode: `${!!userConfig.build?.ssr}`,
-              }
-            : undefined,
-        },
+        [jsTransformConfigKey]:
+          userConfig[jsTransformConfigKey] === false
+            ? false
+            : {
+                define: isProd
+                  ? {
+                      ngDevMode: 'false',
+                      ngJitMode: 'false',
+                      ngI18nClosureMode: 'false',
+                      ngServerMode: `${!!userConfig.build?.ssr}`,
+                    }
+                  : undefined,
+              },
       } as UserConfig;
     },
     // The top-level define keys `ngServerMode` off the legacy `build.ssr`


### PR DESCRIPTION
## PR Checklist

Fix development SSR failures when a Nitro-only helper contains TypeScript syntax but is outside Angular's compilation program. The platform plugin currently excludes every `.ts` file from Vite's built-in transform; the experimental Angular compilation API leaves these helpers untouched, so Rolldown receives raw type annotations and rejects the module.

This PR removes that platform-level override and lets the selected Angular compiler mode own transformation settings. No application workaround or dependency upgrade is required.

## Affected scope

- Primary scope: `platform`
- Secondary scopes: none. Tests exercise the existing `vite-plugin-angular` compilation API and fast compiler.

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

No commit-preservation requirement.

## What is the new behavior?

`depsPlugin()` configures dependencies without setting a blanket `oxc`/`esbuild` exclusion. Each compiler retains its own behavior:

| Configuration | Result |
| --- | --- |
| Experimental Angular compilation API | Angular AOT runs first; Vite can compile TypeScript outside the Angular program. |
| Fast compiler | Angular AOT output is preserved and the remaining TypeScript transform stays available. |
| Normal Angular compiler | Continues to disable Vite's built-in transform and own TypeScript compilation. |
| Application-authored transform exclusions | Preserved without appending `**/*.ts` or `**/*.js`. |

### Reproduction

The [executable regression](https://github.com/analogjs/analog/blob/ea5dc03dec4a870af9202125e9bde9d86206f7ea/packages/platform/src/lib/deps-plugin.spec.ts#L19) creates a temporary project with an Angular component as its only tsconfig root. A separate, deliberately unreferenced server helper contains:

```ts
export const CANONICAL_HOST = 'example.com' as const;

export function canonicalUrl(requestUrl: URL): URL {
  const result = new URL(requestUrl);
  result.hostname = CANONICAL_HOST;
  return result;
}
```

It composes the real platform dependency plugin with:

```ts
angular({
  tsconfig: join(root, 'tsconfig.json'),
  liveReload: false,
  experimental: { useAngularCompilationAPI: true },
})
```

Then it loads the helper through Vite's actual development SSR pipeline:

```ts
const helper = await server.ssrLoadModule('/src/server/helper.ts');
helper.canonicalUrl(new URL('https://www.example.com/path?q=1')).href;
// Expected: 'https://example.com/path?q=1'
```

Against the unmodified alpha implementation, this reproduced:

```text
[vite] (ssr) Error when evaluating SSR module /src/server/helper.ts:
Parse failure: Parse failed with 2 errors:
Type assertion expressions can only be used in TypeScript files.
Expected `,` or `)` but found `:`
```

With this change, the module executes and returns the expected URL. Both compilation API and fast-compiler cases also transform the Angular component and assert that its output contains `ɵɵdefineComponent` and no raw `@Component` decorator.

**The test explicitly sets development mode and clears `VITEST`.** Analog's Vitest-only TypeScript fallback otherwise masks this development failure. It uses Vite middleware mode, closes the server, and removes the temporary project; no listening server or external service is required.

Run the focused regression from this PR checkout after installing dependencies and building `vite-plugin-angular`:

```sh
NX_DAEMON=false NX_NO_CLOUD=true pnpm nx test platform \
  --excludeTaskDependencies --testFiles=src/lib/deps-plugin.spec.ts
```

The pre-fix comparison used the same regression with `deps-plugin.ts` from alpha base `4225f45090a4cf4bdfb562a788e908787b6ec73c` (`3.0.0-alpha.86`).

## Test plan

Local results for **`ea5dc03dec4a870af9202125e9bde9d86206f7ea`**, on macOS arm64 with Node 24.14.1, pnpm 10.33.0, and the alpha workspace's Vite 8.0.8. The original application reported the same failure on Vite 8.2.2 / Rolldown 1.2.7; the upstream regression also reproduces it on the existing workspace pins.

- [x] Frozen dependency installation: `pnpm install --frozen-lockfile --ignore-scripts`; required builds were run explicitly.
- [x] Red/green development SSR reproduction described above.
- [x] `pnpm nx run-many -t test -p platform vite-plugin-angular --excludeTaskDependencies`: **390 platform tests passed; 843 Angular plugin tests passed, with 6 existing skips**.
- [x] `pnpm nx build platform`: passed, including all five dependency tasks and package artifact validation.
- [x] `pnpm nx lint platform`: passed.
- [x] Prettier check on both changed files and `git diff --check`: passed.
- [ ] `pnpm nx run platform:typecheck`: **37 diagnostics on both this change and the unmodified alpha implementation; the sorted diagnostic sets are identical**. These include existing isolated-declaration annotations, Shiki types, and build-config import errors.
- [ ] Full workspace build/test, browser, Windows, and deployment qualification: not run locally. Hosted results are tracked in the [PR checks](https://github.com/analogjs/analog/pull/2554/checks); the local results above do not imply completed CI.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Related work was checked before preparing this fix. #2520 / #2518 cover compiler roots and lifecycle; #2521 covers compiler composition; #2544 covers source-linked packages; #2535 / #2534 cover Nitro v3 qualification. None changes this platform-level exclusion. #2548 concerns bundling the TypeScript compiler package, a separate failure. This focused PR does not close those broader workstreams.

Prepared with OpenAI Codex.

## [optional] What gif best describes this PR or how it makes you feel?

Not applicable.
