### PR TITLE
fix(vite-plugin-angular): preprocess styles with the top-level resolved config

### DIFF
--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -3,8 +3,16 @@ import * as realFs from 'node:fs';
 import { SourceMap } from 'node:module';
 import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
-import { normalizePath, resolveConfig } from 'vite';
+import { normalizePath, preprocessCSS, resolveConfig } from 'vite';
 import { NgtscProgram } from '@angular/compiler-cli';
+
+vi.mock('vite', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vite')>();
+  return {
+    ...actual,
+    preprocessCSS: vi.fn(actual.preprocessCSS),
+  };
+});
 
 vi.mock('@angular/compiler-cli', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@angular/compiler-cli')>();
@@ -1386,6 +1394,39 @@ export class AppComponent {}
 
     expect(compiled?.code).toContain('ɵcmp');
     expect(released).toBeUndefined();
+  }, 60_000);
+
+  it('preprocesses styles with the top-level resolved config (#2556)', async () => {
+    // Vite keys its CSS preprocessor worker cache by the top-level config
+    // object, so `this.environment.config` (a distinct object) must never be
+    // handed to `preprocessCSS` — that falls back to a worker Vite never
+    // closes and keeps Vitest from exiting.
+    vi.mocked(preprocessCSS).mockClear();
+    const mainPlugin = createAppBuildPlugin();
+
+    await mainPlugin.config(
+      { root: fixtureDir, build: {} },
+      { command: 'build' },
+    );
+    const resolvedConfig = await resolveConfig(
+      { configFile: false, root: fixtureDir, mode: 'production' },
+      'build',
+    );
+    mainPlugin.configResolved(resolvedConfig);
+    const ctx = {
+      environment: { config: resolvedConfig.environments['client'] },
+      warn: vi.fn(),
+      error: vi.fn(),
+      addWatchFile: vi.fn(),
+    };
+
+    await mainPlugin.buildStart.call(ctx);
+
+    expect(ctx.environment.config).not.toBe(resolvedConfig);
+    expect(vi.mocked(preprocessCSS)).toHaveBeenCalled();
+    for (const [, , config] of vi.mocked(preprocessCSS).mock.calls) {
+      expect(config).toBe(resolvedConfig);
+    }
   }, 60_000);
 
   it('handles missing this.environment gracefully', async () => {

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -426,6 +426,10 @@ export function angular(options?: PluginOptions): Plugin[] {
         });
       },
       async buildStart() {
+        // Vite keys its CSS preprocessor worker cache by the top-level resolved
+        // config object. Passing `this.environment.config` misses that cache
+        // and falls back to a worker Vite never closes, which keeps Vitest
+        // from exiting after AOT tests with `.scss` styleUrls. (#2556)
         if (!jit) {
           styleTransform = (code: string, filename: string) =>
             preprocessCSS(code, filename, resolvedConfig);
@@ -1226,11 +1230,6 @@ export function angular(options?: PluginOptions): Plugin[] {
     // Each pass creates a new builder/program, so previously emitted output
     // can go stale — only dedupe emits within a single pass.
     emittedIds = new Set<string>();
-
-    if (!jit) {
-      styleTransform = (code: string, filename: string) =>
-        preprocessCSS(code, filename, config);
-    }
 
     const discardIncrementalProgram = shouldDiscardIncrementalProgram({
       externalRuntimeStylesNowEnabled: shouldEnableExternalRuntimeStyles({


### PR DESCRIPTION
## PR Checklist

Since #2506, `performCompilation` receives `this.environment?.config ?? resolvedConfig`, and `_doPerformCompilation` re-bound `styleTransform` to that object — overwriting the binding `buildStart` had just made with `resolvedConfig`.

Vite keys its CSS preprocessor worker cache (`preprocessorWorkerControllerCache`, a `WeakMap`) by the **top-level** resolved config object. The environment config is a distinct object, so `preprocessCSS` misses the cache and silently falls back to a module-scoped `alwaysFakeWorkerWorkerControllerCache` that Vite never closes. With AOT and a `.scss` styleUrl, the leaked sass-embedded compiler keeps Vitest from exiting (`close timed out after 10000ms`). The `releaseCssPreprocessorWorkers()` cleanup from #2506 doesn't cover this path — `buildEnd`/`closeBundle` never fire in the Vitest flow.

Closes #2556

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: `vitest-angular` (symptom surfaces there)

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

N/A

## What is the new behavior?

- The redundant `styleTransform` rebinding in `_doPerformCompilation` is removed, so `styleTransform` keeps the `buildStart` binding that passes the top-level `resolvedConfig` to `preprocessCSS`. The rest of `_doPerformCompilation` still uses the environment config for `mode`/`build.sourcemap`/`build.lib`, as #2506 intended.
- New spec in `angular-vite-plugin.spec.ts` hands the plugin `resolvedConfig.environments.client` as `this.environment.config` (a distinct object, like real Vite) and asserts every `preprocessCSS` call receives the top-level config. The existing `buildStart` specs passed the same object for both, which is why they never caught this. The new spec fails on `beta` and passes with this change.
- Vitest exits cleanly after AOT tests with `.scss` styleUrls again.

## Test plan

- [x] `nx format:check` (prettier on changed files, clean)
- [x] `pnpm build` (`nx build vite-plugin-angular`)
- [x] `pnpm test` (`nx test vite-plugin-angular`: 41 files passed, 2 skipped pre-existing)
- [x] Manual verification — the reporter's repro from #2556 (Vite 8.0.0, Vitest 4.1.11, Angular 22.1.5, sass-embedded 1.104.0, Node 24) in an isolated sandbox:
  - 2.7.2: test passes, then `close timed out after 10000ms` — 14.3s
  - 2.7.1: clean exit — 4.3s
  - this branch (packed `nx build` output installed into the sandbox): clean exit — 3.8s, and an instrumented Vite confirms `preprocessCSS` no longer falls back to the unclosed worker

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Root cause evidence in Vite 8.0.0 `dist/node/chunks/node.js`: `vite:css` `buildStart` registers the worker controller under the top-level config (~L20298); `preprocessCSS` looks it up by identity and falls back to the never-closed module-scoped controller on a miss (~L20984–20988).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CE4HWnmBK8DkmgKrqFivRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CE4HWnmBK8DkmgKrqFivRC)_