### PR TITLE
feat(vite-plugin-angular): export experimental Angular compilation plugin

### DIFF
--- a/apps/analog-app-e2e-playwright/tests/angular-compilation-api.spec.ts
+++ b/apps/analog-app-e2e-playwright/tests/angular-compilation-api.spec.ts
@@ -2,7 +2,8 @@
  * Integration tests for the Angular Compilation API path.
  *
  * These tests run against the live dev server (http://localhost:43000) which
- * is started with `useAngularCompilationAPI: true` in the analog-app config.
+ * should be started with `angularCompilationPlugin()` in the analog-app config
+ * when exercising the Compilation API.
  *
  * They verify:
  *  1. The dev server compiles and serves pages via the Compilation API
@@ -90,7 +91,7 @@ function cleanup() {
 }
 
 describe('Angular Compilation API', () => {
-  test('serves the home page (confirms dev server is using useAngularCompilationAPI)', async () => {
+  test('serves the home page', async () => {
     await page.goto('/');
     expect(await page.locator('h2').first().textContent()).toContain(
       'Products',

--- a/apps/analog-app-e2e/tests/angular-compilation-api.spec.ts
+++ b/apps/analog-app-e2e/tests/angular-compilation-api.spec.ts
@@ -23,9 +23,7 @@ test.afterAll(() => cleanup());
 test.beforeEach(() => cleanup());
 
 test.describe('Angular Compilation API', () => {
-  test('serves the home page (confirms dev server is using useAngularCompilationAPI)', async ({
-    page,
-  }) => {
+  test('serves the home page', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('h2').first()).toContainText('Products');
   });

--- a/apps/docs-analog/src/content/guides/migrating-v2-to-v3.md
+++ b/apps/docs-analog/src/content/guides/migrating-v2-to-v3.md
@@ -131,7 +131,7 @@ These options used to live on `analog()`. Pass them to `angular()` or `nitro()` 
 | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
 | `analog({ vite: {...} })`                                                                                                                        | spread directly into `angular({...})`                                                                 |
 | `analog({ jit })`, `disableTypeChecking`, `liveReload`, `inlineStylesExtension`, `fileReplacements`, `fastCompile`, `fastCompileMode`, `include` | `angular({...})`                                                                                      |
-| `analog({ experimental: { useAngularCompilationAPI: true } })`                                                                                   | `angular({ experimental: { useAngularCompilationAPI: true } })`                                       |
+| `analog({ experimental: { useAngularCompilationAPI: true } })`                                                                                   | `angularCompilationPlugin()`                                                                          |
 | `analog({ experimental: { stylePipeline: { angularPlugins: [...] } } })`                                                                         | a Vite plugin exposing `analog.setup()` (see the [Style Pipeline guide](/docs/guides/style-pipeline)) |
 | `analog({ nitro: {...} })`                                                                                                                       | `nitro({...})` (first arg)                                                                            |
 | `analog({ vite: false })`                                                                                                                        | drop `angular()` from the plugins array                                                               |
@@ -301,7 +301,7 @@ If your app has a `src/server/routes/api` directory, no change is needed — tha
 
 If your app depends on `@analogjs/trpc`, plan that migration separately. The first-party package is removed in v3, so you need to replace it with standard Analog server and API routes or maintain a custom tRPC integration outside the removed package.
 
-If you enabled the experimental Analog Compiler in v2 with `experimental.useAnalogCompiler`, `analogCompilationMode`, or a direct `@analogjs/angular-compiler` dependency, treat that path as not yet ported to the current v3 alpha line. Do not represent it as a stable v3 migration target yet. Use the standard `@analogjs/vite-plugin-angular` path for the v3 alpha migration itself, and treat `experimental.useAngularCompilationAPI` as a separate opt-in evaluation rather than a drop-in replacement.
+If you enabled the experimental Analog Compiler in v2 with `experimental.useAnalogCompiler`, `analogCompilationMode`, or a direct `@analogjs/angular-compiler` dependency, treat that path as not yet ported to the current v3 alpha line. Do not represent it as a stable v3 migration target yet. Use the standard `@analogjs/vite-plugin-angular` path for the v3 alpha migration itself, and treat `angularCompilationPlugin()` as a separate experimental opt-in evaluation rather than a drop-in replacement. Its API and behavior may change in future releases.
 
 ### Template and toolchain baseline shifts
 

--- a/apps/opt-catchall-app/vite.config.ts
+++ b/apps/opt-catchall-app/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import analog from '@analogjs/platform';
-import angular from '@analogjs/vite-plugin-angular';
+import { angularCompilationPlugin } from '@analogjs/vite-plugin-angular';
 import { nitro } from 'nitro/vite';
 import { defineConfig } from 'vite';
 import { getWorkspaceDependencyExcludes } from '../../tools/vite/get-workspace-dependency-excludes.js';
@@ -26,11 +26,8 @@ export default defineConfig(() => {
           highlighter: 'shiki',
         },
       }),
-      angular({
+      angularCompilationPlugin({
         liveReload: true,
-        experimental: {
-          useAngularCompilationAPI: true,
-        },
       }),
       nitro(),
     ],

--- a/apps/tailwind-debug-app-e2e/tests/component-css-hmr.spec.ts
+++ b/apps/tailwind-debug-app-e2e/tests/component-css-hmr.spec.ts
@@ -54,7 +54,7 @@ test.afterAll(() => {
 });
 
 // This test validates the legacy (non-API) HMR path. When the debug app
-// enables useAngularCompilationAPI the HMR wiring differs and the test
+// enables angularCompilationPlugin the HMR wiring differs and the test
 // needs to be updated separately. Skip for now so the #2293 host-apply
 // tests (which require the Compilation API) can run in the same suite.
 test.skip('reproduces Tailwind-triggered full reload for component stylesheet edits', async ({

--- a/apps/tailwind-debug-app/vite.config.ts
+++ b/apps/tailwind-debug-app/vite.config.ts
@@ -1,7 +1,9 @@
 /// <reference types="vitest" />
 
 import analog from '@analogjs/platform';
-import angular from '@analogjs/vite-plugin-angular';
+import angular, {
+  angularCompilationPlugin,
+} from '@analogjs/vite-plugin-angular';
 import { nitro } from 'nitro/vite';
 import tailwindcss from '@tailwindcss/vite';
 import fs from 'node:fs';
@@ -132,14 +134,8 @@ export default defineConfig(({ mode }) => ({
       },
       ssr: false,
     }),
-    angular({
+    (USE_COMPILATION_API ? angularCompilationPlugin : angular)({
       liveReload: LIVE_RELOAD,
-      experimental: {
-        // Required to reproduce #2293: @apply inside :host with Tailwind
-        // prefix configuration requires the Angular Compilation API path
-        // for style externalization.
-        useAngularCompilationAPI: USE_COMPILATION_API,
-      },
     }),
     angularTailwind({
       prefixes: ['tdbg:'],

--- a/packages/vite-plugin-angular/src/index.ts
+++ b/packages/vite-plugin-angular/src/index.ts
@@ -1,3 +1,7 @@
+export {
+  angularCompilationPlugin,
+  type AngularCompilationPluginOptions,
+} from './lib/compilation-api/index.js';
 import { angular } from './lib/angular-vite-plugin.js';
 export { angular } from './lib/angular-vite-plugin.js';
 export type { PluginOptions } from './lib/angular-vite-plugin.js';

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin-live-reload.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin-live-reload.spec.ts
@@ -119,16 +119,13 @@ async function setupLiveReloadPlugin(options: {
     };
   });
 
-  const { angular } = await import('./angular-vite-plugin');
-  const plugin = angular({
+  const { angularCompilationPlugin } = await import('./compilation-api/index');
+  const plugin = angularCompilationPlugin({
     liveReload: true,
     include: options.include,
     tsconfig: resolvedTsconfig,
     inlineStylesExtension: 'css',
     workspaceRoot: resolvedWorkspaceRoot,
-    experimental: {
-      useAngularCompilationAPI: true,
-    },
   }).find(
     (entry) => entry.name === '@analogjs/vite-plugin-angular-compilation-api',
   ) as any;

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin-transform.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin-transform.spec.ts
@@ -93,9 +93,6 @@ async function setupLegacyTransformPlugin() {
   const plugin = angular({
     tsconfig: tsconfigPath,
     workspaceRoot,
-    experimental: {
-      useAngularCompilationAPI: false,
-    },
   }).find((entry) => entry.name === '@analogjs/vite-plugin-angular') as any;
 
   await plugin.config?.(

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.spec.ts
@@ -1075,7 +1075,7 @@ describe('encapsulation plugin', () => {
 // =============================================================================
 // hasComponent detection
 //
-// When useAngularCompilationAPI is enabled, the Vite transform hook receives
+// When angularCompilationPlugin is enabled, the Vite transform hook receives
 // already-compiled code (decorators stripped), so hasComponent is always false.
 // This suite is behavior documentation for both compilation paths rather than
 // a regression harness for `hasComponent`.
@@ -1092,7 +1092,7 @@ describe('hasComponent detection behavior docs', () => {
     expect(rawTs.includes('@Component')).toBe(true);
   });
 
-  it('documents missing @Component detection in compiled output (useAngularCompilationAPI path)', () => {
+  it('documents missing @Component detection in compiled output (angularCompilationPlugin path)', () => {
     // Simulates what the Vite transform hook sees after Angular compilation.
     // `@Component` becomes `ɵɵdefineComponent()`, so the naive string check
     // returns false. This is expected documented behavior for that path.

--- a/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vite-plugin.ts
@@ -54,7 +54,6 @@ import {
   type TransformFilter,
 } from './analog-plugin-interop.js';
 
-import { compilationAPIPlugin } from './compilation-api/index.js';
 import { fastCompilePlugin } from './fast-compile-plugin.js';
 import { ANGULAR_DECORATOR_CALL_RE } from './compiler/index.js';
 import {
@@ -178,9 +177,6 @@ export interface PluginOptions {
    * - `'partial'`: Emit partial declarations for library publishing.
    */
   fastCompileMode?: 'full' | 'partial';
-  experimental?: {
-    useAngularCompilationAPI?: boolean;
-  };
   /**
    * Enable debug logging for specific scopes.
    *
@@ -242,8 +238,6 @@ export function angular(options?: PluginOptions): Plugin[] {
     liveReload,
     disableTypeChecking: options?.disableTypeChecking ?? true,
     fileReplacements: options?.fileReplacements ?? [],
-    useAngularCompilationAPI:
-      options?.experimental?.useAngularCompilationAPI ?? false,
     fastCompile: options?.fastCompile ?? false,
     fastCompileMode: options?.fastCompileMode ?? 'full',
     // Set on each compilation from preprocessors registered by Vite plugins
@@ -1122,15 +1116,6 @@ export function angular(options?: PluginOptions): Plugin[] {
             return;
           }
 
-          // When the Angular Compilation API path is active the transform hook
-          // receives already-analyzed code, so files without Angular decorators
-          // have nothing to do here — skip them before any further work.
-          if (pluginOptions.useAngularCompilationAPI) {
-            if (!ANGULAR_DECORATOR_CALL_RE.test(code)) {
-              return;
-            }
-          }
-
           // Encapsulation of component stylesheets is handled by the
           // separate '@analogjs/vite-plugin-angular:encapsulation' plugin
           // with enforce: 'post'. This ensures @tailwindcss/vite (enforce:
@@ -1326,34 +1311,19 @@ export function angular(options?: PluginOptions): Plugin[] {
     };
   }
 
-  const compilationPlugin = pluginOptions.useAngularCompilationAPI
-    ? compilationAPIPlugin({
+  const compilationPlugin = pluginOptions.fastCompile
+    ? fastCompilePlugin({
         tsconfigGetter: pluginOptions.tsconfigGetter,
         workspaceRoot: pluginOptions.workspaceRoot,
         inlineStylesExtension: pluginOptions.inlineStylesExtension,
         jit,
         liveReload: pluginOptions.liveReload,
-        disableTypeChecking: pluginOptions.disableTypeChecking,
         supportedBrowsers: pluginOptions.supportedBrowsers,
-        fileReplacements: pluginOptions.fileReplacements,
         isTest,
         isAstroIntegration,
-        include: pluginOptions.include,
-        debug: options?.debug,
+        fastCompileMode: pluginOptions.fastCompileMode,
       })
-    : pluginOptions.fastCompile
-      ? fastCompilePlugin({
-          tsconfigGetter: pluginOptions.tsconfigGetter,
-          workspaceRoot: pluginOptions.workspaceRoot,
-          inlineStylesExtension: pluginOptions.inlineStylesExtension,
-          jit,
-          liveReload: pluginOptions.liveReload,
-          supportedBrowsers: pluginOptions.supportedBrowsers,
-          isTest,
-          isAstroIntegration,
-          fastCompileMode: pluginOptions.fastCompileMode,
-        })
-      : angularPlugin();
+    : angularPlugin();
 
   return [
     // Scope the `style` package-export condition to `.css`-extension

--- a/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/angular-vitest-plugin.ts
@@ -121,7 +121,7 @@ export function angularVitestEsbuildPlugin(): Plugin {
 /**
  * Post-processing pass that converts any `.ts` files Angular's compilation
  * skipped (e.g. files without Angular decorators when
- * `useAngularCompilationAPI` is on) into runnable JS via esbuild/OXC.
+ * `angularCompilationPlugin()` is used) into runnable JS via esbuild/OXC.
  *
  * Files Angular already compiled have a sourcemap available via
  * `getInMap` — we skip those here to avoid breaking the chain Vite is

--- a/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.spec.ts
@@ -11,13 +11,40 @@ const originalVitestEnv = process.env['VITEST'];
 let cachedViteActual: typeof import('vite');
 let cachedDevkitActual: typeof import('../utils/devkit.js');
 
-describe('compilationAPIPlugin', () => {
+describe('angularCompilationPlugin', () => {
   let tempRoot: string;
+  let angularCompilationPlugin: typeof import('../../index.js').angularCompilationPlugin;
+
+  function getCompilerPlugin(
+    options: Parameters<typeof angularCompilationPlugin>[0],
+  ) {
+    return angularCompilationPlugin(options).find(
+      (plugin) =>
+        plugin.name === '@analogjs/vite-plugin-angular-compilation-api',
+    )!;
+  }
+
+  async function configure(plugin: ReturnType<typeof getCompilerPlugin>) {
+    await (plugin.config as any)(
+      { root: tempRoot, mode: 'development' },
+      { command: 'serve', mode: 'development' },
+    );
+    await (plugin.configResolved as any)({
+      root: tempRoot,
+      cacheDir: join(tempRoot, '.vite'),
+      mode: 'development',
+      build: {},
+      server: { hmr: true },
+      plugins: [],
+    });
+  }
 
   beforeEach(async () => {
     process.env['NODE_ENV'] = 'development';
     delete process.env['VITEST'];
     vi.resetModules();
+    createAngularCompilationMock.mockReset();
+    preprocessCSSMock.mockReset();
 
     tempRoot = mkdtempSync(join(tmpdir(), 'analog-compilation-api-'));
     writeFileSync(
@@ -47,6 +74,7 @@ describe('compilationAPIPlugin', () => {
       angularFullVersion: 200100,
       createAngularCompilation: createAngularCompilationMock,
     }));
+    ({ angularCompilationPlugin } = await import('../../index.js'));
   });
 
   afterEach(() => {
@@ -54,6 +82,8 @@ describe('compilationAPIPlugin', () => {
     if (originalVitestEnv !== undefined) {
       process.env['VITEST'] = originalVitestEnv;
     }
+    vi.doUnmock('vite');
+    vi.doUnmock('../utils/devkit.js');
     vi.restoreAllMocks();
     if (tempRoot) {
       try {
@@ -65,10 +95,8 @@ describe('compilationAPIPlugin', () => {
   });
 
   it('creates a plugin with the correct name and enforce', async () => {
-    const { compilationAPIPlugin } =
-      await import('./compilation-api-plugin.js');
-    const plugin = compilationAPIPlugin({
-      tsconfigGetter: () => join(tempRoot, 'tsconfig.json'),
+    const plugin = getCompilerPlugin({
+      tsconfig: () => join(tempRoot, 'tsconfig.json'),
       workspaceRoot: tempRoot,
       inlineStylesExtension: 'css',
       jit: false,
@@ -76,8 +104,6 @@ describe('compilationAPIPlugin', () => {
       disableTypeChecking: true,
       supportedBrowsers: ['safari 15'],
       fileReplacements: [],
-      isTest: false,
-      isAstroIntegration: false,
       include: [],
     });
 
@@ -86,10 +112,8 @@ describe('compilationAPIPlugin', () => {
   });
 
   it('has required Vite plugin hooks', async () => {
-    const { compilationAPIPlugin } =
-      await import('./compilation-api-plugin.js');
-    const plugin = compilationAPIPlugin({
-      tsconfigGetter: () => join(tempRoot, 'tsconfig.json'),
+    const plugin = getCompilerPlugin({
+      tsconfig: () => join(tempRoot, 'tsconfig.json'),
       workspaceRoot: tempRoot,
       inlineStylesExtension: 'css',
       jit: false,
@@ -97,8 +121,6 @@ describe('compilationAPIPlugin', () => {
       disableTypeChecking: true,
       supportedBrowsers: ['safari 15'],
       fileReplacements: [],
-      isTest: false,
-      isAstroIntegration: false,
       include: [],
     });
 
@@ -114,10 +136,8 @@ describe('compilationAPIPlugin', () => {
   });
 
   it('config hook disables esbuild/oxc', async () => {
-    const { compilationAPIPlugin } =
-      await import('./compilation-api-plugin.js');
-    const plugin = compilationAPIPlugin({
-      tsconfigGetter: () => join(tempRoot, 'tsconfig.json'),
+    const plugin = getCompilerPlugin({
+      tsconfig: () => join(tempRoot, 'tsconfig.json'),
       workspaceRoot: tempRoot,
       inlineStylesExtension: 'css',
       jit: false,
@@ -125,8 +145,6 @@ describe('compilationAPIPlugin', () => {
       disableTypeChecking: true,
       supportedBrowsers: ['safari 15'],
       fileReplacements: [],
-      isTest: false,
-      isAstroIntegration: false,
       include: [],
     });
 
@@ -156,10 +174,8 @@ describe('compilationAPIPlugin', () => {
       emitAffectedFiles: emitAffectedFilesMock,
     });
 
-    const { compilationAPIPlugin } =
-      await import('./compilation-api-plugin.js');
-    const plugin = compilationAPIPlugin({
-      tsconfigGetter: () => join(tempRoot, 'tsconfig.json'),
+    const plugin = getCompilerPlugin({
+      tsconfig: () => join(tempRoot, 'tsconfig.json'),
       workspaceRoot: tempRoot,
       inlineStylesExtension: 'css',
       jit: false,
@@ -167,8 +183,6 @@ describe('compilationAPIPlugin', () => {
       disableTypeChecking: true,
       supportedBrowsers: ['safari 15'],
       fileReplacements: [],
-      isTest: false,
-      isAstroIntegration: false,
       include: [],
     });
 
@@ -197,10 +211,8 @@ describe('compilationAPIPlugin', () => {
 
   it('hands the stylesheet registry to analog.setup configurators', async () => {
     const configure = vi.fn();
-    const { compilationAPIPlugin } =
-      await import('./compilation-api-plugin.js');
-    const plugin = compilationAPIPlugin({
-      tsconfigGetter: () => join(tempRoot, 'tsconfig.json'),
+    const plugin = getCompilerPlugin({
+      tsconfig: () => join(tempRoot, 'tsconfig.json'),
       workspaceRoot: tempRoot,
       inlineStylesExtension: 'css',
       jit: false,
@@ -208,8 +220,6 @@ describe('compilationAPIPlugin', () => {
       disableTypeChecking: true,
       supportedBrowsers: ['safari 15'],
       fileReplacements: [],
-      isTest: false,
-      isAstroIntegration: false,
       include: [],
     });
 
@@ -268,10 +278,8 @@ describe('compilationAPIPlugin', () => {
       emitAffectedFiles: vi.fn().mockResolvedValue([]),
     });
 
-    const { compilationAPIPlugin } =
-      await import('./compilation-api-plugin.js');
-    const plugin = compilationAPIPlugin({
-      tsconfigGetter: () => join(tempRoot, 'tsconfig.json'),
+    const plugin = getCompilerPlugin({
+      tsconfig: () => join(tempRoot, 'tsconfig.json'),
       workspaceRoot: tempRoot,
       inlineStylesExtension: 'css',
       jit: false,
@@ -279,8 +287,6 @@ describe('compilationAPIPlugin', () => {
       disableTypeChecking: true,
       supportedBrowsers: ['safari 15'],
       fileReplacements: [],
-      isTest: false,
-      isAstroIntegration: false,
       include: [],
     });
 
@@ -346,10 +352,8 @@ describe('compilationAPIPlugin', () => {
       emitAffectedFiles: emitAffectedFilesMock,
     });
 
-    const { compilationAPIPlugin } =
-      await import('./compilation-api-plugin.js');
-    const plugin = compilationAPIPlugin({
-      tsconfigGetter: () => join(tempRoot, 'tsconfig.json'),
+    const plugin = getCompilerPlugin({
+      tsconfig: () => join(tempRoot, 'tsconfig.json'),
       workspaceRoot: tempRoot,
       inlineStylesExtension: 'css',
       jit: false,
@@ -357,8 +361,6 @@ describe('compilationAPIPlugin', () => {
       disableTypeChecking: true,
       supportedBrowsers: ['safari 15'],
       fileReplacements: [],
-      isTest: false,
-      isAstroIntegration: false,
       include: [],
     });
 
@@ -412,10 +414,8 @@ describe('compilationAPIPlugin', () => {
         ]),
     });
 
-    const { compilationAPIPlugin } =
-      await import('./compilation-api-plugin.js');
-    const plugin = compilationAPIPlugin({
-      tsconfigGetter: () => join(tempRoot, 'tsconfig.json'),
+    const plugin = getCompilerPlugin({
+      tsconfig: () => join(tempRoot, 'tsconfig.json'),
       workspaceRoot: tempRoot,
       inlineStylesExtension: 'css',
       jit: false,
@@ -423,8 +423,6 @@ describe('compilationAPIPlugin', () => {
       disableTypeChecking: true,
       supportedBrowsers: ['safari 15'],
       fileReplacements: [],
-      isTest: false,
-      isAstroIntegration: false,
       include: [],
     });
 
@@ -455,5 +453,150 @@ describe('compilationAPIPlugin', () => {
 
     expect(result.code).toBe('export const appConfig = {};');
     expect(warn).not.toHaveBeenCalled();
+  });
+  it('exports a complete plugin set with one compiler and one HMR middleware', () => {
+    const plugins = angularCompilationPlugin();
+    const names = plugins.map((plugin) => plugin.name);
+    expect(
+      names.filter(
+        (name) => name === '@analogjs/vite-plugin-angular-compilation-api',
+      ),
+    ).toHaveLength(1);
+    expect(
+      names.filter((name) => name === 'analogjs-live-reload-plugin'),
+    ).toHaveLength(1);
+    expect(names).not.toContain('@analogjs/vite-plugin-angular');
+    expect(
+      angularCompilationPlugin({ liveReload: false }).map(
+        (plugin) => plugin.name,
+      ),
+    ).not.toContain('analogjs-live-reload-plugin');
+  });
+
+  it.each([
+    [200000, createAngularCompilationMock],
+    [200100, undefined],
+  ])(
+    'rejects an unsupported Compilation API (%s)',
+    async (version, createCompilation) => {
+      vi.resetModules();
+      vi.doMock('../utils/devkit.js', () => ({
+        ...cachedDevkitActual,
+        angularFullVersion: version,
+        createAngularCompilation: createCompilation,
+      }));
+      const { angularCompilationPlugin: unsupportedPlugin } =
+        await import('../../index.js');
+      expect(() => unsupportedPlugin()).toThrow(
+        'requires Angular v20.1 or later',
+      );
+    },
+  );
+
+  it('shares HMR output with its middleware and keeps instances isolated', async () => {
+    const filename = join(tempRoot, 'app.component.ts');
+    const hmrCode = 'export const update = true;';
+    createAngularCompilationMock.mockResolvedValue({
+      initialize: vi.fn().mockResolvedValue({
+        templateUpdates: new Map([
+          [encodeURIComponent(filename) + '@AppComponent', hmrCode],
+        ]),
+      }),
+      diagnoseFiles: vi.fn().mockResolvedValue({ errors: [], warnings: [] }),
+      emitAffectedFiles: vi
+        .fn()
+        .mockResolvedValue([{ filename, contents: 'compiled' }]),
+      close: vi.fn(),
+    });
+    const options = { tsconfig: join(tempRoot, 'tsconfig.json'), jit: false };
+    const first = angularCompilationPlugin(options);
+    const second = angularCompilationPlugin(options);
+    const compiler = first.find(
+      (plugin) =>
+        plugin.name === '@analogjs/vite-plugin-angular-compilation-api',
+    )!;
+    await configure(compiler);
+    await (compiler.buildStart as any)();
+    const request =
+      'file:///@ng/component?c=' +
+      encodeURIComponent(filename + '@AppComponent');
+    const firstMiddleware = first.find(
+      (plugin) => plugin.name === 'analogjs-live-reload-plugin',
+    )!;
+    const secondMiddleware = second.find(
+      (plugin) => plugin.name === 'analogjs-live-reload-plugin',
+    )!;
+    expect((firstMiddleware.load as any)('\0' + request, { ssr: true })).toBe(
+      hmrCode,
+    );
+    expect((secondMiddleware.load as any)('\0' + request, { ssr: true })).toBe(
+      '',
+    );
+    await (compiler.closeBundle as any)();
+    expect((firstMiddleware.load as any)('\0' + request, { ssr: true })).toBe(
+      '',
+    );
+  });
+
+  it('waits for initial compilation, preserves raw imports, and awaits cleanup', async () => {
+    const filename = join(tempRoot, 'app.ts');
+    let finishInitialize!: () => void;
+    const initialize = vi.fn(
+      () =>
+        new Promise<object>((resolve) => {
+          finishInitialize = () => resolve({});
+        }),
+    );
+    let finishClose!: () => void;
+    const close = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishClose = resolve;
+        }),
+    );
+    createAngularCompilationMock.mockResolvedValue({
+      initialize,
+      diagnoseFiles: vi.fn().mockResolvedValue({ errors: [], warnings: [] }),
+      emitAffectedFiles: vi
+        .fn()
+        .mockResolvedValue([{ filename, contents: 'compiled' }]),
+      close,
+    });
+    const compiler = getCompilerPlugin({
+      tsconfig: join(tempRoot, 'tsconfig.json'),
+      jit: false,
+    });
+    await configure(compiler);
+    const building = (compiler.buildStart as any)();
+    await vi.waitFor(() => expect(initialize).toHaveBeenCalledOnce());
+    const transform = (compiler.transform as any).handler;
+    const context = { warn: vi.fn(), error: vi.fn() };
+    await expect(
+      transform.call(context, 'export default "source";', filename + '?raw'),
+    ).resolves.toBeUndefined();
+    let transformed = false;
+    const transforming = transform
+      .call(context, 'source', filename + '?component')
+      .then((result: any) => {
+        transformed = true;
+        return result;
+      });
+    await Promise.resolve();
+    expect(transformed).toBe(false);
+    finishInitialize();
+    await building;
+    await expect(transforming).resolves.toEqual({
+      code: 'compiled',
+      map: null,
+    });
+    let closed = false;
+    const closing = (compiler.closeBundle as any)().then(() => {
+      closed = true;
+    });
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+    expect(closed).toBe(false);
+    finishClose();
+    await closing;
+    expect(closed).toBe(true);
   });
 });

--- a/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
+++ b/packages/vite-plugin-angular/src/lib/compilation-api/compilation-api-plugin.ts
@@ -19,6 +19,7 @@ import {
 } from '../utils/devkit.js';
 import {
   activateDeferredDebug,
+  applyDebugOption,
   debugCompilationApi,
   debugCompiler,
   debugEmit,
@@ -30,6 +31,7 @@ import {
 } from '../utils/debug.js';
 import {
   getTsConfigPath,
+  createTsConfigGetter,
   TS_EXT_REGEX,
   type TsConfigResolutionContext,
 } from '../utils/plugin-config.js';
@@ -63,29 +65,72 @@ import {
   DiagnosticModes,
   isTestWatchMode,
 } from '../utils/compilation-shared.js';
+import { angularVitestPlugins } from '../angular-vitest-plugin.js';
+import { buildOptimizerPlugin } from '../angular-build-optimizer-plugin.js';
+import { jitPlugin } from '../angular-jit-plugin.js';
+import { liveReloadPlugin } from '../live-reload-plugin.js';
+import { virtualModulesPlugin } from '../virtual-modules-plugin.js';
+import { encapsulationPlugin } from '../encapsulation-plugin.js';
+import { nxFolderPlugin } from '../nx-folder-plugin.js';
+import { routerPlugin } from '../router-plugin.js';
+import { replaceFiles } from '../plugins/file-replacements.plugin.js';
+import { cssExtensionStyleResolverPlugin } from '../utils/css-extension-resolver.js';
 import { loadVirtualRawModule } from '../utils/virtual-resources.js';
 
 const require = createRequire(import.meta.url);
 const ts = require('typescript');
 
-export interface CompilationAPIPluginOptions {
-  tsconfigGetter: () => string;
-  workspaceRoot: string;
-  inlineStylesExtension: string;
-  jit: boolean;
-  liveReload: boolean;
-  disableTypeChecking: boolean;
-  supportedBrowsers: string[];
-  fileReplacements: FileReplacement[];
-  isTest: boolean;
-  isAstroIntegration: boolean;
-  include: string[];
+/**
+ * @experimental The Angular Compilation API plugin may change in future releases.
+ */
+export interface AngularCompilationPluginOptions {
+  tsconfig?: string | (() => string);
+  workspaceRoot?: string;
+  inlineStylesExtension?: string;
+  jit?: boolean;
+  liveReload?: boolean;
+  disableTypeChecking?: boolean;
+  supportedBrowsers?: string[];
+  fileReplacements?: FileReplacement[];
+  include?: string[];
   debug?: DebugOption;
 }
 
-export function compilationAPIPlugin(
-  pluginOptions: CompilationAPIPluginOptions,
-): Plugin {
+/**
+ * Compiles Angular applications using Angular's private Compilation API.
+ *
+ * @experimental This plugin may change in future releases.
+ */
+export function angularCompilationPlugin(
+  options: AngularCompilationPluginOptions = {},
+): Plugin[] {
+  if (
+    angularFullVersion < 200100 ||
+    typeof createAngularCompilation !== 'function'
+  ) {
+    throw new Error(
+      '[@analogjs/vite-plugin-angular]: angularCompilationPlugin requires Angular v20.1 or later and a matching @angular/build package with the Compilation API.',
+    );
+  }
+
+  applyDebugOption(options.debug, options.workspaceRoot);
+  const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
+  const isStackBlitz = !!process.versions['webcontainer'];
+  const pluginOptions = {
+    tsconfigGetter: createTsConfigGetter(options.tsconfig),
+    workspaceRoot:
+      options.workspaceRoot ??
+      process.env['NX_WORKSPACE_ROOT'] ??
+      process.cwd(),
+    inlineStylesExtension: options.inlineStylesExtension ?? 'css',
+    jit: options.jit ?? isTest,
+    liveReload: options.liveReload ?? true,
+    disableTypeChecking: options.disableTypeChecking ?? true,
+    supportedBrowsers: options.supportedBrowsers ?? ['safari 15'],
+    fileReplacements: options.fileReplacements ?? [],
+    include: options.include ?? [],
+    isAstroIntegration: process.env['ANALOG_ASTRO'] === 'true',
+  };
   let resolvedConfig: ResolvedConfig;
   let tsConfigResolutionContext: TsConfigResolutionContext | null = null;
   let watchMode = false;
@@ -107,7 +152,6 @@ export function compilationAPIPlugin(
   let initialCompilation = false;
   let viteServer: ViteDevServer | undefined;
 
-  const isTest = process.env['NODE_ENV'] === 'test' || !!process.env['VITEST'];
   const tsconfigResolver = new TsconfigResolver({
     workspaceRoot: pluginOptions.workspaceRoot,
     include: pluginOptions.include,
@@ -538,7 +582,7 @@ export function compilationAPIPlugin(
     classNames.delete(id);
   }
 
-  return {
+  const compilerPlugin: Plugin = {
     name: '@analogjs/vite-plugin-angular-compilation-api',
     enforce: 'pre' as const,
     async config(config, { command }) {
@@ -554,13 +598,7 @@ export function compilationAPIPlugin(
         isLib: !!config?.build?.lib,
       };
 
-      if (angularFullVersion < 200100) {
-        console.warn(
-          '[@analogjs/vite-plugin-angular]: The Angular Compilation API is only available with Angular v20.1 and later',
-        );
-      } else {
-        debugCompilationApi('enabled (Angular %s)', angularFullVersion);
-      }
+      debugCompilationApi('enabled (Angular %s)', angularFullVersion);
 
       // Angular Compilation API handles TypeScript transforms — disable
       // esbuild/oxc so they don't compete.
@@ -586,7 +624,7 @@ export function compilationAPIPlugin(
       // No `resolve.conditions` extension here: the `style` condition is
       // scoped to `.css`-extension requests by
       // `cssExtensionStyleResolverPlugin`, registered once at the
-      // `angular()` factory level. Adding `style` globally caused
+      // `angularCompilationPlugin()` factory level. Adding `style` globally caused
       // Tailwind v4's JS plugin resolver to pick the `style` exports of
       // packages such as `tailwindcss-primeui`, which then crashed Node's
       // ESM loader when it tried to import the resulting `.css` file.
@@ -655,7 +693,8 @@ export function compilationAPIPlugin(
     },
     async buildStart() {
       if (!isVitestVscode) {
-        await performCompilation(resolvedConfig);
+        pendingCompilation = performCompilation(resolvedConfig);
+        await pendingCompilation;
         pendingCompilation = null;
         initialCompilation = true;
       }
@@ -776,10 +815,16 @@ export function compilationAPIPlugin(
       filter: {
         id: {
           include: [TS_EXT_REGEX],
-          exclude: [/node_modules/, 'type=script', '@ng/component'],
+          exclude: [
+            /node_modules/,
+            'type=script',
+            '@ng/component',
+            /[?&]raw\b/,
+          ],
         },
       },
       async handler(code, id) {
+        if (/[?&]raw\b/.test(id)) return;
         if (transformFilter && !transformFilter(code, id)) {
           return;
         }
@@ -851,9 +896,37 @@ export function compilationAPIPlugin(
         };
       },
     },
-    closeBundle() {
-      angularCompilation?.close?.();
+    async closeBundle() {
+      await compilationLock;
+      await angularCompilation?.close?.();
       angularCompilation = undefined;
+      outputFiles.clear();
+      classNames.clear();
+      sourceFileCache.clear();
+      tsconfigResolver.invalidateAll();
+      stylesheetRegistry = undefined;
+      pendingCompilation = null;
+      initialCompilation = false;
     },
   };
+
+  return [
+    cssExtensionStyleResolverPlugin(),
+    replaceFiles(pluginOptions.fileReplacements, pluginOptions.workspaceRoot),
+    virtualModulesPlugin({ jit: pluginOptions.jit }),
+    compilerPlugin,
+    pluginOptions.liveReload && liveReloadPlugin({ classNames, fileEmitter }),
+    ...(isTest && !isStackBlitz
+      ? angularVitestPlugins((id) => outputFiles.get(normalizePath(id))?.map)
+      : []),
+    pluginOptions.jit &&
+      jitPlugin({ inlineStylesExtension: pluginOptions.inlineStylesExtension }),
+    buildOptimizerPlugin({
+      supportedBrowsers: pluginOptions.supportedBrowsers,
+      jit: pluginOptions.jit,
+    }),
+    routerPlugin(),
+    nxFolderPlugin(),
+    encapsulationPlugin(),
+  ].filter(Boolean) as Plugin[];
 }

--- a/packages/vite-plugin-angular/src/lib/compilation-api/index.ts
+++ b/packages/vite-plugin-angular/src/lib/compilation-api/index.ts
@@ -1,4 +1,4 @@
 export {
-  compilationAPIPlugin,
-  type CompilationAPIPluginOptions,
+  angularCompilationPlugin,
+  type AngularCompilationPluginOptions,
 } from './compilation-api-plugin.js';


### PR DESCRIPTION
## PR Checklist

The Angular Compilation API was selected through an experimental option on `angular()`. This change exposes it as a standalone experimental plugin with its own compiler state and supporting plugins.

Closes analogjs/analog#2558 — [Export an experimental standalone Angular Compilation API plugin](https://github.com/analogjs/analog/issues/2558).

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: docs and example app configurations/tests consuming the plugin.

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

No special commit boundaries need preservation. Keep the breaking-change migration note in the squash commit.

## What is the new behavior?

- Export `angularCompilationPlugin()` and `AngularCompilationPluginOptions`, both marked experimental.
- Compose styles, HMR, JIT, optimization, routing, and Vitest support around the Compilation API's own state. HMR middleware reads this compiler's output cache.
- Await initial compilation and asynchronous cleanup, preserve raw imports, and keep standalone instances isolated.
- Remove the experimental compiler selection flag from `angular()`; retain its legacy and fast compilation paths.
- Migrate consumers and document the new API. Direct use requires Angular 20.1 or later and an available Compilation API from the matching `@angular/build` package.

## Test plan

- [x] `nx format:check` — ran `pnpm nx format:check --base=origin/alpha`; commit hooks also passed.
- [x] `pnpm build` — all 23 projects and 8 dependency tasks passed.
- [ ] `pnpm test` — full workspace test suite was not run.
- [x] Package tests: `pnpm nx test vite-plugin-angular --run --skip-nx-cache` — 1,410 passed, 26 skipped.
- [x] Package build: `pnpm nx build vite-plugin-angular --skip-nx-cache` — passed.
- [x] Manual verification — imported the built entrypoint and instantiated the standalone plugin. Browser E2E was not run.

Regression coverage includes unsupported versions, missing Compilation API, HMR output sharing, instance isolation, raw/query imports, initial compilation waiting, and asynchronous cleanup.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE:

Remove `experimental.useAngularCompilationAPI` from `angular()`. Import and use `angularCompilationPlugin()` instead. Pass supported compiler options directly to the new factory. The plugin requires Angular 20.1 or later and remains experimental.

BEFORE:

```ts
import angular from '@analogjs/vite-plugin-angular';

plugins: [
  angular({
    experimental: {
      useAngularCompilationAPI: true,
    },
  }),
];
```

AFTER:

```ts
import { angularCompilationPlugin } from '@analogjs/vite-plugin-angular';

plugins: [angularCompilationPlugin()];
```

## Other information

Targets `alpha`. The standalone TypeScript check reports 57 errors; comparison with an isolated unchanged `alpha` snapshot found the same diagnostics and no new errors. These are separate from the passing package and workspace builds.

## [optional] What gif best describes this PR or how it makes you feel?

Not applicable.

🤖 Generated with Codex.
