### PR TITLE
fix(vite-plugin-angular): handle boundary conformance and deferred dependencies

### DIFF
--- a/apps/docs-analog/src/content/guides/angular-compilation.md
+++ b/apps/docs-analog/src/content/guides/angular-compilation.md
@@ -76,6 +76,14 @@ export default defineConfig({
 | Library / partial builds (`fastCompileMode`) | ✅ Emits partial declarations for library publishing            |
 | Compile-time template type checking          | ❌ Use the Angular Language Service in your editor              |
 
+### Boundary blocks
+
+Fast compilation supports `@boundary` and `@error` blocks when the installed
+`@angular/compiler` supports them (verified with `22.2.0-next.7`). Deferred
+components inside error blocks are loaded lazily, while components also used
+outside a `@defer` body remain eager dependencies. Older compilers, including
+Angular 22.1, do not support this syntax.
+
 ### Building a library
 
 For a library build, set `fastCompileMode: 'partial'` so the compiler emits partial `ɵɵngDeclare*` declarations instead of final Ivy definitions:

--- a/packages/vite-plugin-angular/src/lib/compiler/angular-version.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/angular-version.ts
@@ -1,5 +1,8 @@
 import * as o from '@angular/compiler';
 
+// Boundary blocks were introduced during the Angular 22.2 prereleases.
+export const SUPPORTS_BOUNDARY_BLOCKS = 'TmplAstBoundaryBlock' in o;
+
 // Detect the installed @angular/compiler major version once at module load
 // time and expose helpers for version-aware code paths.
 //

--- a/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/component.spec.ts
@@ -7,7 +7,7 @@ import {
 import { compile as rawCompile } from './compile';
 import { scanFile } from './registry';
 import { inlineResourceUrls, extractInlineStyles } from './resource-inliner';
-import { ANGULAR_MAJOR } from './angular-version';
+import { ANGULAR_MAJOR, SUPPORTS_BOUNDARY_BLOCKS } from './angular-version';
 
 // Angular 19 ships several features in fundamentally different shapes
 // from v20+: `@defer` dependency emission predates the
@@ -867,6 +867,72 @@ describe('@Component', () => {
         expect(result.code).not.toContain('import("./heavy-widget")');
       },
     );
+  });
+
+  describe.skipIf(!SUPPORTS_BOUNDARY_BLOCKS)('@boundary', () => {
+    it('compiles error conditions and retry aliases', () => {
+      const result = compile(
+        `
+        import { Component } from '@angular/core';
+        @Component({
+          template: \`
+            @boundary { Main }
+            @error (let err, retry = $reset; when err.message === '404') {
+              <button (click)="retry()">{{ err.message }}</button>
+            }
+            @error { Fallback }
+          \`
+        })
+        export class BoundaryComponent {}
+        `,
+        'boundary.ts',
+      );
+
+      expect(result).toContain('ɵɵboundaryCreate(');
+      expect(result).toContain('ɵɵboundaryUpdate(');
+      expect(result).toContain('.error.message === "404"');
+      expect(result).toContain('.$reset()');
+      expect(result).toContain('ctx.$error.message');
+    });
+
+    it.each([
+      {
+        description: 'loads a component deferred inside an error block',
+        template: '@boundary { Main } @error { @defer { <heavy-widget /> } }',
+        lazy: true,
+      },
+      {
+        description: 'keeps a component used in an error block eager',
+        template:
+          '@defer { <heavy-widget /> } @boundary { Main } @error { <heavy-widget /> }',
+        lazy: false,
+      },
+      {
+        description: 'loads a boundary error component inside a defer block',
+        template: '@defer { @boundary { Main } @error { <heavy-widget /> } }',
+        lazy: true,
+      },
+    ])('$description', ({ template, lazy }) => {
+      const registry = buildRegistry({
+        'heavy-widget.ts': `
+          import { Component } from '@angular/core';
+          @Component({ selector: 'heavy-widget', template: 'Heavy' })
+          export class HeavyWidget {}
+        `,
+      });
+      const result = rawCompile(
+        `
+        import { Component } from '@angular/core';
+        import { HeavyWidget } from './heavy-widget';
+        @Component({ template: ${JSON.stringify(template)}, imports: [HeavyWidget] })
+        export class BoundaryComponent {}
+        `,
+        'boundary-defer.ts',
+        { registry },
+      );
+
+      expect(result.code.includes('import("./heavy-widget")')).toBe(lazy);
+    });
   });
 
   describe('Content Projection', () => {

--- a/packages/vite-plugin-angular/src/lib/compiler/conformance.spec.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/conformance.spec.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { compile, type CompileOptions } from './compile';
 import { scanFile, type ComponentRegistry } from './registry';
-import { angularVersionAtLeast } from './angular-version';
+import {
+  angularVersionAtLeast,
+  SUPPORTS_BOUNDARY_BLOCKS,
+} from './angular-version';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -300,6 +303,7 @@ function loadTestCaseGroups(
 // Categories to test (focus on features this compiler supports)
 const CATEGORIES = [
   'r3_view_compiler_control_flow',
+  'r3_view_compiler_boundaries',
   'r3_view_compiler_bindings',
   'r3_view_compiler_listener',
   'r3_view_compiler_template',
@@ -384,6 +388,8 @@ describe.skipIf(!angularAvailable)('Angular Compliance Tests', () => {
 
     const minMajor = CATEGORY_MIN_MAJOR[category];
     if (minMajor && !angularVersionAtLeast(minMajor)) continue;
+    if (category === 'r3_view_compiler_boundaries' && !SUPPORTS_BOUNDARY_BLOCKS)
+      continue;
 
     const groups = loadTestCaseGroups(
       categoryDir,

--- a/packages/vite-plugin-angular/src/lib/compiler/defer.ts
+++ b/packages/vite-plugin-angular/src/lib/compiler/defer.ts
@@ -19,6 +19,7 @@ export function collectDeferBlocks(nodes: any[]): any[] {
     // DeferredBlock: children, placeholder/loading/error (each has children)
     if (Array.isArray(node.children)) node.children.forEach(walk);
     if (Array.isArray(node.branches)) node.branches.forEach(walk);
+    if (Array.isArray(node.errorBlocks)) node.errorBlocks.forEach(walk);
     if (Array.isArray(node.groups)) node.groups.forEach(walk);
     if (Array.isArray(node.cases)) node.cases.forEach(walk);
     if (node.empty?.children) node.empty.children.forEach(walk);
@@ -60,6 +61,7 @@ export function collectElementNames(
     if (node.constructor?.name === 'Element') result.add(node.name);
     if (Array.isArray(node.children)) node.children.forEach(walk);
     if (Array.isArray(node.branches)) node.branches.forEach(walk);
+    if (Array.isArray(node.errorBlocks)) node.errorBlocks.forEach(walk);
     if (Array.isArray(node.groups)) node.groups.forEach(walk);
     if (Array.isArray(node.cases)) node.cases.forEach(walk);
     if (node.empty?.children) node.empty.children.forEach(walk);


### PR DESCRIPTION
## PR Checklist

Closes #2563

Angular v22.2.0-next.7 added boundary fixtures, causing beta's conformance drift check to fail. The fast compiler also missed boundary error blocks when collecting dependencies: a nested `@defer` could crash, and components could be incorrectly classified as eager or lazy.

## Affected scope

- Primary scope: `vite-plugin-angular`
- Secondary scopes: compilation guide in `docs-analog`

## Recommended merge strategy for maintainer [optional]

- [x] Squash merge
- [ ] Rebase merge
- [ ] Other

## Commit preservation note [optional]

No commit boundaries need preservation.

## What is the new behavior?

- Register `r3_view_compiler_boundaries` and run its fixtures only when the installed compiler exports `TmplAstBoundaryBlock`. Angular 22.1 lacks this capability, so a major-version gate is insufficient.
- Traverse `errorBlocks` in both dependency walkers so deferred blocks receive their dependency functions and shared components stay eager.
- Add four compiler tests for boundary conditions/retry aliases and dependency classification, plus a short compatibility note in the compilation guide.

## Test plan

- [x] `nx format:check` — checked all five changed files with `pnpm nx format:check --files=...`.
- [ ] `pnpm build`
- [ ] `pnpm test`
- [x] Manual verification

Targeted validation:

- `pnpm install --frozen-lockfile --prefer-offline`.
- `pnpm nx build vite-plugin-angular --skip-nx-cache` — passed.
- `pnpm nx test vite-plugin-angular --run --skip-nx-cache --excludeTaskDependencies` — 1,303 passed, 30 skipped on the workspace compiler.
- Ran the new `@boundary` tests through Nx with an isolated Vite alias to `@angular/compiler@22.2.0-next.7`: the three dependency regressions failed before the traversal fix; all four tests passed afterward.
- Downloaded the complete compliance fixtures at `v22.2.0-next.7` and ran conformance, decorator coverage, and signal API coverage through Nx with temporary configs: 567 passed / 26 skipped on compiler 22.1.5; 574 passed / 26 skipped on compiler 22.2.0-next.7, including all seven boundary fixtures.
- Independently compared all seven boundary fixtures' emitted template function bodies to their upstream expectations, normalizing cosmetic syntax and generated names.

Temporary compiler aliases and downloaded fixtures stayed outside the repository; workspace dependencies and lockfile are unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

[Original failing conformance job](https://github.com/analogjs/analog/actions/runs/34553076576/job/103119837367). Workflow configuration and conformance thresholds are unchanged.

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

Not applicable.

🤖 Generated with [Codex](https://openai.com/codex/)
